### PR TITLE
Sync current app profile from instagrapi 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-05-12
+
 ### Security
 
 - Added a `pip-audit --strict .` CI gate so known-vulnerable runtime dependencies block future releases.
 - Documented the published `GHSA-7mw3-79jq-xc7f` advisory in `SECURITY.md`, including the yanked affected versions and
   the fixed upgrade path.
 
+### Changed
+
+- Synced the async client with `instagrapi` `2.6.0`.
+- Updated the default Android app profile to Instagram `428.0.0.47.67` with a physical Pixel 8 Pro device tuple.
+- Switched private request headers to the current Android transport value.
+- Added `Client(settings=..., override_app_version=True)` so saved session app metadata can be explicitly upgraded during construction.
+
 ### Fixed
 
 - Truncated long public/GraphQL JSON decode error response bodies in logs so HTML error pages no longer flood consoles.
+- Preserved saved legacy app profiles by default while still allowing explicit opt-in app profile upgrades.
 
 ## [0.9.0] - 2026-05-11
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ What you can rely on instead:
 
 ### What's new in 0.6.x through 0.9.x
 
-- **Sync with instagrapi 2.5.18** — Trial Reels, current Reel rupload flow, Reel pin/unpin,
+- **Sync with instagrapi 2.6.0** — current Android app profile defaults,
+  `override_app_version` constructor support, Trial Reels, current Reel rupload flow, Reel pin/unpin,
   feed photo/carousel music, music Notes, archive readers, tagged media pagination,
   Direct reactions and thread title updates.
 - **Android/Pydroid-friendly video uploads** — when you pass `thumbnail=...`, aiograpi can read

--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -45,7 +45,7 @@ from aiograpi.mixins.video import DownloadVideoMixin, UploadVideoMixin
 # Used as fallback logger if another is not provided.
 DEFAULT_LOGGER = logging.getLogger("aiograpi")
 
