### PR TITLE
Add client TLS verification setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added async Reel Facebook cross-post payload helpers for linked Facebook users/pages, including explicit
   `fb_destination_id` and `fb_destination_type` support when Instagram's lightweight preflight does not return a usable
   destination.
+- Added `Client(tls_verify=...)` and `client.set_tls_verify(...)` so users can keep TLS verification enabled by default,
+  pass a trusted CA bundle for debugging proxies, or explicitly disable verification for local captures.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 
 See the [public transport guide](docs/usage-guide/public-transport.md) for live comparison results and caveats.
 
+TLS certificate verification is enabled by default. For a trusted debugging MITM proxy, prefer `Client(tls_verify="/path/to/proxy-ca.pem")`; use `Client(tls_verify=False)` only for temporary local debugging because it allows session interception.
+
 ### Basic Usage
 
 ``` python

--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -103,6 +103,7 @@ class Client(
         override_app_version: bool = False,
         **kwargs,
     ):
+        self.tls_verify = kwargs.pop("tls_verify", True)
         super().__init__(**kwargs)
         self.settings = deepcopy(settings or {})
         self.override_app_version = override_app_version

--- a/aiograpi/httpx_ext.py
+++ b/aiograpi/httpx_ext.py
@@ -1,4 +1,5 @@
 import asyncio
+import ssl
 
 import httpx
 import orjson
@@ -61,10 +62,20 @@ SUPPORTED_DECODERS["zstd"] = ZstdDecoder
 DEFAULT_TIMEOUT = 45
 
 
+def _httpx_verify_value(verify):
+    if isinstance(verify, str):
+        return ssl.create_default_context(cafile=verify)
+    return verify
+
+
 async def request(method, url, proxy=None, verify=True, follow_redirects=True, **kwargs):
     if "timeout" not in kwargs:
         kwargs["timeout"] = DEFAULT_TIMEOUT
-    async with httpx.AsyncClient(proxy=proxy, verify=verify, follow_redirects=follow_redirects) as client:
+    async with httpx.AsyncClient(
+        proxy=proxy,
+        verify=_httpx_verify_value(verify),
+        follow_redirects=follow_redirects,
+    ) as client:
         return await client.request(method, url, **kwargs)
 
 
@@ -100,7 +111,16 @@ class Session:
         self._set_client()
 
     def _set_client(self):
-        self._client = httpx.AsyncClient(proxy=self._proxy, verify=self.verify, follow_redirects=True)
+        self._client = httpx.AsyncClient(
+            proxy=self._proxy,
+            verify=_httpx_verify_value(self.verify),
+            follow_redirects=True,
+        )
+
+    def set_verify(self, verify):
+        self.verify = verify
+        if self._client is not None:
+            self._set_client()
 
     async def __aenter__(self):
         return self
@@ -206,6 +226,10 @@ class CurlSession:
     def proxy(self, p):
         self._proxy = p
         self._client.proxies = {"http": p, "https": p} if p else {}
+
+    def set_verify(self, verify):
+        self.verify = verify
+        self._client.verify = verify
 
     async def __aenter__(self):
         return self

--- a/aiograpi/mixins/auth.py
+++ b/aiograpi/mixins/auth.py
@@ -445,6 +445,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         locale = self.settings.get("locale", self.locale)
         country = self.settings.get("country", self.country)
         country_code = self.settings.get("country_code", self.country_code)
+        self.set_tls_verify(self.settings.get("tls_verify", self.tls_verify))
         self.set_retry_config(
             request_timeout=self.settings.get("request_timeout", self.request_timeout),
             public_request_retries_count=self.settings.get(
@@ -747,6 +748,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             "session_retry_statuses": self.session_retry_statuses,
             "public_transport": self.public_transport,
             "public_transport_impersonate": self.public_transport_impersonate,
+            "tls_verify": self.tls_verify,
         }
 
     def set_settings(self, settings: Dict) -> bool:
@@ -800,6 +802,20 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         """
         with open(path, "w") as fp:
             json.dump(self.get_settings(), fp, indent=4)
+        return True
+
+    def set_tls_verify(self, tls_verify: Union[bool, str]) -> bool:
+        self.tls_verify = tls_verify
+        for name in ("public", "private", "graphql"):
+            session = getattr(self, name, None)
+            if session is None:
+                continue
+            if hasattr(session, "set_verify"):
+                session.set_verify(tls_verify)
+            else:
+                session.verify = tls_verify
+        if self.settings is not None:
+            self.settings["tls_verify"] = tls_verify
         return True
 
     def set_retry_config(

--- a/aiograpi/mixins/base.py
+++ b/aiograpi/mixins/base.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
         settings: Dict[str, Any]
         timezone_offset: int
         tray_session_id: str
+        tls_verify: Any
         user_agent: str
         username: str
         uuid: str

--- a/aiograpi/mixins/challenge.py
+++ b/aiograpi/mixins/challenge.py
@@ -161,7 +161,7 @@ class ChallengeResolveMixin(ClientMixin):
         # this string contains no password, only the current epoch.
         ajax_seed = "#PWD_INSTAGRAM_BROWSER:0:%s:" % str(int(time.time()))
         instagram_ajax = hashlib.sha256(ajax_seed.encode()).hexdigest()[:12]
-        session = httpx_ext.Session()
+        session = httpx_ext.Session(verify=self.tls_verify)
         try:
             session.proxy = self.private.proxy
             session.headers.update(

--- a/aiograpi/mixins/direct.py
+++ b/aiograpi/mixins/direct.py
@@ -901,7 +901,14 @@ class DirectMixin(ClientMixin):
             }
         )
         proxy = getattr(self, "proxy", None)
-        response = await httpx_ext.request("GET", url, headers=headers, proxy=proxy, timeout=30)
+        response = await httpx_ext.request(
+            "GET",
+            url,
+            headers=headers,
+            proxy=proxy,
+            verify=self.tls_verify,
+            timeout=30,
+        )
         if response.status_code != 200:
             raise ClientError(f"messenger_video offset GET failed: {response.status_code} {response.text[:300]}")
         try:
@@ -924,6 +931,7 @@ class DirectMixin(ClientMixin):
             data=video_bytes[offset:],
             headers=post_headers,
             proxy=proxy,
+            verify=self.tls_verify,
             timeout=300,
         )
         if response.status_code != 200:
@@ -989,7 +997,14 @@ class DirectMixin(ClientMixin):
         url = f"https://rupload.facebook.com/messenger_audio/{entity}"
         headers = self._messenger_rupload_headers({"audio_type": "FILE_ATTACHMENT"})
         proxy = getattr(self, "proxy", None)
-        response = await httpx_ext.request("GET", url, headers=headers, proxy=proxy, timeout=30)
+        response = await httpx_ext.request(
+            "GET",
+            url,
+            headers=headers,
+            proxy=proxy,
+            verify=self.tls_verify,
+            timeout=30,
+        )
         if response.status_code != 200:
             raise ClientError(f"messenger_audio offset GET failed: {response.status_code} {response.text[:300]}")
         try:
@@ -1012,6 +1027,7 @@ class DirectMixin(ClientMixin):
             data=audio_bytes[offset:],
             headers=post_headers,
             proxy=proxy,
+            verify=self.tls_verify,
             timeout=120,
         )
         if response.status_code != 200:

--- a/aiograpi/mixins/graphql.py
+++ b/aiograpi/mixins/graphql.py
@@ -81,9 +81,7 @@ class GraphQLRequestMixin(ClientMixin):
     request_logger = logging.getLogger("graphql_request")
 
     def __init__(self, *args, **kwargs):
-        self.graphql = httpx_ext.Session()
-        # NB: TLS verification is ON. To disable for a misbehaving
-        # MITM proxy, set self.graphql.verify = False AFTER construction.
+        self.graphql = httpx_ext.Session(verify=getattr(self, "tls_verify", True))
         self.graphql.headers.update(
             {
                 "Connection": "Keep-Alive",

--- a/aiograpi/mixins/private.py
+++ b/aiograpi/mixins/private.py
@@ -103,9 +103,7 @@ class PrivateRequestMixin(ClientMixin):
     last_json = {}
 
     def __init__(self, *args, **kwargs):
-        self.private = httpx_ext.Session()
-        # NB: TLS verification is ON. To disable for a misbehaving
-        # MITM proxy, set self.private.verify = False AFTER construction.
+        self.private = httpx_ext.Session(verify=getattr(self, "tls_verify", True))
         self.email = kwargs.pop("email", None)
         self.phone_number = kwargs.pop("phone_number", None)
         self.request_timeout = kwargs.pop("request_timeout", getattr(self, "request_timeout", self.request_timeout))

--- a/aiograpi/mixins/public.py
+++ b/aiograpi/mixins/public.py
@@ -70,8 +70,6 @@ class PublicRequestMixin(ClientMixin):
             "public_accept_language", getattr(self, "public_accept_language", self.public_accept_language)
         )
         self.public = self._build_public_session()
-        # NB: TLS verification is ON. To disable for a misbehaving
-        # MITM proxy, set self.public.verify = False AFTER construction.
         self.public.headers.update(
             {
                 "Connection": "Keep-Alive",
@@ -112,10 +110,11 @@ class PublicRequestMixin(ClientMixin):
             return cls.public_curl_user_agents.get(impersonate, cls.public_curl_user_agents["chrome136"])
         return cls.public_user_agent
 
-    def _build_public_session(self):
+    def _build_public_session(self, verify=None):
+        verify = getattr(self, "tls_verify", True) if verify is None else verify
         if self.public_transport == "curl":
-            return httpx_ext.CurlSession(impersonate=self.public_transport_impersonate)
-        return httpx_ext.Session()
+            return httpx_ext.CurlSession(verify=verify, impersonate=self.public_transport_impersonate)
+        return httpx_ext.Session(verify=verify)
 
     def _configure_public_transport(self):
         old_public = getattr(self, "public", None)
@@ -124,8 +123,7 @@ class PublicRequestMixin(ClientMixin):
         old_headers = dict(getattr(old_public, "headers", {}))
         old_cookies = old_public.cookies_dict() if old_public is not None else {}
 
-        self.public = self._build_public_session()
-        self.public.verify = old_verify
+        self.public = self._build_public_session(verify=old_verify)
         self.public.proxy = old_proxy
         self.public.headers.update(old_headers)
         if old_cookies:

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -47,18 +47,17 @@ with `TypeError: 'NoneType' object is not subscriptable`.
 `httpx_ext.Session` and the three Client sessions
 (`client.private` / `.public` / `.graphql`) ship with `verify=True`
 now. If your proxy is a known SSL-MITM (e.g. corporate inspection
-gateway), you'll need to opt out explicitly **after** construction:
+gateway), pass its CA bundle or opt out explicitly at construction:
 
 ```python
