### PR TITLE
security: harden remote image fetch + bump Pillow + pin pypi-publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,11 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      # Pinned to commit SHA (v1.14.0) — moving refs like
+      # release/v1 are a supply-chain risk: an upstream takeover
+      # could swap them to malicious code that runs with the
+      # id-token: write permission this job grants.
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
 
   github-release:
     name: Create GitHub Release

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -108,6 +108,7 @@ jobs:
         run: |
           pytest -sv \
             tests.py::ExtractorsRegressionTestCase \
+            tests.py::ImageUtilSafeRemoteFetchTestCase \
             tests.py::DirectExtractorRegressionTestCase \
             tests.py::PublicRegressionTestCase \
             tests.py::PolarisProfileNormalizationTestCase \

--- a/aiograpi/image_util.py
+++ b/aiograpi/image_util.py
@@ -4,10 +4,13 @@
 # https://opensource.org/licenses/MIT
 
 import io
+import ipaddress
 import os
 import re
 import shutil
+import socket
 import tempfile
+from urllib.parse import urlparse
 
 try:
     from PIL import Image
@@ -15,6 +18,78 @@ except ImportError:
     raise Exception("You don't have PIL installed. Please install PIL or Pillow>=8.1.1")
 
 import httpx
+
+# Whitelist of image formats Pillow is allowed to decode for remote
+# fetches. Restricts the parser surface to the formats Instagram
+# actually accepts as media uploads — drops PSD/FITS/TIFF/etc.
+# parsers that have historically had memory-corruption CVEs
+# (e.g. CVE-2026-25990 PSD OOB write, CVE-2026-40192 FITS bomb).
+_SAFE_REMOTE_IMAGE_FORMATS = ("JPEG", "PNG", "WEBP", "GIF")
+
+# Private / loopback / link-local networks we never want to fetch
+# from when the URL comes from caller-supplied input. Blocks
+# internal-service SSRF and cloud metadata endpoints
+# (169.254.169.254 — AWS / Azure / GCP).
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+]
+
+
+def _is_safe_remote_url(url: str) -> bool:
+    """Return True iff ``url`` resolves to a public IP and uses http(s).
+
+    Resolves DNS so a domain pointing at 127.0.0.1 doesn't slip
+    through a textual check. Caller must still pass
+    ``follow_redirects=False`` to httpx — a 3xx to a blocked target
+    isn't checked here.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return False
+    try:
+        addrinfo = socket.getaddrinfo(parsed.hostname, None)
+    except (socket.gaierror, UnicodeError):
+        return False
+    for family, _type, _proto, _canon, sockaddr in addrinfo:
+        try:
+            ip = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            return False
+        for net in _BLOCKED_NETWORKS:
+            if ip in net:
+                return False
+    return True
+
+
+def _safe_remote_get(url: str) -> httpx.Response:
+    """SSRF-hardened ``httpx.get`` for caller-supplied URLs.
+
+    1. Pre-flight check via :func:`_is_safe_remote_url` — DNS-resolves
+       the host and rejects private / loopback / link-local addresses.
+    2. ``follow_redirects=False`` — a permitted public host can't
+       redirect us into an internal service.
+    3. ``raise_for_status`` so 4xx/5xx surfaces clearly to the caller.
+    """
+    if not _is_safe_remote_url(url):
+        raise ValueError(
+            f"Refusing remote fetch from non-public or non-HTTP URL: {url!r}"
+        )
+    res = httpx.get(url, timeout=5, follow_redirects=False)
+    if res.is_redirect:
+        raise ValueError(
+            f"Refusing redirect to {res.headers.get('location')!r} "
+            f"(remote fetch must be a single hop)"
+        )
+    res.raise_for_status()
+    return res
 
 
 def calc_resize(max_size, curr_size, min_size=(0, 0)):
@@ -112,7 +187,7 @@ def prepare_image(
     max_size=(1080, 1350),
     aspect_ratios=(4.0 / 5.0, 90.0 / 47.0),
     save_path=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Prepares an image file for posting.
@@ -128,8 +203,8 @@ def prepare_image(
     """
     min_size = kwargs.pop("min_size", (320, 167))
     if is_remote(img):
-        res = httpx.get(img, timeout=5, follow_redirects=True)
-        im = Image.open(io.BytesIO(res.content))
+        res = _safe_remote_get(img)
+        im = Image.open(io.BytesIO(res.content), formats=_SAFE_REMOTE_IMAGE_FORMATS)
     else:
         im = Image.open(img)
 