-__upstream_instagrapi_version__ = "2.5.18"
+__upstream_instagrapi_version__ = "2.6.0"
 
 
 class Client(
@@ -100,10 +100,12 @@ class Client(
         proxy: Optional[str] = None,
         delay_range: Optional[list] = None,
         logger=DEFAULT_LOGGER,
+        override_app_version: bool = False,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.settings = deepcopy(settings or {})
+        self.override_app_version = override_app_version
         self.logger = logger
         self.delay_range = delay_range
         self.set_proxy(proxy)

--- a/aiograpi/config.py
+++ b/aiograpi/config.py
@@ -1,9 +1,9 @@
 API_DOMAIN = "i.instagram.com"
 
-# Instagram 134.0.0.26.121
-# Android (26/8.0.0;
-# 480dpi; 1080x1920; Xiaomi;
-# MI 5s; capricorn; qcom; en_US; 205280538)
+# Instagram 428.0.0.47.67
+# Android (34/14;
+# 480dpi; 1344x2992; Google/google;
+# Pixel 8 Pro; husky; husky; en_US; 961145276)
 USER_AGENT_BASE = (
     "Instagram {app_version} "
     "Android ({android_version}/{android_release}; "
@@ -13,16 +13,22 @@ USER_AGENT_BASE = (
 
 # Default device profile (hardware/system) and app version settings.
 DEVICE_SETTINGS = {
-    "android_version": 26,
-    "android_release": "8.0.0",
+    "android_version": 34,
+    "android_release": "14",
     "dpi": "480dpi",
-    "resolution": "1080x1920",
-    "manufacturer": "OnePlus",
-    "device": "devitron",
-    "model": "6T Dev",
-    "cpu": "qcom",
+    "resolution": "1344x2992",
+    "manufacturer": "Google/google",
+    "device": "husky",
+    "model": "Pixel 8 Pro",
+    "cpu": "husky",
 }
+DEFAULT_APP_VERSION = "428.0.0.47.67"
 APP_SETTINGS = {
+    DEFAULT_APP_VERSION: {
+        "app_version": DEFAULT_APP_VERSION,
+        "version_code": "961145276",
+        "bloks_versioning_id": "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8",
+    },
     "364.0.0.35.86": {
         "app_version": "364.0.0.35.86",
         "version_code": "374010953",

--- a/aiograpi/mixins/auth.py
+++ b/aiograpi/mixins/auth.py
@@ -310,7 +310,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
     ig_www_claim = ""  # e.g. hmac.AR2uidim8es5kYgDiNxY0UG_ZhffFFSt8TGCV5eA1VYYsMNx
 
     def __init__(self):
-        self.bloks_versioning_id = "ce555e5500576acd8e84a66018f54a05720f2dce29f0bb5a1f97f0c10d6fac48"
+        self.bloks_versioning_id = config.APP_SETTINGS[config.DEFAULT_APP_VERSION]["bloks_versioning_id"]
         self.user_agent = None
         self.settings = None
         self.override_app_version = False
@@ -812,6 +812,9 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
                 return app_values[idx]
             return random.choice(app_values)
 
+        def default_settings() -> Dict:
+            return config.APP_SETTINGS.get(config.DEFAULT_APP_VERSION) or pick_by_seed()
+
         if app:
             if isinstance(app, str):
                 matched = config.APP_SETTINGS.get(app)
@@ -823,11 +826,11 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         else:
             app_version = self.device_settings.get("app_version")
             matched = config.APP_SETTINGS.get(app_version) if app_version else None
-            if matched:
+            if matched and not override_app_version:
                 apply_settings(matched)
             else:
                 if override_app_version or not app_version:
-                    apply_settings(pick_by_seed())
+                    apply_settings(default_settings())
 
         if override_app_version:
             self.set_user_agent()

--- a/aiograpi/mixins/private.py
+++ b/aiograpi/mixins/private.py
@@ -193,7 +193,7 @@ class PrivateRequestMixin:
             "X-MID": self.mid,  # e.g. X--ijgABABFjLLQ1NTEe0A6JSN7o
             "Accept-Encoding": "zstd, gzip, deflate",
             "Host": self.domain or config.API_DOMAIN,
-            "X-FB-HTTP-Engine": "Liger",
+            "X-FB-HTTP-Engine": "Tigon/MNS/TCP",
             "Connection": "keep-alive",
             # "Pragma": "no-cache",
             # "Cache-Control": "no-cache",

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -7,7 +7,7 @@ ported through.
 The current sync baseline is:
 
 ```text
-instagrapi 2.5.18
+instagrapi 2.6.0
 ```
 
 ## Release policy
@@ -16,8 +16,8 @@ instagrapi 2.5.18
 - Keep patch releases for urgent fixes after that sync lands.
 - Mention the upstream range in GitHub, PyPI, and Telegram release notes.
 
-For the 2026-05 sync, the public release is `aiograpi 0.9.0`, covering
-`instagrapi` releases `2.5.13` through `2.5.18`.
+For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer,
+covering `instagrapi` releases `2.5.13` through `2.6.0`.
 
 ## Porting rules
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "0.9.0"
+version = "0.9.1"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/regression/test_current_app_profile.py
+++ b/tests/regression/test_current_app_profile.py
@@ -1,0 +1,74 @@
+from aiograpi import Client, config
+
+
+def test_default_client_uses_current_android_app_profile():
+    client = Client()
+
+    assert client.device_settings["app_version"] == config.DEFAULT_APP_VERSION
+    assert client.device_settings["version_code"] == "961145276"
+    assert client.bloks_versioning_id == "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8"
+    assert client.user_agent == (
+        "Instagram 428.0.0.47.67 Android (34/14; 480dpi; 1344x2992; "
+        "Google/google; Pixel 8 Pro; husky; husky; en_US; 961145276)"
+    )
+
+
+def test_default_device_profile_matches_current_android_baseline():
+    client = Client()
+
+    assert client.device_settings == {
+        "android_version": 34,
+        "android_release": "14",
+        "dpi": "480dpi",
+        "resolution": "1344x2992",
+        "manufacturer": "Google/google",
+        "device": "husky",
+        "model": "Pixel 8 Pro",
+        "cpu": "husky",
+        "app_version": "428.0.0.47.67",
+        "version_code": "961145276",
+        "bloks_versioning_id": "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8",
+    }
+
+
+def test_private_headers_use_current_android_transport_values():
+    client = Client()
+
+    assert client.private.headers["X-FB-HTTP-Engine"] == "Tigon/MNS/TCP"
+    assert client.private.headers["X-IG-Capabilities"] == "3brTv10="
+    assert client.private.headers["X-IG-App-ID"] == "567067343352427"
+    assert client.private.headers["X-Bloks-Version-Id"] == (
+        "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8"
+    )
+
+
+def test_saved_legacy_app_profile_is_not_overridden_by_default():
+    client = Client(
+        {
+            "device_settings": {
+                "app_version": "385.0.0.47.74",
+                "version_code": "378906843",
+                "bloks_versioning_id": "a8973d49a9cc6a6f65a4997c10216ce2a06f65a517010e64885e92029bb19221",
+            },
+        }
+    )
+
+    assert client.device_settings["app_version"] == "385.0.0.47.74"
+    assert client.device_settings["version_code"] == "378906843"
+    assert client.bloks_versioning_id == "a8973d49a9cc6a6f65a4997c10216ce2a06f65a517010e64885e92029bb19221"
+
+
+def test_constructor_override_app_version_replaces_saved_profile_with_current_default():
+    client = Client(
+        {
+            "device_settings": {
+                "app_version": "385.0.0.47.74",
+                "version_code": "378906843",
+                "bloks_versioning_id": "a8973d49a9cc6a6f65a4997c10216ce2a06f65a517010e64885e92029bb19221",
+            },
+        },
+        override_app_version=True,
+    )
+
+    assert client.device_settings["app_version"] == config.DEFAULT_APP_VERSION
+    assert client.device_settings["version_code"] == "961145276"

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -2,4 +2,4 @@ import aiograpi
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.5.18"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.6.0"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "aiograpi"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Sync the default Android app profile and private transport header from instagrapi 2.6.0.
- Add `Client(settings=..., override_app_version=True)` constructor support while preserving saved legacy profiles by default.
- Update the upstream sync marker, docs, changelog, and package version to 0.9.1.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_current_app_profile.py tests/regression/test_upstream_sync.py -q`
- `.venv/bin/python -m pytest tests/regression -q`
- `.venv/bin/python -m pytest tests/legacy.py::AuthAndStoryRegressionTestCase tests/legacy.py::ClientTestCase tests/legacy.py::UploadRegressionTestCase -q`
- `.venv/bin/python -m ruff check aiograpi tests`
- `.venv/bin/python -m ruff format --check aiograpi tests`
- `.venv/bin/python -m mkdocs build --strict`
- `uvx --from build pyproject-build --outdir /tmp/aiograpi-dist-0.9.1 .`
- `uvx --from twine twine check /tmp/aiograpi-dist-0.9.1/*`
- `.venv/bin/python -m pip_audit --strict --progress-spinner off .`