-client = Client()
-client.private.verify = False
-client.public.verify = False
-client.graphql.verify = False
+client = Client(tls_verify="/path/to/proxy-ca.pem")
+# or, for short trusted local debugging only:
+client = Client(tls_verify=False)
 ```
 
 Most residential / CONNECT-tunnel proxies don't terminate SSL — they
 just pass packets — so they keep working with the new default. Only
-flip `verify=False` if you actually see SSL errors and you've verified
+flip `tls_verify=False` if you actually see SSL errors and you've verified
 the proxy is trustworthy.
 
 ### 0.3.0 — six pure helpers go sync

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -31,7 +31,7 @@
 
 `aiograpi` provides the following `Interactions` that can be used to control and get the information about your `Instagram` account:
 
-* Client(settings: dict = {}, proxy: str = ""): bool - Init `aiograpi` client
+* Client(settings: dict = {}, proxy: str = "", tls_verify: Union[bool, str] = True): bool - Init `aiograpi` client
 
 ``` python
 await cl.login("aiograpi", "42")
@@ -57,6 +57,7 @@ We recommend using [these proxies](https://soax.com/?r=sEysufQI)
 | request\_timeout    | Timeout in seconds between requests (1 second by default)
 | public\_transport   | Public web transport: `requests`-compatible async transport by default, or `curl` when `aiograpi[curl]` is installed
 | public\_transport\_impersonate | Browser fingerprint used by the optional curl public transport
+| tls\_verify | TLS certificate verification: `True` by default, `False` for temporary trusted MITM debugging, or a CA bundle path
 
 
 ### Login
@@ -97,7 +98,8 @@ settings = {
    },
    "user_agent": "Instagram 117.0.0.28.123 Android (23/6.0.1; ...US; 168361634)",
    "public_transport": "requests",
-   "public_transport_impersonate": "chrome136"
+   "public_transport_impersonate": "chrome136",
+   "tls_verify": True
 }
 
 cl = Client(settings)
