### PR TITLE
Sync GraphQL profile timeline flow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -147,8 +147,9 @@ jobs:
           test: "true"
       - name: Run end-to-end smoke
         # Required: anonymous public_gql + login(TOTP) + private_v1 +
-        # private_v2_gql + hashtag_info_v1 + user_medias_v1 +
-        # user_followers + highlight_info.
+        # private_v2_gql + user_short_gql + hashtag_info_v1 +
+        # user_medias_v1 + user_medias_gql + user_followers +
+        # highlight_info.
         # Optional (reports but never fails): all chapi-ported endpoints.
         # PYTHONPATH=. so `from aiograpi import Client` resolves without
         # `pip install -e .` (install-dependencies action installs deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Synced profile GraphQL lookups with the current upstream flow: `user_short_gql` now uses the web profile `doc_id`, `user_medias_gql` uses the app `IGProfileTimelineQuery` `client_doc_id`, and private GraphQL accepts incremental JSON-lines responses.
 - Added an internal typing-only `ClientMixin` contract so mixins can use shared client attributes directly without `getattr` workarounds, eliminating the remaining `[attr-defined]` errors and reducing the internal mypy regression baseline from 1176 to 270 errors.
 - Removed the `py.typed` package marker and user-facing PEP 561 messaging until aiograpi's annotations are ready to be supported as a public typing surface.
+
+### Fixed
+
+- Normalized nullable XDT media fields returned by profile timeline GraphQL so media extraction accepts missing usertags, missing carousel resources, and incomplete scrubber spritesheet blocks.
 
 ## [0.9.4] - 2026-05-12
 

--- a/aiograpi/extractors.py
+++ b/aiograpi/extractors.py
@@ -60,6 +60,9 @@ def extract_media_v1(data):
             media["image_versions2"]["candidates"],
             key=lambda o: o["height"] * o["width"],
         )[-1]["url"]
+        scrubber = media["image_versions2"].get("scrubber_spritesheet_info_candidates") or {}
+        if scrubber.get("default") and not scrubber["default"].get("sprite_urls"):
+            media["image_versions2"].pop("scrubber_spritesheet_info_candidates", None)
     if media["media_type"] == 8:
         # remove thumbnail_url and video_url for albums
         # see resources
@@ -68,8 +71,9 @@ def extract_media_v1(data):
     location = media.get("location")
     media["location"] = location and extract_location(location)
     media["user"] = extract_user_short(media.get("user"))
+    usertags = media.get("usertags") or {}
     media["usertags"] = sorted(
-        [extract_usertag(usertag) for usertag in media.get("usertags", {}).get("in", [])],
+        [extract_usertag(usertag) for usertag in usertags.get("in", [])],
         key=lambda tag: tag.user.pk,
     )
     media["like_count"] = media.get("like_count", 0)
@@ -79,7 +83,7 @@ def extract_media_v1(data):
     media["coauthor_producers"] = media.get("coauthor_producers", [])
     return Media(
         caption_text=(media.get("caption") or {}).get("text", ""),
-        resources=[extract_resource_v1(edge) for edge in media.get("carousel_media", [])],
+        resources=[extract_resource_v1(edge) for edge in media.get("carousel_media") or []],
         **media,
     )
 

--- a/aiograpi/mixins/graphql.py
+++ b/aiograpi/mixins/graphql.py
@@ -102,6 +102,54 @@ class GraphQLRequestMixin(ClientMixin):
         )
         super().__init__(*args, **kwargs)
 
+    def _merge_incremental_graphql_payload(self, base: dict, payload: dict) -> None:
+        path = payload.get("path")
+        if not isinstance(path, list) or not path or "data" not in payload:
+            return
+        target = base
+        if path and path[0] != "data":
+            target = base.get("data", {})
+        elif path and path[0] == "data":
+            path = path[1:]
+        if not path:
+            return
+        try:
+            for key in path[:-1]:
+                target = target[key]
+        except (KeyError, IndexError, TypeError):
+            return
+        key = path[-1]
+        value = payload["data"]
+        if isinstance(target, list):
+            if not isinstance(key, int):
+                return
+            try:
+                current = target[key]
+            except IndexError:
+                return
+            if isinstance(current, dict) and isinstance(value, dict):
+                current.update(value)
+            else:
+                target[key] = value
+            return
+        current = target.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            current.update(value)
+        else:
+            target[key] = value
+
+    def _json_from_graphql_response(self, response):
+        try:
+            return response.json()
+        except orjson.JSONDecodeError:
+            chunks = [orjson.loads(line) for line in response.text.splitlines() if line.strip()]
+            if not chunks:
+                raise
+            body = chunks[0]
+            for chunk in chunks[1:]:
+                self._merge_incremental_graphql_payload(body, chunk)
+            return body
+
     @property
     async def fb_dtsg(self):
         if not self._fb_dtsg:
