### PR TITLE
Add Direct media share live coverage

### DIFF
--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -28,6 +29,7 @@ from aiograpi.exceptions import (
     ClientThrottledError,
     ClientUnauthorizedError,
     ClipConfigureError,
+    DirectMessageNotFound,
     DirectThreadNotFound,
     IGTVConfigureError,
     InvalidTargetUser,
@@ -2465,6 +2467,38 @@ class ClientDirectTestCase(ClientPrivateTestCase):
         instagram = await self.user_id_from_username("instagram")
         dm = await self.cl.direct_send_photo(path="examples/kanada.jpg", user_ids=[instagram])
         self.assertIsInstance(dm, DirectMessage)
+
+    async def test_direct_media_share(self):
+        instagram = await self.user_id_from_username("instagram")
+        medias = await self.cl.user_medias(instagram, amount=5)
+        media = next(media for media in medias if media.id)
+        media_type = "video" if media.media_type == 2 else "photo"
+        dm = None
+        try:
+            dm = await self.cl.direct_media_share(media.id, user_ids=[instagram], media_type=media_type)
+            self.assertIsInstance(dm, DirectMessage)
+            self.assertTrue(dm.id)
+            self.assertTrue(dm.thread_id)
+
+            shared = None
+            for _ in range(6):
+                try:
+                    shared = await self.cl.direct_message(dm.thread_id, dm.id, amount=10)
+                except DirectMessageNotFound:
+                    await asyncio.sleep(2)
+                    continue
+                if shared.media_share or shared.xma_share or shared.raw_xma:
+                    break
+                await asyncio.sleep(2)
+            self.assertIsNotNone(shared)
+            self.assertTrue(shared.media_share or shared.xma_share or shared.raw_xma)
+        finally:
+            if dm and dm.thread_id:
+                try:
+                    await self.cl.direct_message_unsend(dm.thread_id, dm.id)
+                    await self.cl.direct_thread_hide(dm.thread_id)
+                except Exception as exc:
+                    logger.warning("Direct media share cleanup failed: %s", exc)
 
     async def test_direct_send_video(self):
         instagram = await self.user_id_from_username("instagram")


### PR DESCRIPTION
## Summary
- mirror the new instagrapi Direct media share live coverage in the async legacy suite
- use a current public Instagram media instead of a stale hardcoded post URL
- verify the sent Direct message can be read back with media/XMA payload

Upstream: subzeroid/instagrapi#2487

## Tests
- .venv/bin/ruff check tests/legacy.py
- .venv/bin/python -m pytest tests/regression/test_direct.py -q
- PATH="/Users/colinfrl/work/sub/aiograpi/.venv/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/colinfrl/.codex/tmp/arg0/codex-arg0sRMpjz:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/colinfrl/.bun/bin:/Users/colinfrl/.local/bin:/Applications/Ghostty.app/Contents/MacOS:/Users/colinfrl/.orbstack/bin:/Users/colinfrl/.lmstudio/bin:/Users/colinfrl/.orbstack/bin" ./scripts/check-mypy-baseline.sh