### PR TITLE
docs: update aiograpi sync notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added async Reel Facebook cross-post payload helpers for linked Facebook users/pages, including explicit
+  `fb_destination_id` and `fb_destination_type` support when Instagram's lightweight preflight does not return a usable
+  destination.
+
 ## [0.9.8] - 2026-05-16
 
 ### Added

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -4,11 +4,15 @@
 independent, but every sync release records the `instagrapi` tag it has been
 ported through.
 
-The current non-Facebook sync baseline is:
+The current recorded API baseline is:
 
 ```text
-instagrapi 2.6.4
+instagrapi 2.6.6
 ```
+
+`aiograpi 0.9.8` also includes the video dependency split and MoviePy 2 helper migration from `instagrapi 2.6.7`.
+Current `main` includes the next Reel Facebook cross-post payload follow-up from `instagrapi` after 2.6.7; release
+notes should call that out separately until the next version tag records a new baseline.
 
 ## Release policy
 
@@ -18,8 +22,8 @@ instagrapi 2.6.4
 
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
 `aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent
-`aiograpi 0.9.x` patch releases continue that non-Facebook baseline through
-`instagrapi 2.6.4`. Facebook-linked account helpers are tracked separately.
+`aiograpi 0.9.x` patch releases continue that baseline through `instagrapi 2.6.6`, plus targeted maintenance ports
+such as the MoviePy 2 video helper update and Reel Facebook cross-post payload helpers.
 
 ## Porting rules
 


### PR DESCRIPTION
## Summary
- add the unreleased Reel Facebook cross-post payload helper note to CHANGELOG.md
- update upstream sync notes from the stale 2.6.4 baseline wording
- document the 0.9.8 MoviePy 2 maintenance port and the post-2.6.7 Reel cross-post follow-up

## Tests
- .venv/bin/mkdocs build --strict