### PR TITLE
Preserve raw Direct XMA payloads

### DIFF
--- a/aiograpi/extractors.py
+++ b/aiograpi/extractors.py
@@ -337,6 +337,16 @@ def _direct_timestamp_from_microseconds(timestamp):
     return datetime.datetime.fromtimestamp(int(timestamp) // 1_000_000)
 
 
+def _preserve_direct_raw_xma(data):
+    raw_xma = {
+        key: deepcopy(data[key])
+        for key in ("xma_clip", "xma_media_share", "xma_story_share", "xma_profile", "generic_xma")
+        if data.get(key)
+    }
+    if raw_xma:
+        data["raw_xma"] = raw_xma
+
+
 def _convert_direct_visual_media_timestamps(visual_media):
     if not visual_media:
         return
@@ -371,6 +381,7 @@ def _convert_direct_visual_media_timestamps(visual_media):
 
 def extract_reply_message(data):
     data["id"] = data.get("item_id")
+    _preserve_direct_raw_xma(data)
     if "media_share" in data:
         ms = data["media_share"]
         if not ms.get("code"):
@@ -413,6 +424,7 @@ def extract_reply_message(data):
 
 def extract_direct_message(data):
     data["id"] = data.get("item_id")
+    _preserve_direct_raw_xma(data)
     if "replied_to_message" in data:
         data["reply"] = extract_reply_message(data["replied_to_message"])
     if "media_share" in data:

--- a/aiograpi/types.py
+++ b/aiograpi/types.py
@@ -859,6 +859,7 @@ class ReplyMessage(TypesBaseModel):
     felix_share: Optional[dict] = None
     xma_share: Optional[MediaXma] = None
     generic_xma: Optional[List[MediaXma]] = None
+    raw_xma: Optional[dict] = None
     clip: Optional[Media] = None
     placeholder: Optional[dict] = None
 
@@ -884,6 +885,7 @@ class DirectMessage(TypesBaseModel):
     felix_share: Optional[dict] = None
     xma_share: Optional[MediaXma] = None
     generic_xma: Optional[List[MediaXma]] = None
+    raw_xma: Optional[dict] = None
     clip: Optional[Media] = None
     placeholder: Optional[dict] = None
     client_context: Optional[str] = None

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -37,6 +37,8 @@ Notes:
 
 * Direct message requests / invitations are exposed as `direct_requests()`; `direct_pending_inbox()` remains as the older name.
 * `direct_message()` scans the latest `amount` messages in a thread and raises `DirectMessageNotFound` if the id is not present in that window.
+* Shared XMA items such as `xma_clip`, `xma_media_share`, `xma_story_share`, and `xma_profile` keep their original payload in `message.raw_xma`. When Instagram includes `target_url`, the normalized link is also available through `message.xma_share`.
+* Disappearing direct photos and videos with `item_type == "raven_media"` are exposed through `message.visual_media`.
 
 Example of basic actions:
 

--- a/tests/regression/test_extractors.py
+++ b/tests/regression/test_extractors.py
@@ -62,3 +62,46 @@ def test_direct_thread_accepts_string_last_activity_at():
     )
 
     assert thread.last_activity_at == datetime.fromtimestamp(1761953663000000 // 1_000_000)
+
+
+def test_xma_clip_without_target_url_keeps_raw_payload():
+    message = extract_direct_message(
+        {
+            "item_id": "1",
+            "user_id": "2",
+            "timestamp": 1761953663000000,
+            "item_type": "xma_clip",
+            "text": "",
+            "xma_clip": [
+                {
+                    "title_text": "Shared reel",
+                    "preview_media_fbid": "123456789",
+                }
+            ],
+        }
+    )
+
+    assert message.xma_share is None
+    assert message.raw_xma["xma_clip"][0]["preview_media_fbid"] == "123456789"
+
+
+def test_xma_media_share_keeps_raw_payload_when_normalized():
+    message = extract_direct_message(
+        {
+            "item_id": "1",
+            "user_id": "2",
+            "timestamp": 1761953663000000,
+            "item_type": "xma_media_share",
+            "text": "",
+            "xma_media_share": [
+                {
+                    "target_url": "https://example.com/p/abc/",
+                    "title_text": "Shared post",
+                    "preview_media_fbid": "987654321",
+                }
+            ],
+        }
+    )
+
+    assert str(message.xma_share.video_url) == "https://example.com/p/abc/"
+    assert message.raw_xma["xma_media_share"][0]["preview_media_fbid"] == "987654321"


### PR DESCRIPTION
## Summary
- mirror instagrapi PR #2484 Direct raw XMA payload preservation
- keep original shared XMA blocks in `DirectMessage.raw_xma` and `ReplyMessage.raw_xma`
- document `raw_xma` and `visual_media` access for shared and disappearing Direct media

## Verification
- RED: `.venv/bin/python -m pytest tests/regression/test_extractors.py::test_xma_clip_without_target_url_keeps_raw_payload tests/regression/test_extractors.py::test_xma_media_share_keeps_raw_payload_when_normalized -q` failed before the fix because `DirectMessage.raw_xma` did not exist
- GREEN: `.venv/bin/python -m pytest tests/regression/test_extractors.py -q`
- `.venv/bin/python -m pytest tests/regression -q`
- `PATH="$PWD/.venv/bin:$PATH" ./scripts/check-mypy-baseline.sh`
- `.venv/bin/python -m ruff check aiograpi/extractors.py aiograpi/types.py tests/regression/test_extractors.py`
- `.venv/bin/python -m ruff format --check aiograpi/extractors.py aiograpi/types.py tests/regression/test_extractors.py`
- `.venv/bin/python -m mkdocs build --strict`
