### PR TITLE
Add Direct group participant helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added async `direct_thread_add_users(thread_id, user_ids)` for adding users to existing group Direct threads.
+
 ## [0.9.4] - 2026-05-12
 
 ### Fixed

--- a/aiograpi/mixins/direct.py
+++ b/aiograpi/mixins/direct.py
@@ -1138,6 +1138,34 @@ class DirectMixin:
         )
         return result.get("status", "") == "ok"
 
+    async def direct_thread_add_users(self, thread_id: int, user_ids: List[int]) -> bool:
+        """
+        Add users to a group Direct thread.
+
+        Parameters
+        ----------
+        thread_id: int
+            ID of thread to add users to
+        user_ids: List[int]
+            List of unique identifiers of users to add to the group thread
+
+        Returns
+        -------
+        bool
+            A boolean value
+        """
+        user_id = getattr(self, "user_id", None)
+        assert user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        assert user_ids, "At least one user_id required"
+
+        result = await getattr(self, "private_request")(
+            f"direct_v2/threads/{thread_id}/add_user/",
+            data={"_uuid": getattr(self, "uuid"), "user_ids": dumps([str(uid) for uid in user_ids])},
+            with_signature=False,
+        )
+        return result.get("status", "") == "ok"
+
     async def direct_thread_create(self, user_ids: List[int], title: str = "") -> str:
         """
         Create a group Direct thread.

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -14,6 +14,7 @@
 | direct_search(query: str)                                                 | List[DirectShortThread] | Search threads (for example by username)
 | direct_thread_by_participants(user_ids: List[int])                        | DirectThread            | Get thread by user_id
 | direct_thread_create(user_ids: List[int], title: str = "")                | str                     | Create a group thread and return its thread id
+| direct_thread_add_users(thread_id: int, user_ids: List[int])              | bool                    | Add users to a group thread
 | direct_thread_hide(thread_id: int)                                        | bool                    | Delete (called "hide")
 | direct_thread_update_title(thread_id: int, title: str)                    | bool                    | Update a thread title
 | direct_media_share(media_id: str, user_ids: List[int])                    | DirectMessage           | Share a media to list of users
@@ -112,6 +113,9 @@ DirectThread(pk=178612312342, id=340282366812312312312341298762, messages=[Direc
 >>> thread_id = await cl.direct_thread_create([user_id_1, user_id_2], title="New group")
 >>> await cl.direct_thread(thread_id, amount=1)
 DirectThread(pk=178612312342, id=340282366812312312312341298762, messages=[...], ...)
+
+>>> await cl.direct_thread_add_users(thread_id, [user_id_3])
+True
 
 >>> await cl.direct_media_share(media.pk, user_ids=[cl.user_id])
 DirectMessage(id=3007629312312312312312300374016, user_id=None, thread_id=340282366812313212334410641298762, timestamp=datetime.datetime(2021, 8, 31, 19, 45, 20, 708276, tzinfo=datetime.timezone.utc), item_type=None, is_shh_mode=None, reactions=None, text=None, animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -43,6 +43,19 @@ class DirectMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             with_signature=False,
         )
 
+    async def test_direct_thread_add_users_posts_unsigned_user_ids(self):
+        client = _build_client()
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        result = await client.direct_thread_add_users(123, [42, "43"])
+
+        assert result is True
+        client.private_request.assert_awaited_once_with(
+            "direct_v2/threads/123/add_user/",
+            data={"_uuid": "uuid-1", "user_ids": '["42","43"]'},
+            with_signature=False,
+        )
+
     async def test_direct_thread_create_posts_group_payload(self):
         client = _build_client()
         client.generate_mutation_token = lambda: "mutation-token"


### PR DESCRIPTION
## What

Adds async `direct_thread_add_users(thread_id, user_ids)` for adding users to existing group Direct threads.

Updates Direct docs, regression coverage, and the changelog.

## Why

Keeps `aiograpi` aligned with the Direct group management API already available in `instagrapi`.

Related: https://github.com/subzeroid/instagrapi/pull/2490

## Notes for reviewers

The helper posts an unsigned request to `direct_v2/threads/{thread_id}/add_user/` with `_uuid` and a compact JSON `user_ids` list encoded as strings.

Verification:

- Red phase: targeted test failed with missing `direct_thread_add_users` before implementation.
- `.venv/bin/python -m pytest tests/regression/test_direct.py::DirectMixinRegressionTestCase::test_direct_thread_add_users_posts_unsigned_user_ids -q`
- `.venv/bin/python -m pytest tests/regression/test_direct.py -q`
- `.venv/bin/python -m pytest tests/regression -q`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/mkdocs build --strict`
- `./scripts/check-mypy-baseline.sh`
- `.venv/bin/pip-audit --strict .`

## Checklist

- [x] Tests added or updated
- [x] Unit tests pass
- [x] Mypy gate clean
- [x] Dependency audit clean
- [x] Docs updated
- [x] No secrets, tokens, sessionids, or proxy URLs in commits or logs