### PR TITLE
Normalize Direct recipient ids

### DIFF
--- a/aiograpi/mixins/direct.py
+++ b/aiograpi/mixins/direct.py
@@ -38,6 +38,15 @@ SEND_ATTRIBUTES_MEDIA = (
 )
 BOXES = ("general", "primary")
 
+
+def _direct_id_list(ids) -> List[int]:
+    if ids is None:
+        return []
+    if isinstance(ids, (int, str)):
+        return [int(ids)]
+    return [int(item) for item in ids]
+
+
 try:
     from typing import Literal
 
@@ -471,6 +480,8 @@ class DirectMixin:
             An object of DirectMessage
         """
         assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
         assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
             "Specify user_ids or thread_ids, but not both"
         )
@@ -716,6 +727,8 @@ class DirectMixin:
             An object of DirectMessage
         """
         assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
         assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
             "Specify user_ids or thread_ids, but not both"
         )
@@ -757,6 +770,8 @@ class DirectMixin:
             An object of DirectMessage
         """
         assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
         assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
             "Specify user_ids or thread_ids, but not both"
         )
@@ -832,6 +847,8 @@ class DirectMixin:
             An object of DirectMessage
         """
         assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
         assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
             "Specify user_ids or thread_ids, but not both"
         )
@@ -879,6 +896,7 @@ class DirectMixin:
             Dict with User's presences
         """
         assert self.user_id, "Login Required"
+        user_ids = _direct_id_list(user_ids)
         data = {
             "_uuid": self.uuid,
             "subscriptions_off": "false",
@@ -1044,6 +1062,7 @@ class DirectMixin:
             Some information about thread.
             List of UserShort under "users" key
         """
+        user_ids = _direct_id_list(user_ids)
         recipient_users = dumps([int(uid) for uid in user_ids])
         result = await self.private_request(
             "direct_v2/threads/get_by_participants/",
@@ -1139,6 +1158,7 @@ class DirectMixin:
         """
         user_id = getattr(self, "user_id", None)
         assert user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
         assert len(user_ids) >= 2, "Group threads require at least two recipient user_ids"
 
         result = await getattr(self, "private_request")(
@@ -1186,6 +1206,7 @@ class DirectMixin:
         assert self.user_id, "Login required"
         token = self.generate_mutation_token()
         media_id = await self.media_id(media_id)
+        user_ids = _direct_id_list(user_ids)
         recipient_users = dumps([[int(uid) for uid in user_ids]])
         kwargs = {
             "recipient_users": recipient_users,
@@ -1241,6 +1262,8 @@ class DirectMixin:
             An object of DirectMessage
         """
         assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
         assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
             "Specify user_ids or thread_ids, but not both"
         )
@@ -1427,6 +1450,8 @@ class DirectMixin:
             An object of DirectMessage
         """
         assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
         assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
             "Specify user_ids or thread_ids, but not both"
         )

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -36,6 +36,7 @@
 
 Notes:
 
+* Direct recipient arguments accept either one id (`user_ids=123`) or a list of ids (`user_ids=[123]`).
 * Direct message requests / invitations are exposed as `direct_requests()`; `direct_pending_inbox()` remains as the older name.
 * `direct_message()` scans the latest `amount` messages in a thread and raises `DirectMessageNotFound` if the id is not present in that window.
 * Shared XMA items such as `xma_clip`, `xma_media_share`, `xma_story_share`, and `xma_profile` keep their original payload in `message.raw_xma`. When Instagram includes `target_url`, the normalized link is also available through `message.xma_share`.

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -18,6 +18,17 @@ def _build_client():
     return client
 
 
+def _direct_payload():
+    return {
+        "payload": {
+            "item_id": "1",
+            "timestamp": 1761953663000000,
+            "user_id": "1",
+        },
+        "status": "ok",
+    }
+
+
 class DirectMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_direct_thread_update_title_posts_unsigned_title(self):
         client = _build_client()
@@ -109,6 +120,37 @@ class DirectMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         assert result is True
         client.direct_pending_approve.assert_awaited_once_with(123)
+
+    async def test_direct_send_accepts_scalar_user_id(self):
+        client = _build_client()
+        client.private_request = AsyncMock(return_value=_direct_payload())
+        client.generate_mutation_token = lambda: "mutation-token"
+
+        await client.direct_send("hello", user_ids="42")
+
+        data = client.private_request.call_args.kwargs["data"]
+        assert json.loads(data["recipient_users"]) == [[42]]
+
+    async def test_direct_send_accepts_scalar_thread_id(self):
+        client = _build_client()
+        client.private_request = AsyncMock(return_value=_direct_payload())
+        client.generate_mutation_token = lambda: "mutation-token"
+
+        await client.direct_send("hello", thread_ids="340282366841710300949128149448121770626")
+
+        data = client.private_request.call_args.kwargs["data"]
+        assert json.loads(data["thread_ids"]) == [340282366841710300949128149448121770626]
+
+    async def test_direct_media_share_accepts_scalar_user_id(self):
+        client = _build_client()
+        client.private_request = AsyncMock(return_value=_direct_payload())
+        client.generate_mutation_token = lambda: "mutation-token"
+        client.media_id = AsyncMock(return_value="123_1")
+
+        await client.direct_media_share("123", user_ids=42)
+
+        data = client.private_request.call_args.kwargs["data"]
+        assert json.loads(data["recipient_users"]) == [[42]]
 
     async def test_direct_send_reaction_posts_reaction_payload(self):
         client = _build_client()


### PR DESCRIPTION
## Summary
- accept scalar Direct recipient ids such as `user_ids=123` and `thread_ids=123`
- apply the same normalization across async Direct send/share/presence/thread lookup helpers
- document scalar recipient ids in the Direct usage guide

## Verification
- RED: `.venv/bin/python -m pytest tests/regression/test_direct.py -q` failed before the fix for scalar `user_ids`/`thread_ids`
- `.venv/bin/python -m pytest tests/regression/test_direct.py -q`
- `.venv/bin/ruff check aiograpi/mixins/direct.py tests/regression/test_direct.py`
- `.venv/bin/python -m pytest tests/regression -q`
- `PATH="/Users/colinfrl/work/sub/aiograpi/.venv/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/colinfrl/.codex/tmp/arg0/codex-arg0sRMpjz:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/colinfrl/.bun/bin:/Users/colinfrl/.local/bin:/Applications/Ghostty.app/Contents/MacOS:/Users/colinfrl/.orbstack/bin:/Users/colinfrl/.lmstudio/bin:/Users/colinfrl/.orbstack/bin" ./scripts/check-mypy-baseline.sh`
- `.venv/bin/python -m mkdocs build --strict`

Mirrors subzeroid/instagrapi#2486.