### PR TITLE
Add Direct group thread creation helper

### DIFF
--- a/aiograpi/mixins/direct.py
+++ b/aiograpi/mixins/direct.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from aiograpi.exceptions import (
+    ClientError,
     ClientNotFoundError,
     DirectMessageNotFound,
     DirectThreadNotFound,
@@ -1117,6 +1118,44 @@ class DirectMixin:
             with_signature=False,
         )
         return result.get("status", "") == "ok"
+
+    async def direct_thread_create(self, user_ids: List[int], title: str = "") -> str:
+        """
+        Create a group Direct thread.
+
+        Parameters
+        ----------
+        user_ids: List[int]
+            List of unique identifiers of users to add to the group thread.
+            Instagram group threads require at least two recipients besides
+            the authenticated user.
+        title: str, optional
+            Initial group thread title.
+
+        Returns
+        -------
+        str
+            Created Direct thread id.
+        """
+        user_id = getattr(self, "user_id", None)
+        assert user_id, "Login required"
+        assert len(user_ids) >= 2, "Group threads require at least two recipient user_ids"
+
+        result = await getattr(self, "private_request")(
+            "direct_v2/create_group_thread/",
+            data={
+                "_uuid": getattr(self, "uuid"),
+                "_uid": str(user_id),
+                "client_context": getattr(self, "generate_mutation_token")(),
+                "is_partnership_folder": "false",
+                "recipient_users": dumps([int(uid) for uid in user_ids]),
+                "thread_title": title,
+            },
+        )
+        thread_id = result.get("thread_id") or result.get("thread", {}).get("thread_id")
+        if not thread_id:
+            raise ClientError("Create group thread response missing thread_id", **result)
+        return str(thread_id)
 
     async def direct_media_share(
         self,

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -13,6 +13,7 @@
 | direct_send(text: str, user_ids: List[int] = [], thread_ids: List[int] = []) | DirectMessage        | Send Message to Users or Threads
 | direct_search(query: str)                                                 | List[DirectShortThread] | Search threads (for example by username)
 | direct_thread_by_participants(user_ids: List[int])                        | DirectThread            | Get thread by user_id
+| direct_thread_create(user_ids: List[int], title: str = "")                | str                     | Create a group thread and return its thread id
 | direct_thread_hide(thread_id: int)                                        | bool                    | Delete (called "hide")
 | direct_thread_update_title(thread_id: int, title: str)                    | bool                    | Update a thread title
 | direct_media_share(media_id: str, user_ids: List[int])                    | DirectMessage           | Share a media to list of users
@@ -106,6 +107,10 @@ DirectMessage(id=30076213210116812312341061613568, user_id=None, thread_id=34028
 
 >>> await cl.direct_thread_by_participants([cl.user_id])
 DirectThread(pk=178612312342, id=340282366812312312312341298762, messages=[DirectMessage(id=30076214123123123123123864, user_id=1903424587, thread_id=None, timestamp=datetime.datetime(2021, 8, 31, 18, 33, 49, 107154, ...)
+
+>>> thread_id = await cl.direct_thread_create([user_id_1, user_id_2], title="New group")
+>>> await cl.direct_thread(thread_id, amount=1)
+DirectThread(pk=178612312342, id=340282366812312312312341298762, messages=[...], ...)
 
 >>> await cl.direct_media_share(media.pk, user_ids=[cl.user_id])
 DirectMessage(id=3007629312312312312312300374016, user_id=None, thread_id=340282366812313212334410641298762, timestamp=datetime.datetime(2021, 8, 31, 19, 45, 20, 708276, tzinfo=datetime.timezone.utc), item_type=None, is_shh_mode=None, reactions=None, text=None, animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -32,6 +32,35 @@ class DirectMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             with_signature=False,
         )
 
+    async def test_direct_thread_create_posts_group_payload(self):
+        client = _build_client()
+        client.generate_mutation_token = lambda: "mutation-token"
+        client.private_request = AsyncMock(return_value={"thread_id": "3402823668417103"})
+
+        result = await client.direct_thread_create([42, "43"], title="Group title")
+
+        assert result == "3402823668417103"
+        client.private_request.assert_awaited_once_with(
+            "direct_v2/create_group_thread/",
+            data={
+                "_uuid": "uuid-1",
+                "_uid": "1",
+                "client_context": "mutation-token",
+                "is_partnership_folder": "false",
+                "recipient_users": "[42,43]",
+                "thread_title": "Group title",
+            },
+        )
+
+    async def test_direct_thread_create_accepts_nested_thread_id_response(self):
+        client = _build_client()
+        client.generate_mutation_token = lambda: "mutation-token"
+        client.private_request = AsyncMock(return_value={"thread": {"thread_id": "3402823668417104"}})
+
+        result = await client.direct_thread_create([42, 43])
+
+        assert result == "3402823668417104"
+
     async def test_direct_message_returns_matching_message_by_id(self):
         client = _build_client()
         first = DirectMessage(id="111", user_id="1", timestamp=1)


### PR DESCRIPTION
## Summary
- sync Direct group thread creation helper from instagrapi #2485
- add async regression coverage for the create_group_thread payload and response forms
- document direct_thread_create() in the Direct usage guide

## Tests
- .venv/bin/python -m pytest tests/regression/test_direct.py -q
- .venv/bin/python -m pytest tests/regression -q
- .venv/bin/ruff check aiograpi/mixins/direct.py tests/regression/test_direct.py
- PATH="/Users/colinfrl/work/sub/aiograpi/.venv/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/colinfrl/.codex/tmp/arg0/codex-arg0sRMpjz:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/colinfrl/.bun/bin:/Users/colinfrl/.local/bin:/Applications/Ghostty.app/Contents/MacOS:/Users/colinfrl/.orbstack/bin:/Users/colinfrl/.lmstudio/bin:/Users/colinfrl/.orbstack/bin" ./scripts/check-mypy-baseline.sh
- .venv/bin/python -m mkdocs build --strict