### PR TITLE
Sync Direct helpers from instagrapi 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-05-12
+
+### Added
+
+- Synced the async Direct helper API with `instagrapi` `2.6.1`.
+- Added `direct_message(thread_id, message_id, amount=20)` to fetch a Direct message by id.
+- Added clearer Direct message request helpers: `direct_requests()` and `direct_request_approve(thread_id)`.
+- Added `direct_message_unsend(thread_id, message_id)` as the unsend-style alias for the Direct item delete endpoint.
+
+### Changed
+
+- Updated Direct docs with message request, single-message lookup, and unsend examples.
+
 ## [0.9.1] - 2026-05-12
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ What you can rely on instead:
 
 ### What's new in 0.6.x through 0.9.x
 
-- **Sync with instagrapi 2.6.0** — current Android app profile defaults,
+- **Sync with instagrapi 2.6.1** — current Android app profile defaults,
   `override_app_version` constructor support, Trial Reels, current Reel rupload flow, Reel pin/unpin,
   feed photo/carousel music, music Notes, archive readers, tagged media pagination,
-  Direct reactions and thread title updates.
+  Direct reactions, thread title updates, message request helpers, single-message lookup, and Direct unsend.
 - **Android/Pydroid-friendly video uploads** — when you pass `thumbnail=...`, aiograpi can read
   MP4 dimensions/duration without importing MoviePy/ffmpeg. If thumbnail generation is needed,
   the error now explains how to install ffmpeg or set `IMAGEIO_FFMPEG_EXE`.

--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -45,7 +45,7 @@ from aiograpi.mixins.video import DownloadVideoMixin, UploadVideoMixin
 # Used as fallback logger if another is not provided.
 DEFAULT_LOGGER = logging.getLogger("aiograpi")
 