@@ -148,6 +150,7 @@ await cl.get_timeline_feed()  # check session
 | set_country_code(country_code: int = 1)  | bool | Set country calling code. Default: +1 (USA)
 | set_locale(locale: str = "en_US")        | bool | Set locale (advice: use the locale of your proxy)
 | set_timezone_offset(seconds: int)        | bool | Set timezone offset in seconds
+| set_tls_verify(tls_verify: bool \| str)  | bool | Update TLS certificate verification for existing public, private and GraphQL sessions
 
 ``` python
 cl = Client()
@@ -198,6 +201,24 @@ cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 
 The default remains `public_transport="requests"`. Private mobile API requests still use the regular mobile session.
 See [Public Transport](public-transport.md) for live comparison results and caveats.
+
+### TLS verification and debugging proxies
+
+By default `aiograpi` verifies TLS certificates on all client sessions. Keep this enabled for production, residential proxies, and normal CONNECT-tunnel proxies.
+
+If you use a trusted local debugging proxy that intercepts TLS, prefer installing its CA certificate and pointing the client at that bundle:
+
+```python
+cl = Client(tls_verify="/path/to/proxy-ca.pem")
+```
+
+For short local captures you can disable verification explicitly:
+
+```python
+cl = Client(tls_verify=False)
+```
+
+Do not disable TLS verification on untrusted networks or shared proxies because session cookies and passwords can be intercepted.
 
 ## What's Next?
 

--- a/docs/usage-guide/troubleshooting.md
+++ b/docs/usage-guide/troubleshooting.md
@@ -85,17 +85,14 @@ Connection-level failure. Most common causes:
 ### `ssl.SSLCertVerificationError` / TLS handshake failures
 
 Since 0.6.6 aiograpi verifies TLS by default. If your proxy is a known
-SSL-MITM (corporate inspection gateway), opt out **after** construction:
+SSL-MITM (corporate inspection gateway), pass its CA bundle:
 
 ```python
