### PR TITLE
Link async example scripts in docs

### DIFF
--- a/docs/usage-guide/examples.md
+++ b/docs/usage-guide/examples.md
@@ -17,11 +17,11 @@ Common scripts:
 
 | Script | Purpose |
 | --- | --- |
-| `public_lookup.py` | Public profile lookup with optional `public_transport="curl"`. |
-| `download_user_media.py` | Login, list recent media for a username, and download photos/videos/albums. |
-| `upload_media.py` | Upload a feed photo, feed video, Reel, or Trial Reel. |
-| `upload_story.py` | Upload a photo or video story, optionally with a link sticker. |
-| `direct_message.py` | Send a Direct text message to user IDs or thread IDs. |
+| [`public_lookup.py`](https://github.com/subzeroid/aiograpi/blob/main/examples/public_lookup.py) | Public profile lookup with optional `public_transport="curl"`. |
+| [`download_user_media.py`](https://github.com/subzeroid/aiograpi/blob/main/examples/download_user_media.py) | Login, list recent media for a username, and download photos/videos/albums. |
+| [`upload_media.py`](https://github.com/subzeroid/aiograpi/blob/main/examples/upload_media.py) | Upload a feed photo, feed video, Reel, or Trial Reel. |
+| [`upload_story.py`](https://github.com/subzeroid/aiograpi/blob/main/examples/upload_story.py) | Upload a photo or video story, optionally with a link sticker. |
+| [`direct_message.py`](https://github.com/subzeroid/aiograpi/blob/main/examples/direct_message.py) | Send a Direct text message to user IDs or thread IDs. |
 
 Examples:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,12 +30,12 @@ export IG_PUBLIC_TRANSPORT_IMPERSONATE="chrome136"
 
 | Script | Purpose |
 | --- | --- |
-| `_common.py` | Shared async login, proxy, session, and environment helpers used by the examples. |
-| `public_lookup.py` | Public profile lookup with optional `public_transport="curl"`. |
-| `download_user_media.py` | Login, list recent media for a username, and download photos/videos/albums. |
-| `upload_media.py` | Upload a feed photo, feed video, Reel, or Trial Reel. |
-| `upload_story.py` | Upload a photo or video story, optionally with a link sticker. |
-| `direct_message.py` | Send a Direct text message to user IDs or thread IDs. |
+| [`_common.py`](_common.py) | Shared async login, proxy, session, and environment helpers used by the examples. |
+| [`public_lookup.py`](public_lookup.py) | Public profile lookup with optional `public_transport="curl"`. |
+| [`download_user_media.py`](download_user_media.py) | Login, list recent media for a username, and download photos/videos/albums. |
+| [`upload_media.py`](upload_media.py) | Upload a feed photo, feed video, Reel, or Trial Reel. |
+| [`upload_story.py`](upload_story.py) | Upload a photo or video story, optionally with a link sticker. |
+| [`direct_message.py`](direct_message.py) | Send a Direct text message to user IDs or thread IDs. |
 
 ## Public lookup
 

--- a/tests/regression/test_examples.py
+++ b/tests/regression/test_examples.py
@@ -5,9 +5,19 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 EXAMPLES = ROOT / "examples"
+DOCS_EXAMPLES = ROOT / "docs" / "usage-guide" / "examples.md"
+GITHUB_EXAMPLES_URL = "https://github.com/subzeroid/aiograpi/blob/main/examples"
 
 EXPECTED_EXAMPLE_SCRIPTS = [
     "_common.py",
+    "public_lookup.py",
+    "download_user_media.py",
+    "upload_media.py",
+    "upload_story.py",
+    "direct_message.py",
+]
+
+DOCS_EXAMPLE_SCRIPTS = [
     "public_lookup.py",
     "download_user_media.py",
     "upload_media.py",
@@ -23,7 +33,14 @@ def test_examples_readme_links_practical_scripts():
     content = readme.read_text()
     for filename in EXPECTED_EXAMPLE_SCRIPTS:
         assert (EXAMPLES / filename).exists()
-        assert filename in content
+        assert f"[`{filename}`]({filename})" in content
+
+
+def test_docs_examples_links_to_github_scripts():
+    content = DOCS_EXAMPLES.read_text()
+    for filename in DOCS_EXAMPLE_SCRIPTS:
+        assert (EXAMPLES / filename).exists()
+        assert f"[`{filename}`]({GITHUB_EXAMPLES_URL}/{filename})" in content
 
 
 def test_practical_examples_compile():


### PR DESCRIPTION
## Summary
- make async example script names clickable in the docs examples table
- make examples/README script names link to local files
- strengthen regression coverage so examples must be linked, not just mentioned

## Test Plan
- .venv/bin/python -m pytest tests/regression/test_examples.py -q
- .venv/bin/python -m ruff check tests/regression/test_examples.py
- .venv/bin/python -m mkdocs build --strict