### PR TITLE
fix: corroutine never awaited in `direct_messages` method

### DIFF
--- a/aiograpi/mixins/direct.py
+++ b/aiograpi/mixins/direct.py
@@ -202,7 +202,7 @@ class DirectMixin:
         """
         if not self.user_id:
             raise PreLoginRequired
-        return await self.direct_thread(thread_id, amount).messages
+        return (await self.direct_thread(thread_id, amount)).messages
 
     async def direct_answer(self, thread_id: int, text: str) -> DirectMessage:
         """


### PR DESCRIPTION
It solves the problem by properly awaiting the coroutine; after that, it accesses the messages attribute from the coroutine's result.

How to reproduce:

python version: 3.11.9
library version: aiograpi==0.0.3

sample code:
```
from aiograpi import Client
from asyncio import new_event_loop

eventloop = new_event_loop()


async def insta_task():
    cl = Client()
    await cl.login(USERNAME, PASSWORD)

    user_id = await cl.user_id_from_username(USERNAME)
    thread = (await cl.direct_threads(1))[0]
    message = (await cl.direct_messages(thread.id, 1))[0]

eventloop.run_until_complete(insta_task())
```