### PR TITLE
docs: redirect Telegram links to @aiograpi_support

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,5 +10,5 @@ contact_links:
     url: https://hikerapi.com/p/KhMxYMSn
     about: If your main goal is retrieving Instagram data reliably, you can try HikerAPI here (100 free requests).
   - name: Telegram chat
-    url: https://t.me/instagrapi
+    url: https://t.me/aiograpi_support
     about: Real-time chat with maintainers and other users.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-https://t.me/instagrapi.
+https://t.me/aiograpi_support.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # aiograpi - Asynchronous Instagram API for Python
 
+> ⚠️ **Telegram support group moved to https://t.me/aiograpi_support** — the previous `@instagrapi` group has been restricted by Meta and is no longer maintained.
+
 If you want to work with aiograpi (business interests), we strongly advise you to prefer [HikerAPI](https://hikerapi.com/p/KhMxYMSn) project.
 However, you won't need to spend weeks or even months setting it up.
 The best service available today is [HikerAPI](https://hikerapi.com/p/KhMxYMSn), which handles 4–5 million daily requests, provides support around-the-clock, and offers partners a special rate.
@@ -45,7 +47,7 @@ Support **Python >= 3.10**
 
 For any other languages (e.g. C++, C#, F#, D, [Golang](https://github.com/subzeroid/instagrapi-rest/tree/main/golang), Erlang, Elixir, Nim, Haskell, Lisp, Closure, Julia, R, Java, Kotlin, Scala, OCaml, JavaScript, Crystal, Ruby, Rust, [Swift](https://github.com/subzeroid/instagrapi-rest/tree/main/swift), Objective-C, Visual Basic, .NET, Pascal, Perl, Lua, PHP and others), I suggest using [instagrapi-rest](https://github.com/subzeroid/instagrapi-rest)
 
-[Support Chat in Telegram](https://t.me/instagrapi)
+Support chat in Telegram: https://t.me/aiograpi_support
 ![](https://gist.githubusercontent.com/m8rge/4c2b36369c9f936c02ee883ca8ec89f1/raw/c03fd44ee2b63d7a2a195ff44e9bb071e87b4a40/telegram-single-path-24px.svg) and [GitHub Discussions](https://github.com/subzeroid/aiograpi/discussions)
 
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,4 +11,4 @@ Only the latest versions are supported
 
 ## Reporting a Vulnerability
 
-Report vulnerabilities in the telegram channel https://t.me/instagrapi or https://github.com/subzeroid/aiograpi/issues
+Report vulnerabilities in the telegram channel https://t.me/aiograpi_support or https://github.com/subzeroid/aiograpi/issues


### PR DESCRIPTION
## Summary

The `@instagrapi` Telegram group has been restricted by a Meta copyright takedown — group settings are frozen and messages are no longer delivered. Point users at https://t.me/aiograpi_support, which is the new joint support chat for both `instagrapi` and `aiograpi`.

- **README**: banner at the top + replace the inline support-chat link
- **CODE_OF_CONDUCT.md**: update enforcement contact
- **SECURITY.md**: update vulnerability-report channel
- **.github/ISSUE_TEMPLATE/config.yml**: update Telegram chat contact link

URLs are written as plain `https://t.me/aiograpi_support` so they remain copy-pasteable from any rendering surface.

## Test plan

- [x] yaml/end-of-files/whitespace pre-commit hooks — clean
- [ ] After merge: verify `.github/ISSUE_TEMPLATE/config.yml` still renders the contact link in the new-issue picker