### PR TITLE
Fix Termux pydantic install resolution

### DIFF
--- a/docs/usage-guide/termux.md
+++ b/docs/usage-guide/termux.md
@@ -8,10 +8,12 @@ Termux can run many `aiograpi` flows, but Android does not use the same binary w
 pkg update
 pkg install python python-pillow
 python -m pip install -U pip setuptools wheel
-python -m pip install aiograpi
+python -m pip install --extra-index-url https://termux-user-repository.github.io/pypi/ aiograpi
 ```
 
 `python-pillow` is recommended because photo uploads use Pillow through `aiograpi.image_util`. Installing it with `pkg` avoids a slow or fragile Pillow source build in pip.
+
+The Termux User Repository PyPI index provides Android wheels for native packages that PyPI may only publish as desktop Linux wheels. On Android, `aiograpi` uses `pydantic==2.12.5`, which depends on `pydantic-core==2.41.5`; that version has Android wheels for Python 3.13 in the Termux index. Newer `pydantic-core` releases may otherwise try to build with Rust and fail on-device.
 
 ## Video Uploads
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,8 @@ keywords = [
 dependencies = [
     "httpx==0.28.1",
     "orjson==3.11.8",
-    "pydantic==2.13.4",
+    "pydantic==2.12.5; sys_platform == 'android'",
+    "pydantic>=2.12.5,<2.14; sys_platform != 'android'",
     "pycryptodomex==3.23.0",
     "zstandard==0.25.0",
     "Pillow>=12.2.0",

--- a/tests/regression/test_packaging.py
+++ b/tests/regression/test_packaging.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_pydantic_dependency_allows_termux_android_wheel_version():
+    pyproject = Path("pyproject.toml").read_text()
+    required_dependencies = pyproject.split("[project.optional-dependencies]", 1)[0]
+
+    assert "\"pydantic==2.12.5; sys_platform == 'android'\"" in required_dependencies
+    assert "\"pydantic>=2.12.5,<2.14; sys_platform != 'android'\"" in required_dependencies
+    assert '"pydantic==2.13.4"' not in required_dependencies
+
+
+def test_termux_guide_documents_android_pydantic_core_wheel_index():
+    termux_guide = Path("docs/usage-guide/termux.md").read_text()
+
+    assert "https://termux-user-repository.github.io/pypi/" in termux_guide
+    assert "pydantic==2.12.5" in termux_guide

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,12 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version >= '3.11' and python_full_version < '3.15'",
-    "python_full_version < '3.11'",
+    "python_full_version >= '3.15' and sys_platform == 'android'",
+    "python_full_version >= '3.15' and sys_platform != 'android'",
+    "python_full_version >= '3.11' and python_full_version < '3.15' and sys_platform == 'android'",
+    "python_full_version >= '3.11' and python_full_version < '3.15' and sys_platform != 'android'",
+    "python_full_version < '3.11' and sys_platform == 'android'",
+    "python_full_version < '3.11' and sys_platform != 'android'",
 ]
 
 [[package]]
@@ -16,7 +19,8 @@ dependencies = [
     { name = "orjson" },
     { name = "pillow" },
     { name = "pycryptodomex" },
-    { name = "pydantic" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'android'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'android'" },
     { name = "zstandard" },
 ]
 
@@ -84,7 +88,8 @@ requires-dist = [
     { name = "proglog", marker = "extra == 'test'", specifier = "<=1.0.0" },
     { name = "proglog", marker = "extra == 'video'", specifier = "<=1.0.0" },
     { name = "pycryptodomex", specifier = "==3.23.0" },
-    { name = "pydantic", specifier = "==2.13.4" },
+    { name = "pydantic", marker = "sys_platform != 'android'", specifier = ">=2.12.5,<2.14" },
+    { name = "pydantic", marker = "sys_platform == 'android'", specifier = "==2.12.5" },
     { name = "pytest", marker = "extra == 'test'", specifier = "==9.0.3" },
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = "==3.8.0" },
     { name = "python-dotenv", marker = "extra == 'test'", specifier = ">=0.10" },
@@ -1259,7 +1264,8 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'android'",
+    "python_full_version < '3.11' and sys_platform != 'android'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -1324,8 +1330,10 @@ name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version >= '3.11' and python_full_version < '3.15'",
+    "python_full_version >= '3.15' and sys_platform == 'android'",
+    "python_full_version >= '3.15' and sys_platform != 'android'",
+    "python_full_version >= '3.11' and python_full_version < '3.15' and sys_platform == 'android'",
+    "python_full_version >= '3.11' and python_full_version < '3.15' and sys_platform != 'android'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
 wheels = [
@@ -1826,13 +1834,38 @@ wheels = [
 
 [[package]]
 name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'android'",
+    "python_full_version >= '3.11' and python_full_version < '3.15' and sys_platform == 'android'",
+    "python_full_version < '3.11' and sys_platform == 'android'",
+]
+dependencies = [
+    { name = "annotated-types", marker = "sys_platform == 'android'" },
+    { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'android'" },
+    { name = "typing-extensions", marker = "sys_platform == 'android'" },
+    { name = "typing-inspection", marker = "sys_platform == 'android'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform != 'android'",
+    "python_full_version >= '3.11' and python_full_version < '3.15' and sys_platform != 'android'",
+    "python_full_version < '3.11' and sys_platform != 'android'",
+]
 dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-types", marker = "sys_platform != 'android'" },
+    { name = "pydantic-core", version = "2.46.4", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'android'" },
+    { name = "typing-extensions", marker = "sys_platform != 'android'" },
+    { name = "typing-inspection", marker = "sys_platform != 'android'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
@@ -1841,10 +1874,29 @@ wheels = [
 
 [[package]]
 name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'android'",
+    "python_full_version >= '3.11' and python_full_version < '3.15' and sys_platform == 'android'",
+    "python_full_version < '3.11' and sys_platform == 'android'",
+]
+dependencies = [
+    { name = "typing-extensions", marker = "sys_platform == 'android'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+
+[[package]]
+name = "pydantic-core"
 version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform != 'android'",
+    "python_full_version >= '3.11' and python_full_version < '3.15' and sys_platform != 'android'",
+    "python_full_version < '3.11' and sys_platform != 'android'",
+]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform != 'android'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- use an Android-specific pydantic pin so Termux resolves to pydantic-core 2.41.5, which has Android wheels in the Termux User Repository PyPI
- keep non-Android installs on the current pydantic range through 2.13.x
- update the Termux install guide, uv.lock, and packaging regression coverage

## Verification
- PYTHONPATH=. /Users/colinfrl/work/sub/aiograpi/.venv/bin/pytest tests/regression/test_packaging.py
- /Users/colinfrl/work/sub/aiograpi/.venv/bin/python -m ruff check tests/regression/test_packaging.py
- uv run --with build python -m build --wheel --outdir /tmp/aiograpi-termux-pydantic-dist
- unzip METADATA check: pydantic==2.12.5 for sys_platform == android; pydantic>=2.12.5,<2.14 otherwise
- /Users/colinfrl/work/sub/aiograpi/.venv/bin/mkdocs build --strict
- verified TUR publishes pydantic_core-2.41.5 cp313 Android arm64 wheel