### PR TITLE
Stabilize live smoke upstream baseline

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -146,11 +146,11 @@ jobs:
         with:
           test: "true"
       - name: Run end-to-end smoke
-        # Required: anonymous public_gql + login(TOTP) + private_v1 +
-        # private_v2_gql + user_short_gql + hashtag_info_v1 +
-        # user_medias_v1 + user_medias_gql + user_followers +
-        # highlight_info.
-        # Optional (reports but never fails): all chapi-ported endpoints.
+        # Required: login(TOTP) + private_v1 + private_v2_gql +
+        # user_short_gql + hashtag_info_v1 + user_medias_v1 +
+        # user_medias_gql + user_followers + highlight_info.
+        # Optional (reports but never fails): anonymous public web
+        # lookup + all chapi-ported endpoints.
         # PYTHONPATH=. so `from aiograpi import Client` resolves without
         # `pip install -e .` (install-dependencies action installs deps
         # only, not the package itself).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Made the anonymous public web lookup in `tests/live/smoke.py` optional so Instagram 429 throttling does not fail otherwise healthy logged-in live checks.
+- Updated the recorded upstream sync baseline to `instagrapi` 2.6.4.
+
 ## [0.9.5] - 2026-05-13
 
 ### Added

--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -45,7 +45,7 @@ from aiograpi.mixins.video import DownloadVideoMixin, UploadVideoMixin
 # Used as fallback logger if another is not provided.
 DEFAULT_LOGGER = logging.getLogger("aiograpi")
 
-__upstream_instagrapi_version__ = "2.6.3"
+__upstream_instagrapi_version__ = "2.6.4"
 
 
 class Client(

--- a/tests/live/smoke.py
+++ b/tests/live/smoke.py
@@ -1,8 +1,9 @@
 """Live end-to-end smoke for aiograpi.
 
 Exits 0 if all REQUIRED checks pass; non-zero otherwise. Optional
-checks (chapi-style new endpoints) are reported but never fail the
-build — IG rotates doc_ids and we don't want a flaky CI gate.
+checks (anonymous public web paths and chapi-style new endpoints) are
+reported but never fail the build — IG rotates doc_ids and throttles
+anonymous web requests, and we don't want a flaky CI gate.
 
 Required env: TEST_ACCOUNTS_URL pointing at an accounts endpoint
 that returns at least one usable account (with TOTP seed if 2FA is
@@ -64,15 +65,15 @@ async def main():
 
     failures = []
 
-    # REQUIRED: anonymous public path
+    # OPTIONAL: anonymous public path. IG often throttles this web endpoint
+    # with 429 while logged-in app-backed checks are healthy.
     try:
         c = Client()
         u = await c.user_info_by_username_gql("instagram")
         assert u.username == "instagram" and u.pk == "25025320"
-        print(f"REQ public_gql: {u.username}/{u.pk}")
+        print(f"opt anonymous_public_gql: {u.username}/{u.pk}")
     except Exception as e:
-        failures.append(("public_gql", e))
-        print(f"REQ public_gql FAIL: {type(e).__name__}: {e}")
+        print(f"opt anonymous_public_gql: {type(e).__name__}: {str(e)[:140]}")
 
     # REQUIRED: login (TOTP) + private path
     cl = await _login_first_usable(accs)

--- a/tests/regression/test_live_smoke.py
+++ b/tests/regression/test_live_smoke.py
@@ -1,0 +1,65 @@
+import importlib.util
+import os
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+
+def _load_live_smoke_module():
+    smoke_path = Path(__file__).resolve().parents[1] / "live" / "smoke.py"
+    spec = importlib.util.spec_from_file_location("aiograpi_live_smoke", smoke_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeLiveClient:
+    user_id = "1"
+
+    async def user_info_by_username_gql(self, username):
+        raise RuntimeError("429 Too Many Requests")
+
+    async def user_info_by_username_v1(self, username):
+        return types.SimpleNamespace(username=username, pk="25025320")
+
+    async def user_info_by_username_v2_gql(self, username):
+        return types.SimpleNamespace(username=username, pk="25025320")
+
+    async def user_short_gql(self, user_id):
+        return types.SimpleNamespace(username="instagram", pk=str(user_id))
+
+    async def hashtag_info_v1(self, name):
+        return types.SimpleNamespace(name=name)
+
+    async def user_medias_v1(self, user_id, amount=0):
+        return [types.SimpleNamespace(pk=str(i)) for i in range(amount)]
+
+    async def user_medias_gql(self, user_id, amount=0):
+        return [types.SimpleNamespace(pk=str(i)) for i in range(amount)]
+
+    async def user_followers(self, user_id, amount=0):
+        return [types.SimpleNamespace(pk=str(i)) for i in range(amount)]
+
+    async def highlight_info(self, highlight_id):
+        return types.SimpleNamespace(pk=str(highlight_id))
+
+    def __getattr__(self, name):
+        async def _method(*args, **kwargs):
+            return types.SimpleNamespace(name=name)
+
+        return _method
+
+
+class LiveSmokeRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_anonymous_public_lookup_throttle_does_not_fail_smoke(self):
+        smoke = _load_live_smoke_module()
+        fake_logged_client = _FakeLiveClient()
+
+        with patch.dict(os.environ, {"TEST_ACCOUNTS_URL": "https://example.test/accounts"}):
+            with patch.object(smoke, "Client", return_value=_FakeLiveClient()):
+                with patch.object(smoke, "_fetch_accounts", AsyncMock(return_value=[{"username": "example"}])):
+                    with patch.object(smoke, "_login_first_usable", AsyncMock(return_value=fake_logged_client)):
+                        status = await smoke.main()
+
+        self.assertEqual(status, 0)

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -2,4 +2,4 @@ import aiograpi
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.6.3"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.6.4"


### PR DESCRIPTION
## Summary
- make the anonymous public web lookup in the live smoke optional so Instagram 429 throttling does not fail otherwise healthy logged-in checks
- keep logged-in user/profile/media GraphQL checks required
- update the recorded upstream sync baseline to instagrapi 2.6.4
- add regression coverage for the smoke behavior

## Sync audit
- instagrapi 2.6.1..2.6.4 changes are represented in aiograpi: Direct helpers, Direct recipient normalization, Direct media-share live coverage, profile/media GraphQL doc ids, incremental private GraphQL JSON-lines parsing, and nullable XDT media normalization
- no reverse instagrapi patch is needed for this PR; this is aiograpi-only CI/live-smoke behavior plus baseline metadata

## Verification
- .venv/bin/ruff check .
- .venv/bin/ruff format --check .
- .venv/bin/python -m pytest -q tests/regression/test_live_smoke.py tests/regression/test_upstream_sync.py
- .venv/bin/python -m pytest -q tests/regression/test_live_smoke.py tests/regression/test_upstream_sync.py tests/regression/test_direct.py tests/regression/test_media_pagination.py tests/regression/test_request_logging.py tests/regression/test_user.py
- .venv/bin/python -m pytest -q tests/regression
- ./scripts/check-mypy-baseline.sh
- .venv/bin/mkdocs build --strict
- live smoke on a fresh branch clone: ALL REQUIRED PASS