@@ -164,7 +239,7 @@ def prepare_video(
     max_duration=60.0,
     save_path=None,
     skip_reencoding=False,
-    **kwargs
+    **kwargs,
 ):
     """
     Prepares a video file for posting.
@@ -209,8 +284,9 @@ def prepare_video(
     )
 
     if is_remote(vid):
-        # Download remote file
-        res = httpx.get(vid, timeout=5, follow_redirects=True)
+        # Download remote file (SSRF-hardened: blocks private nets,
+        # disables redirects).
+        res = _safe_remote_get(vid)
         temp_video_file.write(res.content)
         video_src_filename = temp_video_file.name
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     "moviepy==1.0.3",
     "pycryptodomex==3.23.0",
     "zstandard==0.25.0",
-    "Pillow>=8.1.1",
+    "Pillow>=12.2.0",
 ]
 
 [project.urls]
@@ -75,7 +75,7 @@ Changelog = "https://github.com/subzeroid/aiograpi/blob/main/CHANGELOG.md"
 test = [
     "flake8==7.3.0",
     "mypy==1.20.2",
-    "Pillow==12.0.0",
+    "Pillow==12.2.0",
     "isort==7.0.0",
     "bandit==1.9.1",
     "mike==2.1.3",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 flake8==7.3.0
 mypy==1.20.2
-Pillow==12.0.0
+Pillow==12.2.0
 isort==7.0.0
 bandit==1.9.1
 mike==2.1.3

--- a/tests.py
+++ b/tests.py
@@ -298,6 +298,85 @@ class ExtractorsRegressionTestCase(unittest.TestCase):
         self.assertEqual(resource.pk, "1")
 
 
+class ImageUtilSafeRemoteFetchTestCase(unittest.TestCase):
+    """SSRF hardening for image_util._is_safe_remote_url and
+    _safe_remote_get — block private/loopback/link-local destinations
+    and refuse redirects on caller-supplied URLs."""
+
+    def test_blocks_loopback_ipv4(self):
+        from aiograpi.image_util import _is_safe_remote_url
+
+        self.assertFalse(_is_safe_remote_url("http://127.0.0.1/"))
+        self.assertFalse(_is_safe_remote_url("http://127.0.0.1:6379/"))
+
+    def test_blocks_loopback_ipv6(self):
+        from aiograpi.image_util import _is_safe_remote_url
+
+        self.assertFalse(_is_safe_remote_url("http://[::1]/"))
+
+    def test_blocks_aws_metadata_endpoint(self):
+        from aiograpi.image_util import _is_safe_remote_url
+
+        self.assertFalse(
+            _is_safe_remote_url("http://169.254.169.254/latest/meta-data/")
+        )
+
+    def test_blocks_rfc1918_ipv4_ranges(self):
+        from aiograpi.image_util import _is_safe_remote_url
+
+        self.assertFalse(_is_safe_remote_url("http://10.0.0.1/"))
+        self.assertFalse(_is_safe_remote_url("http://172.16.0.1/"))
+        self.assertFalse(_is_safe_remote_url("http://192.168.1.1/"))
+
+    def test_rejects_non_http_schemes(self):
+        from aiograpi.image_util import _is_safe_remote_url
+
+        self.assertFalse(_is_safe_remote_url("file:///etc/passwd"))
+        self.assertFalse(_is_safe_remote_url("ftp://example.com/foo"))
+        self.assertFalse(_is_safe_remote_url("gopher://example.com/"))
+        self.assertFalse(_is_safe_remote_url("ssh://example.com/"))
+
+    def test_rejects_unresolvable_host(self):
+        from aiograpi.image_util import _is_safe_remote_url
+
+        # .invalid is RFC 6761 — guaranteed never to resolve.
+        self.assertFalse(_is_safe_remote_url("http://nonexistent.invalid/"))
+
+    def test_blocks_dns_rebinding_attempt_via_resolution(self):
+        from aiograpi.image_util import _is_safe_remote_url
+
+        # localhost resolves to 127.0.0.1 — reject even if textual
+        # check would have passed on hostname alone.
+        self.assertFalse(_is_safe_remote_url("http://localhost/"))
+
+    def test_safe_remote_get_blocks_private_url_before_fetching(self):
+        from aiograpi.image_util import _safe_remote_get
+
+        with self.assertRaises(ValueError) as cm:
+            _safe_remote_get("http://127.0.0.1/foo")
+
+        self.assertIn("non-public", str(cm.exception).lower())
+
+    def test_safe_remote_get_refuses_redirect(self):
+        from aiograpi.image_util import _safe_remote_get
+
+        # Build a fake redirect response. _is_safe_remote_url is bypassed
+        # by patching it to True so the test isolates redirect handling.
+        fake_response = Mock(
+            status_code=302,
+            is_redirect=True,
+            headers={"location": "http://169.254.169.254/secret"},
+        )
+        with (
+            mock.patch("aiograpi.image_util._is_safe_remote_url", return_value=True),
+            mock.patch("aiograpi.image_util.httpx.get", return_value=fake_response),
+        ):
+            with self.assertRaises(ValueError) as cm:
+                _safe_remote_get("http://example.com/redirect")
+
+        self.assertIn("redirect", str(cm.exception).lower())
+
+
 class PublicRegressionTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_public_request_uses_post_for_post_bodies(self):
         client = Client()


### PR DESCRIPTION
## Summary

Closes three findings from yesterday's `/cso` audit.

### Finding 1 (HIGH) — SSRF + reachable Pillow OOB-write

`image_util.prepare_image` and `prepare_video` called
`httpx.get(url, follow_redirects=True)` on caller-supplied URLs with no allowlist, then fed bytes straight to `Image.open(BytesIO)` (CVE-2026-25990 PSD OOB write, CVE-2026-40192 FITS bomb) or `VideoFileClip`.

**Three layers of defense:**

1. **DNS-resolved private-network denylist** (`_is_safe_remote_url`) — rejects 10/8, 172.16/12, 192.168/16, 127/8, ::1, 169.254/16 (cloud metadata!), fe80::/10, fc00::/7. Resolves DNS first so `attacker.com → 127.0.0.1` fails the same as the literal IP. Non-http(s) schemes (`file://`, `ftp://`, `gopher://`) rejected.

2. **`follow_redirects=False`** — a permitted public host can't redirect us into a blocked target.

3. **`Image.open(..., formats=("JPEG","PNG","WEBP","GIF"))`** — restricts Pillow's parser to formats IG accepts as media. Drops the PSD/FITS/TIFF parsers that historically carry memory-corruption CVEs.

Both `prepare_image` and `prepare_video` share the new `_safe_remote_get()` helper.

### Finding 2 (MEDIUM) — Unpinned `pypa/gh-action-pypi-publish`

Was `@release/v1` (moving ref); now pinned to commit SHA `cef221092ed1bacb1cc03d23a2d87d1d172e277b` (v1.14.0). The job has `id-token: write` for trusted PyPI publishing — upstream compromise of the moving ref would have given attackers PyPI publish authority for `aiograpi`. Comment in workflow explains the rationale.

### Finding 3 (MEDIUM) — Pillow runtime constraint too loose

`Pillow>=8.1.1` resolved to versions 10.3.0–12.1.0 (all hit by CVE-2026-25990). Bumped to `Pillow>=12.2.0`. Compatible with aiograpi's Python 3.10+ requirement. Test pin (`[test]` extras + `requirements-test.txt`) also bumped to `12.2.0`; `pip-audit` now reports zero CVEs.

## Test plan

- [x] **9 new `ImageUtilSafeRemoteFetchTestCase` cases:**
  - loopback IPv4 / IPv6 / AWS metadata / RFC1918 ranges
  - non-http schemes (`file://`, `ftp://`, `gopher://`, `ssh://`)
  - unresolvable host (`*.invalid` per RFC 6761)
  - DNS-rebinding via `localhost`
  - `_safe_remote_get` raises `ValueError` on private URL before fetching
  - `_safe_remote_get` raises on 3xx redirect
- [x] **Full unit-test matrix:** 198 passed, 10 skipped (was 189 → +9).
- [x] **mkdocs --strict:** clean.
- [x] **flake8 / black / isort:** all green.
- [x] **`pip-audit` on requirements-test.txt:** zero known vulnerabilities (was 2 — both Pillow CVEs).

## Source

Findings from `/cso` audit report: `.gstack/security-reports/2026-04-29-011450.json` (local, not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)