### PR TITLE
Harden signup challenge path validation

### DIFF
--- a/aiograpi/mixins/signup.py
+++ b/aiograpi/mixins/signup.py
@@ -3,6 +3,7 @@ import base64
 import random
 import secrets
 import time
+from urllib.parse import urlsplit
 from uuid import uuid4
 
 from aiograpi.exceptions import (
@@ -26,6 +27,26 @@ class SignUpMixin(ClientMixin):
     waterfall_id = str(uuid4())
     adid = str(uuid4())
     wait_seconds = 5
+
+    @staticmethod
+    def _safe_challenge_api_path(api_path: str, field_name: str = "api_path") -> str:
+        if not isinstance(api_path, str) or not api_path:
+            raise ClientError(f"Malformed challenge data from Instagram (missing {field_name}).")
+        parts = urlsplit(api_path)
+        has_control_chars = any(ord(char) < 32 or ord(char) == 127 for char in api_path)
+        if (
+            parts.scheme
+            or parts.netloc
+            or not api_path.startswith("/")
+            or api_path.startswith("//")
+            or "\\" in api_path
+            or has_control_chars
+        ):
+            raise ClientError(f"Unsafe challenge path from Instagram: {field_name}")
+        return api_path
+
+    def _challenge_url(self, api_path: str, prefix: str = "", field_name: str = "api_path") -> str:
+        return f"https://i.instagram.com{prefix}{self._safe_challenge_api_path(api_path, field_name)}"
 
     async def signup(
         self,
@@ -256,7 +277,7 @@ class SignUpMixin(ClientMixin):
 
     async def challenge_api(self, data):
         resp = await self.private.get(
-            f"https://i.instagram.com/api/v1{data['api_path']}",
+            self._challenge_url(data.get("api_path"), prefix="/api/v1"),
             params={
                 "guid": self.uuid,
                 "device_id": self.android_device_id,
@@ -276,7 +297,7 @@ class SignUpMixin(ClientMixin):
             )
             raise ClientError("Malformed captcha challenge data from Instagram (missing site_key or api_path).")
 
-        challenge_post_url = f"https://i.instagram.com{api_path}"
+        challenge_post_url = self._challenge_url(api_path)
         captcha_details_for_solver = {
             "site_key": site_key,
             "challenge_type": challenge_type,
@@ -307,7 +328,7 @@ class SignUpMixin(ClientMixin):
     async def challenge_submit_phone_number(self, data, phone_number):
         api_path = data.get("navigation", {}).get("forward")
         resp = await self.private.post(
-            f"https://i.instagram.com{api_path}",
+            self._challenge_url(api_path, field_name="navigation.forward"),
             data={
                 "phone_number": phone_number,
                 "challenge_context": data["challenge_context"],
@@ -318,7 +339,7 @@ class SignUpMixin(ClientMixin):
     async def challenge_verify_sms_captcha(self, data, security_code):
         api_path = data.get("navigation", {}).get("forward")
         resp = await self.private.post(
-            f"https://i.instagram.com{api_path}",
+            self._challenge_url(api_path, field_name="navigation.forward"),
             data={
                 "security_code": security_code,
                 "challenge_context": data["challenge_context"],

--- a/tests/regression/test_signup.py
+++ b/tests/regression/test_signup.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest.mock import AsyncMock, Mock
+
+from aiograpi import Client
+from aiograpi.exceptions import ClientError
+
+
+class SignupHelperRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_challenge_api_rejects_external_api_path(self):
+        client = Client()
+        client.uuid = "uuid"
+        client.android_device_id = "android-id"
+        client.private.get = AsyncMock()
+
+        for api_path in ("@attacker.example/steal", "//attacker.example/steal"):
+            with self.subTest(api_path=api_path):
+                with self.assertRaises(ClientError):
+                    await client.challenge_api(
+                        {
+                            "api_path": api_path,
+                            "challenge_context": "{}",
+                        }
+                    )
+
+        client.private.get.assert_not_awaited()
+
+    async def test_challenge_captcha_rejects_external_api_path_before_solver(self):
+        client = Client()
+        client.captcha_resolve = AsyncMock(side_effect=AssertionError("solver should not be called"))
+        client.private.post = AsyncMock()
+
+        with self.assertRaises(ClientError):
+            await client.challenge_captcha(
+                {
+                    "api_path": "@attacker.example/steal",
+                    "fields": {"sitekey": "site-key"},
+                    "challengeType": "RecaptchaChallengeForm",
+                }
+            )
+
+        client.captcha_resolve.assert_not_awaited()
+        client.private.post.assert_not_awaited()
+
+    async def test_challenge_submit_phone_number_rejects_external_forward_path(self):
+        client = Client()
+        client.private.post = AsyncMock(return_value=Mock(json=Mock(return_value={"status": "ok"})))
+
+        with self.assertRaises(ClientError):
+            await client.challenge_submit_phone_number(
+                {
+                    "navigation": {"forward": "@attacker.example/steal"},
+                    "challenge_context": "{}",
+                },
+                "+15551234567",
+            )
+
+        client.private.post.assert_not_awaited()
+
+    async def test_challenge_verify_sms_captcha_rejects_external_forward_path(self):
+        client = Client()
+        client.private.post = AsyncMock(return_value=Mock(json=Mock(return_value={"status": "ok"})))
+
+        with self.assertRaises(ClientError):
+            await client.challenge_verify_sms_captcha(
+                {
+                    "navigation": {"forward": "@attacker.example/steal"},
+                    "challenge_context": "{}",
+                },
+                "123456",
+            )
+
+        client.private.post.assert_not_awaited()


### PR DESCRIPTION
## Summary
- validate signup challenge paths before building request URLs
- reject malformed or non-relative challenge paths before network requests or captcha solving
- add regression coverage for challenge API, captcha, and SMS challenge forward paths

## Tests
- `PYTHONPATH=. /Users/colinfrl/work/sub/aiograpi/.venv/bin/pytest tests/regression/test_signup.py`
- `PYTHONPATH=. /Users/colinfrl/work/sub/aiograpi/.venv/bin/pytest tests/regression/test_signup.py tests/legacy.py::ChallengeRegressionTestCase`
- `PYTHONPATH=. /Users/colinfrl/work/sub/aiograpi/.venv/bin/pytest tests/regression`
- `PYTHONPATH=. /Users/colinfrl/work/sub/aiograpi/.venv/bin/ruff check .`