-client = Client()
-client.private.verify = False
-client.public.verify = False
-client.graphql.verify = False
+client = Client(tls_verify="/path/to/proxy-ca.pem")
 ```
 
-Don't blindly disable on residential proxies — that's how MITM attackers
-intercept your sessionid.
+For short trusted local debugging only, use `Client(tls_verify=False)`.
+Don't blindly disable verification on residential proxies because MITM attackers can intercept your sessionid.
 
 ### `AuthRequiredProxyError: 302 Found`
 

--- a/tests/regression/test_tls_verify.py
+++ b/tests/regression/test_tls_verify.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import certifi
+
+from aiograpi import Client
+
+
+class _FakeResponse:
+    status_code = 200
+    text = ""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _assert_client_tls_verify(test_case, client, expected):
+    test_case.assertEqual(client.tls_verify, expected)
+    test_case.assertEqual(client.public.verify, expected)
+    test_case.assertEqual(client.private.verify, expected)
+    test_case.assertEqual(client.graphql.verify, expected)
+
+
+class ClientTLSVerifyRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    def test_default_client_tls_verify_is_enabled(self):
+        _assert_client_tls_verify(self, Client(), True)
+
+    def test_client_tls_verify_can_be_disabled_for_debugging_proxy(self):
+        _assert_client_tls_verify(self, Client(tls_verify=False), False)
+
+    def test_client_tls_verify_accepts_ca_bundle_path_and_roundtrips_settings(self):
+        ca_bundle = certifi.where()
+        client = Client(tls_verify=ca_bundle)
+
+        settings = client.get_settings()
+        self.assertEqual(settings["tls_verify"], ca_bundle)
+
+        restored = Client(settings=settings)
+        _assert_client_tls_verify(self, restored, ca_bundle)
+
+    def test_set_tls_verify_updates_existing_sessions(self):
+        client = Client()
+
+        self.assertTrue(client.set_tls_verify(False))
+        _assert_client_tls_verify(self, client, False)
+
+    async def test_direct_rupload_requests_use_client_tls_verify(self):
+        client = Client(tls_verify=False)
+
+        with mock.patch(
+            "aiograpi.mixins.direct.httpx_ext.request",
+            new_callable=AsyncMock,
+        ) as request:
+            request.side_effect = [_FakeResponse({"offset": 0}), _FakeResponse({"media_id": 123})]
+
+            media_id = await client._video_rupload(b"video-bytes", "entity-name", "waterfall-id")
+
+        self.assertEqual(media_id, 123)
+        self.assertEqual(request.await_count, 2)
+        for call in request.await_args_list:
+            self.assertIs(call.kwargs["verify"], False)


### PR DESCRIPTION
## Summary
- add Client(tls_verify=...) and set_tls_verify(...)
- propagate TLS verification to public, private, GraphQL, challenge, and Direct rupload sessions
- document CA bundle / temporary debug disable usage

## Tests
- PYTHONPATH=. .venv/bin/pytest tests/regression/test_tls_verify.py tests/regression/test_public_transport.py tests/regression/test_direct.py -q
- PYTHONPATH=. .venv/bin/ruff check aiograpi tests/regression/test_tls_verify.py
- ./scripts/check-mypy-baseline.sh
- .venv/bin/mkdocs build --strict