### PR TITLE
Make MoviePy optional for video helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a `video` optional extra for MoviePy-backed helpers and Termux install notes.
+
+### Changed
+
+- Removed MoviePy/NumPy from the default install path; standard MP4 video uploads with `thumbnail=...` continue to use the built-in parser without MoviePy.
+
 ## [0.9.7] - 2026-05-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ It will be difficult to find good accounts, good proxies, or resolve challenges,
 
 The aiograpi more suits for testing or research than a working business!
 
-Video uploads can use a built-in MP4 metadata parser when you provide `thumbnail=...`. Automatic thumbnail generation,
-`StoryBuilder`, and video/audio composition still need executable `ffmpeg`; Android/Pydroid users should see
-[Pydroid and ffmpeg](docs/usage-guide/pydroid.md).
+Video uploads can use a built-in MP4 metadata parser when you provide `thumbnail=...`. Automatic thumbnail generation, `StoryBuilder`, and video/audio composition still need the optional video extra and executable `ffmpeg`:
+
+```bash
+pip install "aiograpi[video]"
+```
+
+Android users should see [Pydroid and ffmpeg](docs/usage-guide/pydroid.md) and [Termux](docs/usage-guide/termux.md).
 
 ### We recommend using our services:
 
@@ -94,9 +98,9 @@ What you can rely on instead:
   `override_app_version` constructor support, Trial Reels, current Reel rupload flow, Reel pin/unpin,
   feed photo/carousel music, music Notes, archive readers, tagged media pagination,
   Direct reactions, thread title updates, message request helpers, single-message lookup, and Direct unsend.
-- **Android/Pydroid-friendly video uploads** — when you pass `thumbnail=...`, aiograpi can read
-  MP4 dimensions/duration without importing MoviePy/ffmpeg. If thumbnail generation is needed,
-  the error now explains how to install ffmpeg or set `IMAGEIO_FFMPEG_EXE`.
+- **Android/Pydroid/Termux-friendly video uploads** — when you pass `thumbnail=...`, aiograpi can read
+  MP4 dimensions/duration without importing MoviePy/ffmpeg. MoviePy is now available through the optional
+  `video` extra for automatic thumbnails, StoryBuilder, `prepare_video()`, and audio/video composition.
 - **Modern dev tooling** — `uv.lock`, Ruff formatting/checks, updated test pins, and an
   upstream sync tracking workflow.
 - **Sync with instagrapi 2.4.4** — every mixin and infrastructure module ported, plus three new mixins:
