### PR TITLE
docs: fix t.me/aiograpi → t.me/aiograpi_support in docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Support **Python >= 3.10**
 
 For any other languages (e.g. C++, C#, F#, D, [Golang](https://github.com/subzeroid/instagrapi-rest/tree/main/golang), Erlang, Elixir, Nim, Haskell, Lisp, Closure, Julia, R, Java, Kotlin, Scala, OCaml, JavaScript, Crystal, Ruby, Rust, [Swift](https://github.com/subzeroid/instagrapi-rest/tree/main/swift), Objective-C, Visual Basic, .NET, Pascal, Perl, Lua, PHP and others), I suggest using [instagrapi-rest](https://github.com/subzeroid/instagrapi-rest)
 
-[Support Chat in Telegram](https://t.me/aiograpi)
+[Support Chat in Telegram](https://t.me/aiograpi_support)
 ![](https://gist.githubusercontent.com/m8rge/4c2b36369c9f936c02ee883ca8ec89f1/raw/c03fd44ee2b63d7a2a195ff44e9bb071e87b4a40/telegram-single-path-24px.svg) and [GitHub Discussions](https://github.com/subzeroid/aiograpi/discussions)
 
 ## Features


### PR DESCRIPTION
## Summary

The mass-rewrite in #246 missed this one occurrence in `docs/index.md`. The bare `@aiograpi` group has been restricted by Meta and is no longer maintained — all support links must point at `@aiograpi_support`.

## Test plan

- [x] `grep -rn 't\.me/aiograpi' --include='*.md' . | grep -v aiograpi_support` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)