### PR TITLE
Mirror Reel Facebook crosspost support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ What you can rely on instead:
 
 ### What's new in 0.6.x through 0.9.x
 
-- **Sync with instagrapi 2.6.1** — current Android app profile defaults,
+- **Sync with instagrapi 2.6.x** — current Android app profile defaults,
   `override_app_version` constructor support, Trial Reels, current Reel rupload flow, Reel pin/unpin,
+  Reel Facebook cross-post payload helpers,
   feed photo/carousel music, music Notes, archive readers, tagged media pagination,
   Direct reactions, thread title updates, message request helpers, single-message lookup, and Direct unsend.
 - **Android/Pydroid/Termux-friendly video uploads** — when you pass `thumbnail=...`, aiograpi can read

--- a/aiograpi/mixins/clip.py
+++ b/aiograpi/mixins/clip.py
@@ -172,6 +172,125 @@ class UploadClipMixin(ClientMixin):
             params={"device_status": json.dumps(device_status)},
         )
 
+    async def clip_share_to_fb_extra_data(
+        self,
+        config: Optional[Dict[str, object]] = None,
+        destination_id: Optional[str] = None,
+        destination_type: Optional[str] = None,
+        destination_audience_type: Optional[str] = None,
+        xpost_surface: str = "IG_REELS_COMPOSER",
+        validation_check_bypass: Optional[bool] = None,
+        attempt_id: Optional[str] = None,
+    ) -> Dict[str, object]:
+        """
+        Build configure fields for sharing a Reel to Facebook.
+
+        Instagram Android 428 stores Reel Facebook cross-posting in
+        ``XPlatformParams`` fields. The old ``share_to_facebook`` flag alone is
+        not enough for accounts that require an explicit Facebook destination.
+
+        Parameters
+        ----------
+        config: Dict[str, object], optional
+            Facebook cross-posting config. The lightweight
+            ``clip_share_to_fb_config()`` response contains availability flags;
+            app/draft configs can also contain destination fields.
+        destination_id: str, optional
+            Facebook destination id. Overrides config values.
+        destination_type: str, optional
+            Facebook destination type/posting type, ``USER`` or ``PAGE``.
+            Overrides config values.
+        destination_audience_type: str, optional
+            Facebook Reels audience type, e.g. ``PUBLIC``.
+        xpost_surface: str, optional
+            Cross-posting surface reported by the Instagram app.
+        validation_check_bypass: bool, optional
+            Whether to bypass app-side FB validation. Overrides config values.
+        attempt_id: str, optional
+            Cross-post configure attempt id. Generated when omitted.
+
+        Returns
+        -------
+        Dict
+            Extra configure data for ``clip_upload(..., extra_data=...)``.
+        """
+        fb_config = (config if config is not None else await self.clip_share_to_fb_config()) or {}
+        if fb_config.get("enabled") is False or fb_config.get("is_account_linked") is False:
+            raise ClientError("Facebook Reel sharing is not enabled or no Facebook account is linked")
+
+        destination_id_value = (
+            destination_id
+            or fb_config.get("share_to_fb_destination_id")
+            or fb_config.get("reels_destination_id")
+            or fb_config.get("destination_id")
+            or fb_config.get("account_id")
+        )
+        destination_id = str(destination_id_value) if destination_id_value is not None else None
+        destination_type_value = (
+            destination_type
+            or fb_config.get("share_to_fb_destination_type")
+            or fb_config.get("destination_type")
+            or fb_config.get("posting_type")
+        )
+        destination_type = str(destination_type_value) if destination_type_value is not None else None
+        destination_audience_type_value = (
+            destination_audience_type
+            or fb_config.get("share_to_fb_destination_audience_type")
+            or fb_config.get("reels_destination_audience_type")
+            or fb_config.get("audience_type")
+        )
+        destination_audience_type = (
+            str(destination_audience_type_value) if destination_audience_type_value is not None else None
+        )
+        if validation_check_bypass is None:
+            validation_check_bypass_value = fb_config.get(
+                "reels_cross_app_share_fb_validation_check_bypass",
+                fb_config.get("cross_app_share_fb_validation_check_bypass"),
+            )
+            validation_check_bypass = (
+                bool(validation_check_bypass_value) if validation_check_bypass_value is not None else None
+            )
+
+        has_destination = bool(destination_id and destination_type)
+        if fb_config.get("share_to_fb_unavailable") and not has_destination:
+            raise ClientError(
+                "Facebook Reel sharing is unavailable from the Reel preflight response. "
+                "If the Instagram app can still cross-post manually, pass destination_id "
+                "and destination_type explicitly."
+            )
+        if not destination_id:
+            raise ClientError(
+                "Facebook Reel sharing configuration has no destination. "
+                "Link a Facebook account/page in the Instagram app or pass destination_id."
+            )
+        if not destination_type:
+            raise ClientError(
+                "Facebook Reel sharing configuration has no destination type. Pass destination_type as USER or PAGE."
+            )
+        destination_type = str(destination_type).upper()
+        if destination_type not in {"USER", "PAGE"}:
+            raise ClientError(
+                "Facebook Reel sharing destination type must be USER or PAGE. "
+                "Do not pass reels_cross_app_share_type here."
+            )
+        attempt_id = attempt_id or str(uuid4())
+
+        data = {
+            "share_to_facebook": "1",
+            "is_reel_shared_to_fb": True,
+            "share_to_facebook_reels": True,
+            "share_to_fb_destination_id": destination_id,
+            "share_to_fb_destination_type": destination_type,
+            "xpost_surface": xpost_surface,
+            "no_token_crosspost": "1",  # nosec B105
+            "attempt_id": attempt_id,
+        }
+        if destination_audience_type:
+            data["share_to_fb_destination_audience_type"] = destination_audience_type
+        if validation_check_bypass is not None:
+            data["cross_app_share_fb_validation_check_bypass"] = bool(validation_check_bypass)
+        return data
+
     async def clip_upload(
         self,
         path: Path,
@@ -184,6 +303,12 @@ class UploadClipMixin(ClientMixin):
         extra_data: Dict[str, object] = {},
         trial: bool = False,
         trial_graduation_strategy: str = "manual",
+        share_to_facebook: bool = False,
+        fb_destination_id: Optional[str] = None,
+        fb_destination_type: Optional[str] = None,
+        fb_destination_audience_type: Optional[str] = None,
+        fb_xpost_surface: str = "IG_REELS_COMPOSER",
+        fb_validation_check_bypass: Optional[bool] = None,
     ) -> Media:
         """
         Upload CLIP to Instagram
@@ -213,6 +338,19 @@ class UploadClipMixin(ClientMixin):
             Upload as a Trial Reel for eligible accounts, default is False.
         trial_graduation_strategy: str, optional
             Trial Reel graduation strategy, default is "manual".
+        share_to_facebook: bool, optional
+            Share this Reel to a linked Facebook account/page, default is False.
+        fb_destination_id: str, optional
+            Facebook destination id used when share_to_facebook is True.
+        fb_destination_type: str, optional
+            Facebook destination type used when share_to_facebook is True,
+            ``USER`` or ``PAGE``.
+        fb_destination_audience_type: str, optional
+            Facebook Reels audience type, e.g. ``PUBLIC``.
+        fb_xpost_surface: str, optional
+            Cross-posting surface reported by the Instagram app.
+        fb_validation_check_bypass: bool, optional
+            Override the validation bypass value from share_to_fb_config.
 
         Returns
         -------
@@ -228,6 +366,15 @@ class UploadClipMixin(ClientMixin):
             clip_data = fp.read()
             clip_len = str(len(clip_data))
         configure_extra_data = dict(extra_data or {})
+        if share_to_facebook:
+            fb_extra_data = await self.clip_share_to_fb_extra_data(
+                destination_id=fb_destination_id,
+                destination_type=fb_destination_type,
+                destination_audience_type=fb_destination_audience_type,
+                xpost_surface=fb_xpost_surface,
+                validation_check_bypass=fb_validation_check_bypass,
+            )
+            configure_extra_data = {**fb_extra_data, **configure_extra_data}
         if trial:
             feed_show = "0"
             configure_extra_data.setdefault(

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -272,11 +272,12 @@ Upload medias to your feed. Common arguments:
 | album_upload(paths: List[Path], caption: str, usertags: List[Usertag], location: Location, extra_data: Dict = {})                      | Media   | Upload Album (Support JPG/MP4 files)
 | album_upload_with_music(paths: List[Path], caption: str, track: Track, extra_data: Dict = {}) | Media | Upload feed album/carousel with music metadata
 | igtv_upload(path: Path, title: str, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}) | Media   | Upload IGTV (Support MP4 files)
-| clip_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, trial: bool = False) | Media | Upload Reels Clip (Support MP4 files), optionally as a Trial Reel
+| clip_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, trial: bool = False, share_to_facebook: bool = False) | Media | Upload Reels Clip (Support MP4 files), optionally as a Trial Reel or cross-posted to Facebook
 | clip_upload_as_reel_with_music(path: Path, caption: str, track: Track, extra_data: Dict = {}) | Media | Upload Reels Clip as reel with music metadata
 | clip_info_for_creation()                                      | Dict    | Get Reel creation preflight configuration for the current user
 | clip_trial_eligible()                                         | bool    | Check whether Reel creation preflight reports Trial Reels enabled
 | clip_share_to_fb_config()                                      | Dict    | Get Reel Facebook sharing configuration for the current user
+| clip_share_to_fb_extra_data(config: Dict = None, destination_id: str = None, destination_type: str = None) | Dict | Build modern Reel Facebook cross-post configure fields for manual `extra_data`
 
 For video uploads in Android environments, pass `thumbnail=...` to avoid automatic thumbnail generation, or install the optional video dependencies, MoviePy `2.2.1`, and executable ffmpeg. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).
 
@@ -288,6 +289,40 @@ media = await cl.clip_upload(
     "Trying a new format",
     thumbnail=Path("reel-thumb.jpg"),
     trial=True,
+)
+```
+
+Facebook Reel sharing requires a Facebook account/page linked in the Instagram app. Modern Android app builds no longer
+use only `{"share_to_facebook": 1}` for Reels; they also send destination and cross-posting fields such as
+`share_to_fb_destination_id`, `share_to_fb_destination_type`, `no_token_crosspost`, and `attempt_id`.
+
+`clip_share_to_fb_config()` calls the lightweight Reel sharing preflight endpoint. On recent app versions this response
+contains availability flags, not the full Account Center destination state, and some linked accounts can still return
+`share_to_fb_unavailable=True` even when the Instagram app can cross-post manually. For those accounts, pass
+`fb_destination_id` and `fb_destination_type="USER"` or `"PAGE"` to `clip_upload(...)`, or build `extra_data` manually
+with `clip_share_to_fb_extra_data(...)`. If neither the preflight/config data nor the caller provides a destination,
+aiograpi raises `ClientError` before uploading video bytes. The Reel cross-post `attempt_id` is generated automatically;
+only pass it to `clip_share_to_fb_extra_data(...)` when replaying or testing a specific low-level payload.
+
+``` python
+media = await cl.clip_upload(
+    Path("reel.mp4"),
+    "Cross-posting this Reel to Facebook",
+    thumbnail=Path("reel-thumb.jpg"),
+    share_to_facebook=True,
+    fb_destination_id="FACEBOOK_DESTINATION_ID",
+    fb_destination_type="USER",
+)
+
+fb_extra = await cl.clip_share_to_fb_extra_data(
+    destination_id="FACEBOOK_DESTINATION_ID",
+    destination_type="USER",
+)
+media = await cl.clip_upload(
+    Path("reel.mp4"),
+    "Cross-posting with explicit Facebook destination",
+    thumbnail=Path("reel-thumb.jpg"),
+    extra_data=fb_extra,
 )
 ```
 

--- a/tests/regression/test_clip.py
+++ b/tests/regression/test_clip.py
@@ -5,6 +5,7 @@ from unittest import mock
 from unittest.mock import AsyncMock, Mock
 
 from aiograpi import Client
+from aiograpi.exceptions import ClientError
 
 
 def _build_client():
@@ -111,6 +112,96 @@ class ClipUploadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         assert device_status["chip_vendor"] == "others"
         assert device_status["hw_av1_dec"] is False
         assert result == expected
+
+    async def test_clip_share_to_fb_extra_data_builds_current_reel_crosspost_payload(self):
+        client = _build_client()
+        config = {
+            "enabled": True,
+            "is_account_linked": True,
+            "reels_share_to_facebook": True,
+            "reels_destination_id": "fb-destination-id",
+            "posting_type": "USER",
+            "reels_cross_app_share_type": "CROSSPOST",
+            "reels_cross_app_share_fb_validation_check_bypass": True,
+            "status": "ok",
+        }
+
+        result = await client.clip_share_to_fb_extra_data(config=config, attempt_id="attempt-id")
+
+        assert result == {
+            "share_to_facebook": "1",
+            "is_reel_shared_to_fb": True,
+            "share_to_facebook_reels": True,
+            "share_to_fb_destination_id": "fb-destination-id",
+            "share_to_fb_destination_type": "USER",
+            "cross_app_share_fb_validation_check_bypass": True,
+            "xpost_surface": "IG_REELS_COMPOSER",
+            "no_token_crosspost": "1",
+            "attempt_id": "attempt-id",
+        }
+
+    async def test_clip_share_to_fb_extra_data_allows_explicit_destination_when_preflight_is_unavailable(self):
+        client = _build_client()
+
+        result = await client.clip_share_to_fb_extra_data(
+            config={
+                "share_to_fb_unavailable": True,
+                "status": "ok",
+            },
+            destination_id="fb-destination-id",
+            destination_type="USER",
+            attempt_id="attempt-id",
+        )
+
+        assert result["share_to_fb_destination_id"] == "fb-destination-id"
+        assert result["share_to_fb_destination_type"] == "USER"
+        assert result["attempt_id"] == "attempt-id"
+
+    async def test_clip_share_to_fb_extra_data_allows_config_destination_when_preflight_is_unavailable(self):
+        client = _build_client()
+
+        result = await client.clip_share_to_fb_extra_data(
+            config={
+                "share_to_fb_unavailable": True,
+                "reels_destination_id": "fb-destination-id",
+                "posting_type": "PAGE",
+                "status": "ok",
+            },
+            attempt_id="attempt-id",
+        )
+
+        assert result["share_to_fb_destination_id"] == "fb-destination-id"
+        assert result["share_to_fb_destination_type"] == "PAGE"
+
+    async def test_clip_share_to_fb_extra_data_does_not_use_cross_app_share_type_as_destination_type(self):
+        client = _build_client()
+
+        with self.assertRaises(ClientError) as ctx:
+            await client.clip_share_to_fb_extra_data(
+                config={
+                    "enabled": True,
+                    "is_account_linked": True,
+                    "reels_destination_id": "fb-destination-id",
+                    "reels_cross_app_share_type": "CROSSPOST",
+                    "status": "ok",
+                }
+            )
+
+        assert "destination type" in str(ctx.exception)
+
+    async def test_clip_share_to_fb_extra_data_raises_without_destination(self):
+        client = _build_client()
+
+        with self.assertRaises(ClientError) as ctx:
+            await client.clip_share_to_fb_extra_data(
+                config={
+                    "enabled": True,
+                    "default_share_to_fb_enabled": False,
+                    "status": "ok",
+                }
+            )
+
+        assert "Facebook Reel sharing configuration has no destination" in str(ctx.exception)
 
     async def test_clip_info_for_creation_requests_reel_creation_config(self):
         client = _build_client()
@@ -256,3 +347,54 @@ class ClipUploadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             "graduation_strategy": "ss_performance",
             "custom_field": "1",
         }
+
+    async def test_clip_upload_share_to_facebook_adds_crosspost_params_before_upload(self):
+        client = _build_client()
+        client.last_json = {"media": _build_media_payload()}
+        ok_response = Mock(status_code=200)
+        client.private.get = AsyncMock(return_value=ok_response)
+        client.private.post = AsyncMock(side_effect=[ok_response, ok_response])
+        client.clip_configure = AsyncMock(return_value={"status": "ok", "media": _build_media_payload()})
+        extra_data = {"disable_comments": "1"}
+        fb_extra = {
+            "share_to_facebook": "1",
+            "is_reel_shared_to_fb": True,
+            "share_to_facebook_reels": True,
+            "share_to_fb_destination_id": "fb-destination-id",
+            "share_to_fb_destination_type": "USER",
+            "cross_app_share_fb_validation_check_bypass": False,
+            "xpost_surface": "IG_REELS_COMPOSER",
+            "no_token_crosspost": "1",
+            "attempt_id": "attempt-id",
+        }
+        client.clip_share_to_fb_extra_data = AsyncMock(return_value=fb_extra)
+
+        with mock.patch(
+            "aiograpi.mixins.clip.analyze_video",
+            return_value=(Path("/tmp/thumb.jpg"), 720, 1280, 6.023),
+        ):
+            with mock.patch("builtins.open", mock.mock_open(read_data=b"video-bytes")):
+                with mock.patch("aiograpi.mixins.clip.asyncio.sleep", new=AsyncMock()):
+                    await client.clip_upload(
+                        Path("example.mp4"),
+                        "caption",
+                        share_to_facebook=True,
+                        fb_destination_id="fb-destination-id",
+                        fb_destination_type="USER",
+                        extra_data=extra_data,
+                    )
+
+        client.clip_share_to_fb_extra_data.assert_awaited_once_with(
+            destination_id="fb-destination-id",
+            destination_type="USER",
+            destination_audience_type=None,
+            xpost_surface="IG_REELS_COMPOSER",
+            validation_check_bypass=None,
+        )
+        assert extra_data == {"disable_comments": "1"}
+        configure_extra = client.clip_configure.call_args.kwargs["extra_data"]
+        assert configure_extra["disable_comments"] == "1"
+        assert configure_extra["share_to_fb_destination_id"] == "fb-destination-id"
+        assert configure_extra["share_to_fb_destination_type"] == "USER"
+        assert configure_extra["share_to_facebook_reels"] is True
+        assert configure_extra["xpost_surface"] == "IG_REELS_COMPOSER"


### PR DESCRIPTION
## Summary
- mirror instagrapi Reel Facebook crosspost support in the async client
- add `clip_share_to_fb_extra_data(...)` and `clip_upload(..., share_to_facebook=True, fb_destination_id=..., fb_destination_type=...)`
- align the crosspost payload with the current Android app fields: `USER`/`PAGE`, `no_token_crosspost`, and generated `attempt_id`
- document explicit destination usage and add regression coverage

## Tests
- python -m pytest tests/regression/test_clip.py -q
- python -m ruff check --output-format=github aiograpi/mixins/clip.py tests/regression/test_clip.py docs/usage-guide/media.md README.md
- python -m ruff format --check aiograpi/mixins/clip.py tests/regression/test_clip.py
- python -m bandit -c pyproject.toml -r aiograpi
- ./scripts/check-mypy-baseline.sh
- mkdocs build --strict

Mirrors subzeroid/instagrapi#2509.