-__upstream_instagrapi_version__ = "2.6.0"
+__upstream_instagrapi_version__ = "2.6.1"
 
 
 class Client(

--- a/aiograpi/mixins/direct.py
+++ b/aiograpi/mixins/direct.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Tuple
 
 from aiograpi.exceptions import (
     ClientNotFoundError,
+    DirectMessageNotFound,
     DirectThreadNotFound,
 )
 from aiograpi.extractors import (
@@ -179,6 +180,22 @@ class DirectMixin:
             threads = threads[:amount]
         return threads
 
+    async def direct_requests(self, amount: int = 20) -> List[DirectThread]:
+        """
+        Get Direct message request threads, also known as pending inbox or invitations.
+
+        Parameters
+        ----------
+        amount: int, optional
+            Maximum number of threads to return, default is 20
+
+        Returns
+        -------
+        List[DirectThread]
+            A list of objects of DirectThread
+        """
+        return await self.direct_pending_inbox(amount)
+
     async def direct_pending_chunk(self, cursor: str = None) -> Tuple[List[DirectThread], str]:
         """
         Get direct threads of Pending inbox. Chunk
@@ -233,6 +250,22 @@ class DirectMixin:
             with_signature=False,
         )
         return result.get("status", "") == "ok"
+
+    async def direct_request_approve(self, thread_id: int) -> bool:
+        """
+        Approve a Direct message request thread.
+
+        Parameters
+        ----------
+        thread_id: int
+            ID of thread to approve
+
+        Returns
+        -------
+        bool
+            A boolean value
+        """
+        return await self.direct_pending_approve(thread_id)
 
     async def direct_spam_inbox(self, amount: int = 20) -> List[DirectThread]:
         """
@@ -355,6 +388,36 @@ class DirectMixin:
         """
         assert self.user_id, "Login required"
         return (await self.direct_thread(thread_id, amount)).messages
+
+    async def direct_message(self, thread_id: int, message_id: int, amount: int = 20) -> DirectMessage:
+        """
+        Get a Direct message from a thread by message id.
+
+        Parameters
+        ----------
+        thread_id: int
+            Unique identifier of a Direct Message thread
+
+        message_id: int
+            Unique identifier of a Direct Message item
+
+        amount: int, optional
+            Maximum number of latest messages to scan, default is 20
+
+        Returns
+        -------
+        DirectMessage
+            An object of DirectMessage
+        """
+        message_pk = str(message_id)
+        for message in await self.direct_messages(thread_id, amount):
+            if message.id == message_pk:
+                return message
+        raise DirectMessageNotFound(
+            f"Direct message {message_pk} not found in thread {thread_id}",
+            thread_id=thread_id,
+            message_id=message_pk,
+        )
 
     async def direct_answer(self, thread_id: int, text: str) -> DirectMessage:
         """
@@ -1213,6 +1276,24 @@ class DirectMixin:
         data.pop("device_id", None)
         result = await self.private_request(f"direct_v2/threads/{thread_id}/items/{message_id}/delete/", data=data)
         return result["status"] == "ok"
+
+    async def direct_message_unsend(self, thread_id: int, message_id: int) -> bool:
+        """
+        Unsend a message from a Direct thread.
+
+        Parameters
+        ----------
+        thread_id: int
+            Id of thread
+        message_id: int
+            Id of message
+
+        Returns
+        -------
+        bool
+            A boolean value
+        """
+        return await self.direct_message_delete(thread_id, message_id)
 
     async def direct_thread_mute(self, thread_id: int, revert: bool = False) -> bool:
         """

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -7,7 +7,7 @@ ported through.
 The current sync baseline is:
 
 ```text
-instagrapi 2.6.0
+instagrapi 2.6.1
 ```
 
 ## Release policy
@@ -16,8 +16,9 @@ instagrapi 2.6.0
 - Keep patch releases for urgent fixes after that sync lands.
 - Mention the upstream range in GitHub, PyPI, and Telegram release notes.
 
-For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer,
-covering `instagrapi` releases `2.5.13` through `2.6.0`.
+For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
+`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent
+`aiograpi 0.9.x` patch releases continue that baseline through `instagrapi 2.6.1`.
 
 ## Porting rules
 

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -2,10 +2,13 @@
 
 | Method                                                                    | Return                  | Description
 | ------------------------------------------------------------------------- | ----------------------- | ----------------------------------
-| `direct_threads(amount: int = 20, selected_filter: str = "", thread_message_limit: Optional[int] = None)` <br> Note: selected_filter = "", "flagged" or "unread" | List[DirectThread] | Get all threads from inbox
+| `direct_threads(amount: int = 20, selected_filter: str = "", box: str = "", thread_message_limit: Optional[int] = None)` <br> Note: `selected_filter` = `""`, `"flagged"` or `"unread"`; `box` = `""`, `"primary"` or `"general"` | List[DirectThread] | Get all threads from inbox
 | direct_pending_inbox(amount: int = 20)                                    | List[DirectThread]      | Get all threads from pending inbox
+| direct_requests(amount: int = 20)                                         | List[DirectThread]      | Get message request threads (pending inbox / invitations)
+| direct_request_approve(thread_id: int)                                    | bool                    | Approve a message request thread
 | direct_thread(thread_id: int, amount: int = 20)                           | DirectThread            | Get Thread with Messages
 | direct_messages(thread_id: int, amount: int = 20)                         | List[DirectMessage]     | Get only Messages in Thread
+| direct_message(thread_id: int, message_id: int, amount: int = 20)         | DirectMessage           | Get one Message from Thread by id
 | direct_answer(thread_id: int, text: str)                                  | DirectMessage           | Add Message to exist Thread
 | direct_send(text: str, user_ids: List[int] = [], thread_ids: List[int] = []) | DirectMessage        | Send Message to Users or Threads
 | direct_search(query: str)                                                 | List[DirectShortThread] | Search threads (for example by username)
@@ -17,6 +20,7 @@
 | direct_profile_share(user_id: str, user_ids: List[int], thread_ids: List[int]) | DirectMessage      | Share a user profile to list of users
 | direct_thread_mark_unread(thread_id: int)                                 | bool                    | Mark a thread as unread
 | direct_message_delete(thread_id: int, message_id: int)                    | bool                    | Delete a message from thread
+| direct_message_unsend(thread_id: int, message_id: int)                    | bool                    | Unsend a message from thread
 | direct_send_reaction(thread_id: int, message_id: int, emoji: str = "❤")  | bool                    | Add an emoji reaction to a message
 | direct_delete_reaction(thread_id: int, message_id: int, emoji: str = "❤") | bool                   | Delete your emoji reaction from a message
 | direct_message_like(thread_id: int, message_id: int)                      | bool                    | Add a heart reaction to a message
@@ -28,6 +32,11 @@
 | direct_send_photo(path: Path, user_ids: List[int], thread_ids: List[int]) | DirectMessage           | Send a direct photo to list of users or threads
 | direct_send_video(path: Path, user_ids: List[int], thread_ids: List[int]) | DirectMessage           | Send a direct video to list of users or threads
 | video_upload_to_direct(path: Path, caption: str, thumbnail: Path, mentions: List[StoryMention], thread_ids: List[int] = [], extra_data: Dict[str, str] = {}) | DirectMessage | Upload video to direct thread as a story and configure it
+
+Notes:
+
+* Direct message requests / invitations are exposed as `direct_requests()`; `direct_pending_inbox()` remains as the older name.
+* `direct_message()` scans the latest `amount` messages in a thread and raises `DirectMessageNotFound` if the id is not present in that window.
 
 Example of basic actions:
 
@@ -60,6 +69,10 @@ DirectThread(
     ...
 )
 
+>>> request = (await cl.direct_requests(1))[0]
+>>> await cl.direct_request_approve(request.id)
+True
+
 >>> await cl.direct_thread(thread.id, 1)
 DirectThread(
     pk=18103276039108479,
@@ -75,6 +88,9 @@ DirectThread(
 )
 
 >>> message = (await cl.direct_messages(thread.id, 1))[0]
+DirectMessage(id=300712312341231237412312312360, user_id=12312312, thread_id=None, timestamp=datetime.datetime(2021, 8, 31, 18, 20, 28, 754135, tzinfo=datetime.timezone.utc), item_type='text', is_shh_mode=False, reactions=None, text='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua', animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)
+
+>>> await cl.direct_message(thread.id, message.id)
 DirectMessage(id=300712312341231237412312312360, user_id=12312312, thread_id=None, timestamp=datetime.datetime(2021, 8, 31, 18, 20, 28, 754135, tzinfo=datetime.timezone.utc), item_type='text', is_shh_mode=False, reactions=None, text='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua', animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)
 
 >>> await cl.direct_answer(thread.id, 'Hello!')
@@ -99,6 +115,9 @@ DirectMessage(id=30076291231321231369939116032, user_id=None, thread_id=34028231
 DirectMessage(id=30076291231231230352896, user_id=None, thread_id=3402812312312310641298762, timestamp=datetime.datetime(2021, 8, 31, 19, 48, 38, 482706, tzinfo=datetime.timezone.utc), item_type=None, is_shh_mode=None, reactions=None, text=None, animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)
 
 >>> await cl.direct_message_delete(thread.id, message.pk)
+True
+
+>>> await cl.direct_message_unsend(thread.id, message.id)
 True
 
 >>> await cl.direct_send_reaction(thread.id, message.id, emoji="😂")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "0.9.1"
+version = "0.9.2"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -3,6 +3,8 @@ import unittest
 from unittest.mock import AsyncMock
 
 from aiograpi import Client
+from aiograpi.exceptions import DirectMessageNotFound
+from aiograpi.types import DirectMessage, DirectThread
 
 
 def _build_client():
@@ -29,6 +31,55 @@ class DirectMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             data={"_uuid": "uuid-1", "title": "Updated title"},
             with_signature=False,
         )
+
+    async def test_direct_message_returns_matching_message_by_id(self):
+        client = _build_client()
+        first = DirectMessage(id="111", user_id="1", timestamp=1)
+        expected = DirectMessage(id="222", user_id="1", timestamp=2)
+        client.direct_messages = AsyncMock(return_value=[first, expected])
+
+        result = await client.direct_message(123, "222", amount=50)
+
+        assert result is expected
+        client.direct_messages.assert_awaited_once_with(123, 50)
+
+    async def test_direct_message_raises_when_message_is_missing(self):
+        client = _build_client()
+        message = DirectMessage(id="111", user_id="1", timestamp=1)
+        client.direct_messages = AsyncMock(return_value=[message])
+
+        with self.assertRaises(DirectMessageNotFound) as ctx:
+            await client.direct_message(123, 222, amount=1)
+
+        assert "222" in str(ctx.exception)
+
+    async def test_direct_message_unsend_delegates_to_delete_endpoint(self):
+        client = _build_client()
+        client.direct_message_delete = AsyncMock(return_value=True)
+
+        result = await client.direct_message_unsend(123, 456)
+
+        assert result is True
+        client.direct_message_delete.assert_awaited_once_with(123, 456)
+
+    async def test_direct_requests_uses_pending_inbox(self):
+        client = _build_client()
+        expected = [unittest.mock.Mock(spec=DirectThread)]
+        client.direct_pending_inbox = AsyncMock(return_value=expected)
+
+        result = await client.direct_requests(amount=7)
+
+        assert result is expected
+        client.direct_pending_inbox.assert_awaited_once_with(7)
+
+    async def test_direct_request_approve_delegates_to_pending_approve(self):
+        client = _build_client()
+        client.direct_pending_approve = AsyncMock(return_value=True)
+
+        result = await client.direct_request_approve(123)
+
+        assert result is True
+        client.direct_pending_approve.assert_awaited_once_with(123)
 
     async def test_direct_send_reaction_posts_reaction_payload(self):
         client = _build_client()

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -2,4 +2,4 @@ import aiograpi
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.6.0"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.6.1"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "aiograpi"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- sync Direct helper aliases from instagrapi 2.6.1: message requests, request approval, single-message lookup, and message unsend
- update Direct usage docs and README highlights
- bump aiograpi to 0.9.2 and update the upstream sync marker to instagrapi 2.6.1

## Verification
- .venv/bin/python -m pytest tests/regression/test_direct.py -q
- .venv/bin/python -m pytest tests/regression/test_direct.py tests/regression/test_upstream_sync.py -q
- .venv/bin/python -m pytest tests/regression -q
- .venv/bin/python -m ruff check aiograpi tests/regression/test_direct.py tests/regression/test_upstream_sync.py
- .venv/bin/python -m ruff format --check aiograpi tests/regression/test_direct.py tests/regression/test_upstream_sync.py
- .venv/bin/python -m mkdocs build --strict
- uvx --from build pyproject-build --outdir /tmp/aiograpi-dist-0.9.2 .
- uvx --from twine twine check /tmp/aiograpi-dist-0.9.2/*
- .venv/bin/python -m pip_audit --strict --progress-spinner off .