### PR TITLE
docs: add docstrings to 7 public methods in high-traffic mixins

### DIFF
--- a/aiograpi/mixins/account.py
+++ b/aiograpi/mixins/account.py
@@ -100,6 +100,26 @@ class AccountMixin:
             return False
 
     async def remove_bio_links(self, link_ids: list) -> dict:
+        """
+        Remove one or more bio links by id.
+
+        ``POST /accounts/remove_bio_links/`` — companion to
+        :meth:`set_external_url` / the bio-link editor in the IG app.
+        Passes a manually-pre-signed body (``with_signature=False``)
+        because IG validates the signature on this endpoint
+        differently than the action-data flow.
+
+        Parameters
+        ----------
+        link_ids: list
+            List of ``link_id`` strings (the ``link_id`` field on each
+            ``BioLink`` object returned by ``user_info``).
+
+        Returns
+        -------
+        dict
+            Raw response.
+        """
         signed_body = {
             "signed_body": "SIGNATURE."
             + json.dumps(
@@ -112,7 +132,24 @@ class AccountMixin:
 
     async def set_external_url(self, external_url) -> dict:
         """
-        Set new biography
+        Replace the profile's external link with a single URL.
+
+        ``POST /accounts/update_bio_links/`` — replaces (not appends)
+        the bio-link list with one ``external``-type link. Sends a
+        signed body via :func:`aiograpi.utils.generate_signature` and
+        ``with_signature=False`` because the endpoint expects the
+        signature pre-baked into the body, not as a header.
+
+        Parameters
+        ----------
+        external_url: str
+            URL to set as the profile's external link. Pass an empty
+            string to clear (untested — IG may reject empty URL).
+
+        Returns
+        -------
+        dict
+            Raw response.
         """
         data = dumps(
             {

--- a/aiograpi/mixins/comment.py
+++ b/aiograpi/mixins/comment.py
@@ -396,6 +396,29 @@ class CommentMixin:
         return comments
 
     async def media_comments(self, media_id: str, amount: int = 20) -> List[Comment]:
+        """
+        Fetch comments for a media via the most-likely-to-succeed path.
+
+        Tries :meth:`media_comments_gql` (public GraphQL) first; falls
+        back to a logged-in retry by injecting ``sessionid`` into the
+        public session if the first attempt raised
+        ``ClientLoginRequired``; finally falls back to
+        :meth:`media_comments_v1` (private API) on any other error.
+        Useful as a "just give me the comments" call when you don't
+        care which surface served them.
+
+        Parameters
+        ----------
+        media_id: str
+            Media pk or full media_id.
+        amount: int, default 20
+            Maximum number of comments to return. ``0`` means "all
+            available pages".
+
+        Returns
+        -------
+        List[Comment]
+        """
         try:
             try:
                 comments = await self.media_comments_gql(media_id, amount)

--- a/aiograpi/mixins/highlight.py
+++ b/aiograpi/mixins/highlight.py
@@ -183,6 +183,32 @@ class HighlightMixin:
         added_media_ids: List[str] = [],
         removed_media_ids: List[str] = [],
     ):
+        """
+        Edit an existing highlight reel — title, cover, or membership.
+
+        ``POST /highlights/highlight:{pk}/edit_reel/``. All four
+        editable fields are optional; pass only what you want to
+        change.
+
+        Parameters
+        ----------
+        highlight_pk: str
+            Target highlight pk.
+        title: str, default ""
+            New title (empty string leaves it unchanged).
+        cover: Dict, default {}
+            New cover dict (e.g. ``{"media_id": "..."}``); empty dict
+            leaves it unchanged.
+        added_media_ids: List[str], default []
+            Story pks to add to the highlight.
+        removed_media_ids: List[str], default []
+            Story pks to remove from the highlight.
+
+        Returns
+        -------
+        Highlight
+            Refreshed highlight after the edit.
+        """
         data = {
             "supported_capabilities_new": json.dumps(config.SUPPORTED_CAPABILITIES),
             "source": "self_profile",

--- a/aiograpi/mixins/media.py
+++ b/aiograpi/mixins/media.py
@@ -1428,6 +1428,25 @@ class MediaMixin:
         return await self.media_pin(media_pk, True)
 
     async def media_template_v1(self, media_id: str):
+        """
+        Fetch a clip template (remix-from-template) for a clip media.
+
+        ``POST /clips/template/`` — the surface IG's app uses when
+        the user taps "Use as template" on a reel/clip. Returns the
+        raw template payload (audio, text overlays, transitions, clip
+        timings) ready to be applied to a new upload.
+
+        Parameters
+        ----------
+        media_id: str
+            Source clip media id (the clip the template is being
+            extracted from).
+
+        Returns
+        -------
+        dict
+            Raw template response.
+        """
         data = {
             "should_show_friends_media_at_top": "false",
             "template_clips_media_id": media_id,

--- a/aiograpi/mixins/story.py
+++ b/aiograpi/mixins/story.py
@@ -323,6 +323,31 @@ class StoryMixin:
     async def story_viewers_chunk(
         self, story_pk: str, max_amount: int = 0, max_id: str = ""
     ) -> tuple[List[Viewer], str]:
+        """
+        Paginated fetch of users who have viewed a story.
+
+        ``GET /media/{story_pk}/list_reel_media_viewer/`` — only the
+        story owner can read this; for any other story it raises
+        ``ClientForbiddenError``. Returns the chunk plus the next
+        cursor so callers can drive their own pagination loop (use
+        :meth:`story_viewers` if you just want everything in one shot).
+
+        Parameters
+        ----------
+        story_pk: str
+            Target story pk.
+        max_amount: int, default 0
+            Max viewers to collect this chunk. ``0`` means "all
+            pages until IG runs out".
+        max_id: str, default ""
+            Pagination cursor from a previous call.
+
+        Returns
+        -------
+        Tuple[List[Viewer], str]
+            ``(viewers, next_max_id)``. Empty ``next_max_id`` means
+            no more pages.
+        """
         unique_set: set = set()
         viewers: List[Viewer] = []
         story_pk = self.media_pk(story_pk)

--- a/aiograpi/mixins/user.py
+++ b/aiograpi/mixins/user.py
@@ -143,6 +143,39 @@ class UserMixin:
         return user
 
     async def user_web_profile_info_gql(self, user_id: str) -> dict:
+        """
+        Fetch a user profile via the public-host PolarisProfilePageContentQuery.
+
+        ``POST /api/graphql`` with ``doc_id="26762473490008061"`` —
+        the modern web-profile GraphQL surface that replaced the old
+        ``query_hash`` profile lookups. Requires a logged-in
+        ``sessionid`` (the doc_id rejects anonymous callers).
+
+        Used as the canonical GraphQL fallback for
+        :meth:`user_short_gql` when the legacy ``query_hash`` path
+        fails.
+
+        Parameters
+        ----------
+        user_id: str
+            Target user pk.
+
+        Returns
+        -------
+        dict
+            The inner ``data["user"]`` block from the GraphQL
+            response (already unwrapped).
+
+        Raises
+        ------
+        ClientLoginRequired
+            ``sessionid`` is not available to inject.
+        UserNotFound
+            Response contained no ``user`` block.
+        ClientGraphqlError
+            GraphQL ``errors`` array was non-empty and ``data`` was
+            missing.
+        """
         user_id = str(user_id)
         if not self.inject_sessionid_to_public():
             raise ClientLoginRequired("Session is required for web profile GraphQL")


### PR DESCRIPTION
## Summary

Coverage batch **2/3** from the docs+tests audit. The audit found 7 public methods on the high-traffic mixins (`user.py`, `media.py`, `comment.py`, `highlight.py`, `story.py`, `account.py`) with either no docstring at all or a one-liner that didn't describe the actual behavior.

## Methods documented

| Mixin | Method | What was wrong |
|---|---|---|
| `user.py` | `user_web_profile_info_gql` | No docstring. Now documents the doc_id PolarisProfilePageContentQuery fallback path, raises (`ClientLoginRequired` / `UserNotFound` / `ClientGraphqlError`). |
| `media.py` | `media_template_v1` | No docstring. Clip "Use as template" remix flow. |
| `comment.py` | `media_comments` | No docstring. Try/fallback orchestration between GraphQL, sessionid-retry, and v1. |
| `highlight.py` | `highlight_edit` | No docstring. All four optional fields (title, cover, added_media_ids, removed_media_ids) now spelled out. |
| `story.py` | `story_viewers_chunk` | No docstring. Owner-only endpoint, returns `(viewers, next_max_id)` tuple. |
| `account.py` | `remove_bio_links` | No docstring. Notes the manual pre-signed body shape. |
| `account.py` | `set_external_url` | One-liner `"Set new biography"` (didn't actually describe what it does). Now: replaces (not appends) the bio-link list with a single `external`-type link via `generate_signature`. |

## Test plan

- [x] **Unit:** 174 passed, 10 skipped (no behavior change).
- [x] **mkdocs --strict:** clean.
- [x] **flake8 / black / isort:** all green.
- [x] **mypy:** unchanged.

## Followup

- Batch 3 (next): smoke-coverage for `notification.py` (27 methods, 100% untested) + `signup.py` (15 methods, 100% untested) — niche mixins, will land minimal "method-exists + is-async-fn + endpoint URL" tests rather than full mocked round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)