@@ -147,7 +195,7 @@ class GraphQLRequestMixin(ClientMixin):
             self.request_log(response)
             self.last_response = response
             response.raise_for_status()
-            self.last_json = response.json()
+            self.last_json = self._json_from_graphql_response(response)
         except orjson.JSONDecodeError as exc:
             url = response.url if response else url
             raise ClientJSONDecodeError(

--- a/aiograpi/mixins/media.py
+++ b/aiograpi/mixins/media.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 from aiograpi import httpx_ext
 from aiograpi.exceptions import (
     ClientError,
+    ClientGraphqlError,
     ClientLoginRequired,
     ClientNotFoundError,
     ClientUnauthorizedError,
@@ -31,6 +32,8 @@ from aiograpi.utils.auth import generate_jazoest
 from aiograpi.utils.ids import InstagramIdCodec
 from aiograpi.utils.serialization import dumps, json_value
 
+IG_PROFILE_TIMELINE_DOC_ID = "56030350814417327502004290437"
+
 
 class MediaMixin(ClientMixin):
     """
@@ -38,6 +41,126 @@ class MediaMixin(ClientMixin):
     """
 
     _medias_cache = {}  # pk -> object
+
+    @staticmethod
+    def _find_profile_timeline_payload(data):
+        if not isinstance(data, dict):
+            return None
+        if "profile_grid_items" in data:
+            return data
+        for value in data.values():
+            found = MediaMixin._find_profile_timeline_payload(value)
+            if found:
+                return found
+        return None
+
+    @staticmethod
+    def _normalize_xdt_profile_media(media: Dict) -> Dict:
+        media = deepcopy(media)
+        user = media.get("user") or {}
+        if "pk" not in user and user.get("id"):
+            user["pk"] = user["id"]
+        media["user"] = user
+        media_id = str(media.get("id") or media.get("pk") or "")
+        if "pk" not in media and media_id:
+            media["pk"] = media_id.split("_", 1)[0]
+        if media_id and "_" not in media_id and user.get("pk"):
+            media["id"] = f"{media_id}_{user['pk']}"
+        if "taken_at" not in media and "1ltaken_at" in media:
+            media["taken_at"] = media["1ltaken_at"]
+        return media
+
+    async def _user_medias_chunk_app_gql(
+        self, user_id: int, amount: int = 0, end_cursor=None
+    ) -> Tuple[List[Media], str]:
+        count = 50 if not amount or amount > 50 else amount
+        variables = {
+            "request_media_chunk": True,
+            "skip_clips_captions_fields": False,
+            "fetch_profile_grid_items": True,
+            "exclude_comment": "false",
+            "request_hints_chunk": False,
+            "include_unseen_media_ids": False,
+            "exclude_pinned_posts": False,
+            "enable_carousel_media_count_in_deferred": True,
+            "include_fb_mentioned_users": False,
+            "include_attribution_ui_data": True,
+            "include_profile_grid_rendering_option": False,
+            "count": count,
+            "initial_count_carousel_media": 5,
+            "exclude_collaborative_posts": False,
+            "include_is_photo_comments_composer_enabled_for_author": False,
+            "include_associated_highlights": False,
+            "include_attribution_ui_data_v2": True,
+            "include_media_notes_fields": True,
+            "include_eligible_insights_entrypoints": False,
+            "include_accessibility_caption_for_carousel": True,
+            "defer_maybe_non_essential_lightweight_fields": False,
+            "num_previews_for_associated_highlights": 3,
+            "include_videos_for_associated_highlights": False,
+            "exclude_user": False,
+            "defer_hints_chunk": False,
+            "exclude_highlights": True,
+            "include_ring_creator_fields": False,
+            "include_timeline_ordered_edge": False,
+            "user_id": str(user_id),
+            "exclude_besties_content": True,
+            "force_compute_user_tags": False,
+            "enable_profile_fm_integration": False,
+            "include_is_unseen_by_viewer": False,
+        }
+        if end_cursor:
+            variables["max_id"] = end_cursor
+        data = {
+            "method": "post",
+            "pretty": "false",
+            "format": "json",
+            "server_timestamps": "true",
+            "locale": self.locale,
+            "fb_api_req_friendly_name": "IGProfileTimelineQuery",
+            "fb_api_caller_class": "graphservice",
+            "client_doc_id": IG_PROFILE_TIMELINE_DOC_ID,
+            "variables": json.dumps(variables, separators=(",", ":")),
+        }
+        response = await self.private_graphql_request(
+            data,
+            headers={"X-FB-Friendly-Name": "IGProfileTimelineQuery"},
+        )
+        timeline = self._find_profile_timeline_payload(response.get("data", response))
+        if not timeline:
+            raise ClientGraphqlError("Missing profile timeline payload in IGProfileTimelineQuery response")
+        medias = []
+        for item in timeline.get("profile_grid_items") or []:
+            media = item.get("media") if isinstance(item, dict) else None
+            if not media:
+                continue
+            medias.append(extract_media_v1(self._normalize_xdt_profile_media(media)))
+        end_cursor = None
+        if timeline.get("more_available"):
+            end_cursor = timeline.get("next_max_id") or timeline.get("profile_grid_items_cursor")
+        if amount:
+            medias = medias[:amount]
+        return medias, end_cursor
+
+    async def _user_medias_chunk_public_gql(
+        self, user_id: int, amount: int = 0, end_cursor=None
+    ) -> Tuple[List[Media], str]:
+        user_id = int(user_id)
+        medias = []
+        variables = {
+            "id": user_id,
+            "first": 50 if not amount or amount > 50 else amount,
+        }
+        variables["after"] = end_cursor
+        data = await self.public_graphql_request(variables, query_hash="e7e2f4da4b02303f74f0841279e52d76")
+        page_info = json_value(data, "user", "edge_owner_to_timeline_media", "page_info", default={})
+        edges = json_value(data, "user", "edge_owner_to_timeline_media", "edges", default=[])
+        for edge in edges:
+            medias.append(edge["node"])
+        end_cursor = page_info.get("end_cursor")
+        if amount:
+            medias = medias[:amount]
+        return ([extract_media_gql(media) for media in medias], end_cursor)
 
     def _extract_configured_media_or_raise(self, configured, exception_cls, context: str):
         media = None
@@ -524,7 +647,9 @@ class MediaMixin(ClientMixin):
         """
         return await self.media_like(media_id, revert=True)
 
-    async def user_medias_chunk_gql(self, user_id: int, sleep: int = 2, end_cursor=None) -> Tuple[List[Media], str]:
+    async def user_medias_chunk_gql(
+        self, user_id: int, sleep: int = 2, end_cursor=None, amount: int = 0
+    ) -> Tuple[List[Media], str]:
         """
         Get a page of a user's media by Public Graphql API
 
@@ -542,24 +667,12 @@ class MediaMixin(ClientMixin):
         Tuple[List[Media], str]
             A tuple containing a list of medias and the next end_cursor value
         """
-        # amount = int(amount)
+        amount = int(amount)
         user_id = int(user_id)
-        medias = []
-        variables = {
-            "id": user_id,
-            "first": 50,
-            # These are Instagram restrictions, you can only specify <= 50
-        }
-        variables["after"] = end_cursor
-        data = await self.public_graphql_request(variables, query_hash="e7e2f4da4b02303f74f0841279e52d76")
-        page_info = json_value(data, "user", "edge_owner_to_timeline_media", "page_info", default={})
-        edges = json_value(data, "user", "edge_owner_to_timeline_media", "edges", default=[])
-        for edge in edges:
-            medias.append(edge["node"])
-        end_cursor = page_info.get("end_cursor")
-        # if amount:
-        #     medias = medias[:amount]
-        return ([extract_media_gql(media) for media in medias], end_cursor)
+        try:
+            return await self._user_medias_chunk_app_gql(user_id, amount, end_cursor=end_cursor)
+        except ClientError:
+            return await self._user_medias_chunk_public_gql(user_id, amount, end_cursor=end_cursor)
 
     async def user_medias_gql(self, user_id: int, amount: int = 0, sleep: int = 0) -> List[Media]:
         """
@@ -583,20 +696,15 @@ class MediaMixin(ClientMixin):
         sleep = int(sleep)
         medias = []
         end_cursor = None
-        variables = {
-            "id": user_id,
-            "first": 50 if not amount or amount > 50 else amount,
-            # These are Instagram restrictions, you can only specify <= 50
-        }
         while True:
             self.logger.info(f"user_medias_gql: {amount}, {end_cursor}")
-            if end_cursor:
-                variables["after"] = end_cursor
 
             if not sleep:
                 sleep = random.randint(1, 3)
 
-            medias_page, end_cursor = await self.user_medias_chunk_gql(user_id, sleep, end_cursor=end_cursor)
+            medias_page, end_cursor = await self.user_medias_chunk_gql(
+                user_id, sleep=sleep, end_cursor=end_cursor, amount=amount
+            )
             medias.extend(medias_page)
             if not end_cursor or len(medias_page) == 0:
                 break

--- a/aiograpi/mixins/user.py
+++ b/aiograpi/mixins/user.py
@@ -6,7 +6,6 @@ from orjson import JSONDecodeError
 
 from aiograpi.exceptions import (
     ClientError,
-    ClientGraphqlError,
     ClientJSONDecodeError,
     ClientLoginRequired,
     ClientNotFoundError,
@@ -35,45 +34,11 @@ from aiograpi.types import (
     User,
     UserShort,
 )
-from aiograpi.utils.auth import generate_jazoest
 from aiograpi.utils.serialization import dumps, json_value
 
 MAX_USER_COUNT = 200
 INFO_FROM_MODULES = ("self_profile", "feed_timeline", "reel_feed_timeline")
-GRAPHQL_WEB_API_URL = "https://www.instagram.com/api/graphql"
-GQL_STUFF = {
-    "av": "17841464591314721",
-    "__d": "www",
-    "__user": "0",
-    "__a": "1",
-    "__req": "q",
-    "__hs": "19768.HYP:instagram_web_pkg.2.1..0.1",
-    "dpr": "2",
-    "__ccg": "UNKNOWN",
-    "__rev": "1011444902",
-    "__s": "x82a1q:agr3gd:4nh4nl",
-    "__hsi": "7335888108907652597",
-    "__dyn": (
-        "7xeUjG1mxu1syUbFp40NonwgU7SbzEdF8aUco2qwJxS0k24o0B-"
-        "q1ew65xO0FE2awt81s8hwGwQwoEcE7O2l0Fwqo31w9O7U2cxe0E"
-        "UjwGzEaE7622362W2K0zK5o4q3y1Sx-0iS2Sq2-azqwt8dUaob8"
-        "2cwMwrUdUbGwmk0KU6O1FwlE6PhA6bxy4VUKUnAwHw"
-    ),
-    "__csr": (
-        "g9cj5kxfs8lifTitQDqhdhalmDEAJaKBRJFdkAGHBkPy9HgCA-A"
-        "rtucm5bCBBGpyAoz-mLJpXJufKWGQ9hHhAhnKECuFUZ3Q8Jkmmp"
-        "eWyGAzkEj_CjyoZUgK-E8bwYzaxy00ktMGx20XU3gw4KAo3MChU"
-        "jw3N80poolwiA1d7G2yu2ucxi1nwEw16OE1JsS043Etw63wkSEgg1Mu00yiU"
-    ),
-    "__comet_req": "7",
-    "lsd": "6b2800R9u4biJOYjcdXFEI",
-    "__spin_r": "1011444902",
-    "__spin_b": "trunk",
-    "__spin_t": "1708019550",
-    "fb_api_caller_class": "RelayModern",
-    "fb_api_req_friendly_name": "PolarisProfilePageContentQuery",
-    "server_timestamps": "true",
-}
+USER_WEB_PROFILE_DOC_ID = "26762473490008061"
 
 logger = logging.getLogger(__name__)
 
@@ -129,24 +94,13 @@ class UserMixin(ClientMixin):
         UserShort
             An object of UserShort type
         """
-        variables = {
-            "user_id": str(user_id),
-            "include_reel": True,
-        }
-        try:
-            data = await self.public_graphql_request(variables, query_hash="ad99dd9d3646cc3c0dda65debcd266a7")
-            if not data["user"]:
-                raise UserNotFound(user_id=user_id, **data)
-            user = extract_user_short(data["user"]["reel"]["user"])
-        except ClientGraphqlError:
-            user = extract_user_short(await self.user_web_profile_info_gql(user_id))
-        return user
+        return extract_user_short(await self.user_web_profile_info_gql(user_id))
 
     async def user_web_profile_info_gql(self, user_id: str) -> dict:
         """
         Fetch a user profile via the public-host PolarisProfilePageContentQuery.
 
-        ``POST /api/graphql`` with ``doc_id="26762473490008061"`` —
+        ``POST /graphql/query/`` with ``doc_id="26762473490008061"`` —
         the modern web-profile GraphQL surface that replaced the old
         ``query_hash`` profile lookups. Requires a logged-in
         ``sessionid`` (the doc_id rejects anonymous callers).
@@ -172,14 +126,10 @@ class UserMixin(ClientMixin):
             ``sessionid`` is not available to inject.
         UserNotFound
             Response contained no ``user`` block.
-        ClientGraphqlError
-            GraphQL ``errors`` array was non-empty and ``data`` was
-            missing.
         """
         user_id = str(user_id)
         if not self.inject_sessionid_to_public():
             raise ClientLoginRequired("Session is required for web profile GraphQL")
-        doc_id = "26762473490008061"
         variables = {
             "enable_integrity_filters": True,
             "id": user_id,
@@ -188,37 +138,14 @@ class UserMixin(ClientMixin):
             "__relay_internal__pv__PolarisCASB976ProfileEnabledrelayprovider": False,
             "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
         }
-        headers = {
-            "Origin": "https://www.instagram.com",
-            "Authority": "www.instagram.com",
-            "Sec-Fetch-Site": "same-origin",
-            "X-FB-Friendly-Name": "PolarisProfilePageContentQuery",
-        }
-        body = await self.public_request(
-            GRAPHQL_WEB_API_URL,
-            data={
-                "variables": dumps(variables),
-                "doc_id": doc_id,
-                "fb_dtsg": await self.fb_dtsg,
-                "jazoest": generate_jazoest(self.phone_id),
-                **GQL_STUFF,
-            },
-            headers=headers,
-            update_headers=False,
-            return_json=True,
+        data = await self.public_doc_id_graphql_request(
+            USER_WEB_PROFILE_DOC_ID,
+            variables,
+            referer=f"https://www.instagram.com/{user_id}/",
+            headers={"X-FB-Friendly-Name": "PolarisProfilePageContentQuery"},
         )
-        if errs := body.get("errors"):
-            if "data" not in body:
-                summary = errs[0].get("summary")
-                description = errs[0].get("description")
-                raise ClientGraphqlError(
-                    "GraphQL user profile fallback failed. Summary: '{}'. Description: '{}'".format(
-                        summary, description
-                    )
-                )
-        data = body.get("data")
         if not data or not data.get("user"):
-            raise UserNotFound(user_id=user_id, **body)
+            raise UserNotFound(user_id=user_id, **(data or {}))
         return data["user"]
 
     async def username_from_user_id_gql(self, user_id: str) -> str:

--- a/tests/live/smoke.py
+++ b/tests/live/smoke.py
@@ -82,8 +82,10 @@ async def main():
         for name, fn in [
             ("private_v1", lambda: cl.user_info_by_username_v1("instagram")),
             ("private_v2_gql", lambda: cl.user_info_by_username_v2_gql("instagram")),
+            ("user_short_gql", lambda: cl.user_short_gql("25025320")),
             ("hashtag_info_v1", lambda: cl.hashtag_info_v1("python")),
             ("user_medias_v1", lambda: cl.user_medias_v1("25025320", amount=3)),
+            ("user_medias_gql", lambda: cl.user_medias_gql("25025320", amount=3)),
             ("user_followers", lambda: cl.user_followers("25025320", amount=10)),
             ("highlight_info", lambda: cl.highlight_info(17983407089364361)),
         ]:

--- a/tests/regression/test_media_pagination.py
+++ b/tests/regression/test_media_pagination.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import AsyncMock
 
+import orjson
+
 from aiograpi import Client
 from aiograpi.exceptions import ClientError
 
@@ -104,3 +106,53 @@ class LocationPaginationRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         assert medias == []
         assert next_max_id is None
+
+
+class UserMediasGraphQLRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    def _xdt_media_payload(self):
+        return {
+            "id": "1",
+            "code": "abc",
+            "1ltaken_at": 1710000000,
+            "media_type": 1,
+            "usertags": None,
+            "carousel_media": None,
+            "user": {
+                "pk": "2",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "image_versions2": {
+                "candidates": [{"url": "https://example.com/x.jpg", "width": 100, "height": 100}],
+                "scrubber_spritesheet_info_candidates": {"default": {"video_length": 15.4}},
+            },
+        }
+
+    async def test_user_medias_chunk_gql_uses_app_timeline_doc_id(self):
+        client = Client()
+        response = {
+            "data": {
+                "xdt_api__v1__profile_timeline": {
+                    "profile_grid_items": [{"media": self._xdt_media_payload()}],
+                    "more_available": True,
+                    "next_max_id": "next-page",
+                }
+            }
+        }
+        client.private_graphql_request = AsyncMock(return_value=response)
+        client.public_graphql_request = AsyncMock(side_effect=AssertionError("legacy query_hash should not be used"))
+
+        medias, end_cursor = await client.user_medias_chunk_gql("123", amount=1, end_cursor="cursor-1")
+
+        client.private_graphql_request.assert_awaited_once()
+        client.public_graphql_request.assert_not_called()
+        data = client.private_graphql_request.call_args.args[0]
+        variables = orjson.loads(data["variables"])
+        self.assertEqual(data["fb_api_req_friendly_name"], "IGProfileTimelineQuery")
+        self.assertEqual(data["client_doc_id"], "56030350814417327502004290437")
+        self.assertEqual(variables["user_id"], "123")
+        self.assertEqual(variables["count"], 1)
+        self.assertEqual(variables["max_id"], "cursor-1")
+        self.assertEqual(end_cursor, "next-page")
+        self.assertEqual([media.pk for media in medias], ["1"])
+        self.assertEqual(medias[0].id, "1_2")

--- a/tests/regression/test_request_logging.py
+++ b/tests/regression/test_request_logging.py
@@ -39,6 +39,29 @@ class RequestLoggingRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIn("truncated", logged_body)
         self.assertNotEqual(logged_body, long_body)
 
+    async def test_private_graphql_request_accepts_incremental_json_lines(self):
+        client = Client()
+        response = Mock()
+        response.url = "https://i.instagram.com/graphql/query"
+        response.text = (
+            '{"data":{"timeline":{"items":[{"media":{"id":"1"}}]}},"status":"ok"}\n'
+            '{"path":["timeline","items",0,"media"],"data":{"code":"abc"}}\n'
+        )
+        response.json.side_effect = _json_decode_error()
+        response.raise_for_status.return_value = None
+        client.private.post = AsyncMock(return_value=response)
+        client.request_log = Mock()
+
+        result = await client.private_graphql_request(
+            {
+                "fb_api_req_friendly_name": "ExampleQuery",
+                "variables": "{}",
+            }
+        )
+
+        self.assertEqual(result["data"]["timeline"]["items"][0]["media"]["id"], "1")
+        self.assertEqual(result["data"]["timeline"]["items"][0]["media"]["code"], "abc")
+
     async def test_graphql_json_decode_error_log_truncates_response_body(self):
         client = Client()
         client.last_response_ts = 0

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -16,3 +16,45 @@ class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(username, "fallback_user")
         client.username_from_user_id_gql.assert_awaited_once_with("123")
         client.user_info_v1.assert_awaited_once_with("123")
+
+    async def test_user_short_gql_uses_web_profile_doc_id_without_legacy_query_hash(self):
+        client = Client()
+        web_user = {
+            "id": "25025320",
+            "username": "instagram",
+            "full_name": "Instagram",
+            "is_private": False,
+            "profile_pic_url": "https://example.com/pic.jpg",
+        }
+        client.public_graphql_request = AsyncMock(side_effect=AssertionError("legacy query_hash should not be used"))
+        client.user_web_profile_info_gql = AsyncMock(return_value=web_user)
+
+        user = await client.user_short_gql("25025320")
+
+        self.assertEqual(user.username, "instagram")
+        client.user_web_profile_info_gql.assert_awaited_once_with("25025320")
+        client.public_graphql_request.assert_not_called()
+
+    async def test_user_web_profile_info_gql_uses_public_doc_id_endpoint(self):
+        client = Client()
+        web_user = {
+            "id": "25025320",
+            "username": "instagram",
+            "full_name": "Instagram",
+            "is_private": False,
+            "profile_pic_url": "https://example.com/pic.jpg",
+        }
+        client.inject_sessionid_to_public = Mock(return_value=True)
+        client.public_request = AsyncMock(side_effect=AssertionError("legacy /api/graphql endpoint should not be used"))
+        client.public_doc_id_graphql_request = AsyncMock(return_value={"user": web_user})
+
+        user = await client.user_web_profile_info_gql("25025320")
+
+        self.assertEqual(user["username"], "instagram")
+        client.public_request.assert_not_called()
+        client.public_doc_id_graphql_request.assert_awaited_once()
+        args, kwargs = client.public_doc_id_graphql_request.call_args
+        self.assertEqual(args[0], "26762473490008061")
+        self.assertEqual(args[1]["id"], "25025320")
+        self.assertEqual(args[1]["render_surface"], "PROFILE")
+        self.assertEqual(kwargs["referer"], "https://www.instagram.com/25025320/")


### PR DESCRIPTION
## Summary
- switch async user profile GraphQL from stale query_hash/web /api/graphql calls to current doc_id flow
- move user_medias_gql to the app IGProfileTimelineQuery client_doc_id with legacy public query fallback
- parse private GraphQL incremental JSON-lines responses and normalize nullable XDT media fields
- add regression coverage and live smoke coverage for user_short_gql/user_medias_gql

## Verification
- .venv/bin/ruff check .
- .venv/bin/ruff format --check .
- .venv/bin/python -m pytest -q tests/regression/test_user.py tests/regression/test_media_pagination.py tests/regression/test_request_logging.py
- .venv/bin/python -m pytest -q tests/regression
- .venv/bin/python -m pytest -q tests/legacy.py::ExtractorsRegressionTestCase tests/legacy.py::ImageUtilSafeRemoteFetchTestCase tests/legacy.py::DirectExtractorRegressionTestCase tests/legacy.py::PublicRegressionTestCase tests/legacy.py::PolarisProfileNormalizationTestCase tests/legacy.py::CaptchaHandlerMixinRegressionTestCase tests/legacy.py::NoteMixinRegressionTestCase tests/legacy.py::LocationMixinRegressionTestCase tests/legacy.py::ChallengeRegressionTestCase tests/legacy.py::AuthAndStoryRegressionTestCase tests/legacy.py::ClientTestCase tests/legacy.py::DownloadRegressionTestCase tests/legacy.py::DirectMixinRegressionTestCase tests/legacy.py::UserMixinRegressionTestCase tests/legacy.py::TimelineRegressionTestCase tests/legacy.py::StoryConfigureRegressionTestCase tests/legacy.py::UploadRegressionTestCase tests/legacy.py::SignUpTestCase tests/legacy.py::NotificationMixinRegressionTestCase tests/legacy.py::ChapiPortedRegressionTestCase tests/regression
- ./scripts/check-mypy-baseline.sh
- .venv/bin/mkdocs build --strict
- .venv/bin/bandit -c pyproject.toml -r aiograpi
- .venv/bin/pip-audit --strict --progress-spinner off .
- targeted live verification: user_short_gql and user_medias_gql passed against a live account

Note: the full live smoke was retried twice; the new required checks passed, but the run was blocked by an unrelated 429 on the pre-existing anonymous public_gql check.