@@ -297,6 +301,7 @@ await cl.video_upload_to_story(
 * [Fundraiser](https://subzeroid.github.io/aiograpi/latest/usage-guide/fundraiser/) - Fundraiser info
 * [Best Practices](https://subzeroid.github.io/aiograpi/latest/usage-guide/best-practices/)
 * [Pydroid and ffmpeg](https://subzeroid.github.io/aiograpi/latest/usage-guide/pydroid/) - Android/Pydroid video upload notes
+* [Termux](https://subzeroid.github.io/aiograpi/latest/usage-guide/termux/) - Termux install notes and optional video helpers
 * [Development Guide](https://subzeroid.github.io/aiograpi/latest/development-guide/)
 * [Handle Exceptions](https://subzeroid.github.io/aiograpi/latest/usage-guide/handle_exception/)
 * [Challenge Resolver](https://subzeroid.github.io/aiograpi/latest/usage-guide/challenge_resolver/)

--- a/aiograpi/image_util.py
+++ b/aiograpi/image_util.py
@@ -19,6 +19,11 @@ except ImportError:
 
 import httpx
 
+VIDEO_EXTRA_MESSAGE = (
+    'prepare_video() requires MoviePy and ffmpeg. Install it with pip install "aiograpi[video]" '
+    "and make sure ffmpeg is executable or set IMAGEIO_FFMPEG_EXE."
+)
+
 # Whitelist of image formats Pillow is allowed to decode for remote
 # fetches. Restricts the parser surface to the formats Instagram
 # actually accepts as media uploads — drops PSD/FITS/TIFF/etc.
@@ -245,8 +250,16 @@ def prepare_video(
          choose ultrafast when you are in a hurry and file size does not matter.
     :return:
     """
-    from moviepy.video.fx.all import crop, resize
-    from moviepy.video.io.VideoFileClip import VideoFileClip
+    try:
+        from moviepy.video.fx.all import crop, resize
+        from moviepy.video.io.VideoFileClip import VideoFileClip
+    except ImportError as exc:
+        raise RuntimeError(VIDEO_EXTRA_MESSAGE) from exc
+    except Exception as exc:
+        message = str(exc).lower()
+        if "ffmpeg" in message or "imageio_ffmpeg_exe" in message or "no ffmpeg exe" in message:
+            raise RuntimeError(VIDEO_EXTRA_MESSAGE) from exc
+        raise
 
     min_size = kwargs.pop("min_size", (612, 320))
     progress_bar = True if kwargs.pop("progress_bar", None) else False

--- a/aiograpi/mixins/clip.py
+++ b/aiograpi/mixins/clip.py
@@ -447,7 +447,7 @@ class UploadClipMixin(ClientMixin):
             try:
                 import moviepy as mp
             except ImportError:
-                raise Exception("Please install moviepy>=1.0.3 and retry")
+                raise RuntimeError('Install video helpers with pip install "aiograpi[video]" and retry')
         video = None
         audio_clip = None
         try:

--- a/aiograpi/story.py
+++ b/aiograpi/story.py
@@ -5,23 +5,48 @@ from urllib.parse import urlparse
 
 from .types import StoryBuild, StoryMention, StorySticker
 
-try:
-    from moviepy import CompositeVideoClip, ImageClip, TextClip, VideoFileClip
-except ImportError:
-    try:
-        from moviepy.editor import (
-            CompositeVideoClip,
-            ImageClip,
-            TextClip,
-            VideoFileClip,
-        )
-    except ImportError:
-        raise Exception("Please install moviepy>=1.0.3 and retry")
+STORY_BUILDER_VIDEO_EXTRA_MESSAGE = (
+    'StoryBuilder requires MoviePy and ffmpeg. Install it with pip install "aiograpi[video]" '
+    "and make sure ffmpeg is executable or set IMAGEIO_FFMPEG_EXE."
+)
+STORY_BUILDER_PILLOW_MESSAGE = "StoryBuilder photo rendering requires Pillow. Install Pillow and retry."
 
-try:
-    from PIL import Image
-except ImportError:
-    raise Exception("You don't have PIL installed. Please install PIL or Pillow>=8.1.1")
+
+def _ffmpeg_unavailable(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return "ffmpeg" in message or "imageio_ffmpeg_exe" in message or "no ffmpeg exe" in message
+
+
+def _import_moviepy_for_story():
+    try:
+        from moviepy import CompositeVideoClip, ImageClip, TextClip, VideoFileClip
+    except ImportError:
+        try:
+            from moviepy.editor import (
+                CompositeVideoClip,
+                ImageClip,
+                TextClip,
+                VideoFileClip,
+            )
+        except ImportError as exc:
+            raise RuntimeError(STORY_BUILDER_VIDEO_EXTRA_MESSAGE) from exc
+        except Exception as exc:
+            if _ffmpeg_unavailable(exc):
+                raise RuntimeError(STORY_BUILDER_VIDEO_EXTRA_MESSAGE) from exc
+            raise
+    except Exception as exc:
+        if _ffmpeg_unavailable(exc):
+            raise RuntimeError(STORY_BUILDER_VIDEO_EXTRA_MESSAGE) from exc
+        raise
+    return CompositeVideoClip, ImageClip, TextClip, VideoFileClip
+
+
+def _import_pillow_for_story():
+    try:
+        from PIL import Image
+    except ImportError as exc:
+        raise RuntimeError(STORY_BUILDER_PILLOW_MESSAGE) from exc
+    return Image
 
 
 class StoryBuilder:
@@ -92,6 +117,7 @@ class StoryBuilder:
         StoryBuild
             An object of StoryBuild
         """
+        CompositeVideoClip, ImageClip, TextClip, _ = _import_moviepy_for_story()
         clips = []
         stickers = []
         # Background
@@ -215,6 +241,7 @@ class StoryBuilder:
         StoryBuild
             An object of StoryBuild
         """
+        _, _, _, VideoFileClip = _import_moviepy_for_story()
         clip = VideoFileClip(str(self.path), has_mask=True)
         build = self.build_main(clip, max_duration, font, fontsize, color, link)
         clip.close()
@@ -248,6 +275,8 @@ class StoryBuilder:
             An object of StoryBuild
         """
 
+        _, ImageClip, _, _ = _import_moviepy_for_story()
+        Image = _import_pillow_for_story()
         with Image.open(self.path) as im:
             image_width, image_height = im.size
 

--- a/aiograpi/utils/video.py
+++ b/aiograpi/utils/video.py
@@ -4,11 +4,13 @@ from pathlib import Path
 from typing import Callable, Optional
 
 THUMBNAIL_FFMPEG_MESSAGE = (
-    "Could not generate video thumbnail. Pass thumbnail=... or install ffmpeg / set IMAGEIO_FFMPEG_EXE."
+    'Could not generate video thumbnail. Pass thumbnail=... or install MoviePy with pip install "aiograpi[video]" '
+    "and configure ffmpeg / set IMAGEIO_FFMPEG_EXE."
 )
 METADATA_FFMPEG_MESSAGE = (
     "Could not read video metadata with the MP4 parser and MoviePy/ffmpeg is unavailable. "
-    "Use a standard MP4 file, or install ffmpeg / set IMAGEIO_FFMPEG_EXE."
+    'Use a standard MP4 file, or install MoviePy with pip install "aiograpi[video]" and configure ffmpeg / '
+    "set IMAGEIO_FFMPEG_EXE."
 )
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,9 +14,13 @@ Asynchronous Instagram Private API wrapper without selenium. Use the most recent
 
 Support **Python >= 3.10**
 
-Video uploads can use a built-in MP4 metadata parser when you provide `thumbnail=...`. Automatic thumbnail generation,
-`StoryBuilder`, and video/audio composition still need executable `ffmpeg`; Android/Pydroid users should see
-[Pydroid and ffmpeg](usage-guide/pydroid.md).
+Video uploads can use a built-in MP4 metadata parser when you provide `thumbnail=...`. Automatic thumbnail generation, `StoryBuilder`, and video/audio composition still need the optional video extra and executable `ffmpeg`:
+
+```bash
+pip install "aiograpi[video]"
+```
+
+Android users should see [Pydroid and ffmpeg](usage-guide/pydroid.md) and [Termux](usage-guide/termux.md).
 
 For any other languages (e.g. C++, C#, F#, D, [Golang](https://github.com/subzeroid/instagrapi-rest/tree/main/golang), Erlang, Elixir, Nim, Haskell, Lisp, Closure, Julia, R, Java, Kotlin, Scala, OCaml, JavaScript, Crystal, Ruby, Rust, [Swift](https://github.com/subzeroid/instagrapi-rest/tree/main/swift), Objective-C, Visual Basic, .NET, Pascal, Perl, Lua, PHP and others), I suggest using [instagrapi-rest](https://github.com/subzeroid/instagrapi-rest)
 
@@ -113,6 +117,7 @@ To learn more about the various ways `aiograpi` can be used, read the [Usage Gui
   * [`Highlight`](usage-guide/highlight.md) - Highlights
   * [`Notes`](usage-guide/notes.md) - Notes
   * [`Pydroid and ffmpeg`](usage-guide/pydroid.md) - Android/Pydroid video upload setup
+  * [`Termux`](usage-guide/termux.md) - Termux install notes and optional video helpers
   * [`Public Transport`](usage-guide/public-transport.md) - Optional curl transport for public web requests
   * [`Story`](usage-guide/story.md) - Story
   * [`StoryLink`](usage-guide/story.md) - Link (Swipe up)

--- a/docs/usage-guide/examples.md
+++ b/docs/usage-guide/examples.md
@@ -34,5 +34,4 @@ python examples/upload_story.py photo ./story.jpg --caption "Story"
 python examples/direct_message.py --user-ids 123456789 --text "Hello"
 ```
 
-Video uploads in Android/Pydroid environments should pass `--thumbnail` or configure executable `ffmpeg`.
-See [Pydroid and ffmpeg](pydroid.md).
+Video uploads in Android environments should pass `--thumbnail` or install the optional video extra and configure executable `ffmpeg`. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -278,7 +278,7 @@ Upload medias to your feed. Common arguments:
 | clip_trial_eligible()                                         | bool    | Check whether Reel creation preflight reports Trial Reels enabled
 | clip_share_to_fb_config()                                      | Dict    | Get Reel Facebook sharing configuration for the current user
 
-For video uploads in Android/Pydroid environments, pass `thumbnail=...` to avoid automatic thumbnail generation or configure executable ffmpeg. See [Pydroid and ffmpeg](pydroid.md).
+For video uploads in Android environments, pass `thumbnail=...` to avoid automatic thumbnail generation, or install the optional video extra and configure executable ffmpeg. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).
 
 Trial Reels use the same upload method:
 

--- a/docs/usage-guide/pydroid.md
+++ b/docs/usage-guide/pydroid.md
@@ -19,7 +19,13 @@ await cl.igtv_upload(Path("video.mp4"), "title", "caption", thumbnail=Path("thum
 await cl.video_upload_to_story(Path("story.mp4"), thumbnail=Path("thumb.jpg"))
 ```
 
-MoviePy/ffmpeg is still required when `aiograpi` has to render or extract media:
+MoviePy/ffmpeg is still required when `aiograpi` has to render or extract media. Install the optional video extra for these flows:
+
+```bash
+pip install "aiograpi[video]"
+```
+
+The extra is intentionally not part of the default install, because it pulls in MoviePy and NumPy and can be hard to build on Android.
 
 * automatic thumbnail generation when `thumbnail` is not provided
 * `StoryBuilder`
@@ -38,7 +44,7 @@ RuntimeError: No ffmpeg exe could be found. Install ffmpeg on your system, or se
 Current `aiograpi` upload helpers raise a clearer error for this thumbnail path:
 
 ```text
-Could not generate video thumbnail. Pass thumbnail=... or install ffmpeg / set IMAGEIO_FFMPEG_EXE.
+Could not generate video thumbnail. Pass thumbnail=... or install MoviePy with pip install "aiograpi[video]" and configure ffmpeg / set IMAGEIO_FFMPEG_EXE.
 ```
 
 ## Fix
@@ -50,8 +56,7 @@ The most reliable Pydroid setup is to pre-process the video outside Pydroid and 
 
 Then call the upload method with `thumbnail=Path("thumb.jpg")`.
 
-If you need automatic thumbnail generation or StoryBuilder inside Pydroid, install an ffmpeg binary that the Pydroid app
-can execute and set `IMAGEIO_FFMPEG_EXE` before running the upload:
+If you need automatic thumbnail generation or StoryBuilder inside Pydroid, install the optional video extra, install an ffmpeg binary that the Pydroid app can execute, and set `IMAGEIO_FFMPEG_EXE` before running the upload:
 
 ```python
 import os

--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -89,7 +89,11 @@ await cl.video_upload_to_story(
 
 ## Build Story to Upload
 
-If you want to format your story correctly (correct resolution, user mentions, etc) use StoryBuilder:
+If you want to format your story correctly (correct resolution, user mentions, etc) use StoryBuilder. StoryBuilder renders media with MoviePy and ffmpeg, so install the optional video extra first:
+
+```bash
+pip install "aiograpi[video]"
+```
 
 | Method                                                | Return     | Description                              |
 | ----------------------------------------------------- | ---------- | ---------------------------------------- |

--- a/docs/usage-guide/termux.md
+++ b/docs/usage-guide/termux.md
@@ -1,0 +1,47 @@
+# Termux
+
+Termux can run many `aiograpi` flows, but Android does not use the same binary wheel ecosystem as desktop Linux. Keep the default install small and add media tooling only when the script really needs it.
+
+## Install
+
+```bash
+pkg update
+pkg install python python-pillow
+python -m pip install -U pip setuptools wheel
+python -m pip install aiograpi
+```
+
+`python-pillow` is recommended because photo uploads use Pillow through `aiograpi.image_util`. Installing it with `pkg` avoids a slow or fragile Pillow source build in pip.
+
+## Video Uploads
+
+For standard MP4 uploads, pass your own thumbnail and `aiograpi` can read width, height, and duration with its built-in MP4 parser:
+
+```python
+from pathlib import Path
+
+media = await cl.clip_upload(
+    Path("reel.mp4"),
+    "Uploaded from Termux",
+    thumbnail=Path("reel-thumb.jpg"),
+)
+```
+
+This path does not need MoviePy, NumPy, or ffmpeg.
+
+## Optional Video Helpers
+
+Install the optional video extra only if you need automatic thumbnail generation, `StoryBuilder`, `prepare_video()`, or audio/video composition helpers:
+
+```bash
+pkg install ffmpeg
+python -m pip install "aiograpi[video]"
+```
+
+If MoviePy cannot find ffmpeg, point ImageIO at the Termux binary before running the script:
+
+```bash
+export IMAGEIO_FFMPEG_EXE="$(command -v ffmpeg)"
+```
+
+If `pip install "aiograpi[video]"` tries to build NumPy and fails, avoid the optional video helpers on-device: prepare the MP4 and thumbnail elsewhere, then use upload methods with `thumbnail=...`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
     - Pydroid and ffmpeg: usage-guide/pydroid.md
     - Public Transport: usage-guide/public-transport.md
     - Story: usage-guide/story.md
+    - Termux: usage-guide/termux.md
     - TOTP: usage-guide/totp.md
     - Track: usage-guide/track.md
     - User: usage-guide/user.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ dependencies = [
     "httpx==0.28.1",
     "orjson==3.11.8",
     "pydantic==2.13.4",
-    "moviepy==1.0.3",
     "pycryptodomex==3.23.0",
     "zstandard==0.25.0",
     "Pillow>=12.2.0",
@@ -74,6 +73,9 @@ Changelog = "https://github.com/subzeroid/aiograpi/blob/main/CHANGELOG.md"
 [project.optional-dependencies]
 curl = [
     "curl-adapter>=1.2.1",
+]
+video = [
+    "moviepy==1.0.3",
 ]
 test = [
     "mypy==1.20.2",

--- a/tests/regression/test_video_metadata.py
+++ b/tests/regression/test_video_metadata.py
@@ -1,5 +1,7 @@
 import builtins
+import importlib
 import struct
+import sys
 import tempfile
 from pathlib import Path
 from unittest import mock
@@ -105,3 +107,44 @@ def test_missing_thumbnail_reports_ffmpeg_fix():
     assert "thumbnail=" in message
     assert "ffmpeg" in message.lower()
     assert "IMAGEIO_FFMPEG_EXE" in message
+
+
+def test_core_install_does_not_require_moviepy():
+    pyproject = Path("pyproject.toml").read_text()
+    required_dependencies = pyproject.split("[project.optional-dependencies]", 1)[0]
+    optional_dependencies = pyproject.split("[project.optional-dependencies]", 1)[1]
+
+    assert "moviepy" not in required_dependencies
+    assert "video = [" in optional_dependencies
+    assert '"moviepy==1.0.3"' in optional_dependencies
+
+
+def test_story_builder_import_does_not_require_moviepy():
+    sys.modules.pop("aiograpi.story", None)
+    with _block_moviepy_imports(ImportError("no moviepy")):
+        try:
+            story = importlib.import_module("aiograpi.story")
+        except Exception as exc:
+            pytest.fail(f"StoryBuilder import should not require MoviePy: {exc}")
+
+    assert story.StoryBuilder(Path("photo.jpg")).path == Path("photo.jpg")
+
+
+def test_story_builder_render_reports_video_extra_without_moviepy():
+    sys.modules.pop("aiograpi.story", None)
+    with _block_moviepy_imports(ImportError("no moviepy")):
+        story = importlib.import_module("aiograpi.story")
+        with pytest.raises(RuntimeError) as ctx:
+            story.StoryBuilder(Path("video.mp4")).video()
+
+    assert "aiograpi[video]" in str(ctx.value)
+
+
+def test_prepare_video_reports_video_extra_without_moviepy():
+    from aiograpi.image_util import prepare_video
+
+    with _block_moviepy_imports(ImportError("no moviepy")):
+        with pytest.raises(RuntimeError) as ctx:
+            prepare_video("video.mp4")
+
+    assert "aiograpi[video]" in str(ctx.value)


### PR DESCRIPTION
## Summary
- mirror instagrapi #2506 by moving MoviePy out of required dependencies into the `video` extra
- keep standard MP4 uploads with `thumbnail=...` on the built-in parser path, and make StoryBuilder/prepare_video errors point to `aiograpi[video]`
- add Termux docs plus README/Pydroid/story docs updates
- add regression coverage for optional MoviePy behavior

## Verification
- `.venv/bin/python -m pytest tests/regression/test_video_metadata.py -q`
- `.venv/bin/python -m pytest tests/regression -q`
- workflow unit-test command from `.github/workflows/python-package.yml`
- `.venv/bin/python -m ruff check --output-format=github .`
- `.venv/bin/python -m ruff format --check .`
- `.venv/bin/python -m bandit -c pyproject.toml -r aiograpi`
- `.venv/bin/python -m mkdocs build --strict`
- `./scripts/check-mypy-baseline.sh`
- `.venv/bin/python -m pip_audit --strict --progress-spinner off .`
- clean venv `pip install .` then import `aiograpi` and `aiograpi.story`; `moviepy` was not installed