### PR TITLE
Mirror GraphQL follow list ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ import uuid
 data = await cl.private_graphql_followers_list(
     user_id="25025320",
     rank_token=str(uuid.uuid4()),
+    order="date_followed_latest",
 )
 # Raw GraphQL envelope: {"data": {...}, "status": "ok", ...}
 ```

--- a/aiograpi/mixins/user.py
+++ b/aiograpi/mixins/user.py
@@ -1869,9 +1869,10 @@ class UserMixin(ClientMixin):
         self,
         user_id: str,
         rank_token: str,
-        client_doc_id: str = "28479704798344003308647327139",
+        client_doc_id: str = "28479704797510738576165798526",
         max_id: int = None,
         priority: str = None,
+        order: Union[str, None] = None,
         exclude_field_is_favorite: bool = None,
         exclude_unused_fields: bool = None,
     ) -> dict:
@@ -1896,6 +1897,8 @@ class UserMixin(ClientMixin):
             Cursor for pagination.
         priority: str, optional
             ``Priority`` header value, e.g. ``"u=3, i"``.
+        order: str, optional
+            Follow-list ordering value such as ``"date_followed_latest"``.
         exclude_field_is_favorite, exclude_unused_fields: bool, optional
             Forwarded to the ``variables`` payload.
 
@@ -1909,17 +1912,25 @@ class UserMixin(ClientMixin):
             "enableGroups": True,
         }
         variables = {
-            "include_unseen_count": False,
-            "query": "",
-            "include_biography": False,
             "user_id": str(user_id),
+            "skip_suggested_users": True,
+            "skip_more_groups_available": True,
+            "skip_friendship_followers_fields": True,
             "request_data": request_data,
+            "skip_page_size": True,
+            "skip_pending_admins": True,
+            "skip_has_more": True,
             "search_surface": "follow_list_page",
+            "query": "",
+            "skip_big_list": True,
+            "include_unseen_count": True,
         }
         if exclude_field_is_favorite is not None:
             variables["exclude_field_is_favorite"] = exclude_field_is_favorite
         if max_id is not None:
             variables["max_id"] = max_id
+        if order is not None:
+            variables["order"] = order
         if exclude_unused_fields is not None:
             variables["exclude_unused_fields"] = exclude_unused_fields
         return await self.private_graphql_query_request(
@@ -1928,15 +1939,17 @@ class UserMixin(ClientMixin):
             variables=variables,
             client_doc_id=client_doc_id,
             priority=priority,
+            extra_headers={"X-FB-RMD": "state=URL_ELIGIBLE"},
         )
 
     async def private_graphql_following_list(
         self,
         user_id: str,
         rank_token: str,
-        client_doc_id: str = "16104639289023609826830352479",
+        client_doc_id: str = "161046392817718486717479294775",
         max_id: int = None,
         priority: str = None,
+        order: Union[str, None] = None,
         exclude_field_is_favorite: bool = None,
         exclude_unused_fields: bool = None,
     ) -> dict:
@@ -1952,17 +1965,31 @@ class UserMixin(ClientMixin):
             "includes_hashtags": True,
         }
         variables = {
-            "include_unseen_count": False,
-            "enable_groups": True,
             "user_id": str(user_id),
+            "skip_use_clickable_see_more": True,
+            "skip_preview_hashtags": True,
+            "skip_should_limit_list_of_followers": True,
+            "skip_pending_admins": True,
+            "skip_more_groups_available": True,
+            "skip_friendship_followers_fields": False,
             "request_data": request_data,
-            "include_biography": False,
+            "skip_page_size": True,
+            "skip_friend_requests": True,
+            "skip_big_list": True,
             "query": "",
+            "include_profile_update_info": True,
+            "skip_suggested_users": True,
+            "include_unseen_count": True,
+            "skip_has_more": True,
+            "enable_groups": True,
+            "skip_hashtag_count": True,
         }
         if exclude_field_is_favorite is not None:
             variables["exclude_field_is_favorite"] = exclude_field_is_favorite
         if max_id is not None:
             variables["max_id"] = max_id
+        if order is not None:
+            variables["order"] = order
         if exclude_unused_fields is not None:
             variables["exclude_unused_fields"] = exclude_unused_fields
         return await self.private_graphql_query_request(
@@ -1971,6 +1998,7 @@ class UserMixin(ClientMixin):
             variables=variables,
             client_doc_id=client_doc_id,
             priority=priority,
+            extra_headers={"X-FB-RMD": "state=URL_ELIGIBLE"},
         )
 
     async def private_graphql_clips_profile(

--- a/docs/usage-guide/private-graphql.md
+++ b/docs/usage-guide/private-graphql.md
@@ -29,8 +29,8 @@ query) and as **named convenience wrappers** (`user_info_v2_gql`,
 | Audio/track clips-pivot stream | `Client.track_stream_info_by_id(track_id, max_id="")` |
 | Media info via discover/media_metadata fallback | `Client.media_info_v2(media_id)` |
 | Lightweight offensive-comment check (raw payload) | `Client.media_check_offensive_comment_v2(media_id, comment)` |
-| Followers list (mobile-app surface) | `Client.private_graphql_followers_list(user_id, rank_token)` |
-| Following list (mobile-app surface) | `Client.private_graphql_following_list(user_id, rank_token)` |
+| Followers list (mobile-app surface) | `Client.private_graphql_followers_list(user_id, rank_token, order=None)` |
+| Following list (mobile-app surface) | `Client.private_graphql_following_list(user_id, rank_token, order=None)` |
 | Profile reels stream | `Client.private_graphql_clips_profile(target_user_id)` |
 | Direct inbox tray digest | `Client.private_graphql_inbox_tray_for_user(user_id)` |
 | Realtime region hints | `Client.private_graphql_realtime_region_hint()` |
@@ -79,6 +79,7 @@ rank_token = str(uuid.uuid4())
 data = await cl.private_graphql_followers_list(
     user_id="25025320",
     rank_token=rank_token,
+    order="date_followed_latest",
 )
 # Returns the raw GraphQL envelope: {"data": {...}, "status": "ok", ...}.
 # Schema is large and varies — pick what you need from data["data"].
@@ -139,6 +140,7 @@ working mobile-app session, but you can override per-call:
 await cl.private_graphql_followers_list(
     user_id="25025320",
     rank_token=rank_token,
+    order="date_followed_latest",
     client_doc_id="<freshly captured doc_id>",
 )
 ```

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -5111,6 +5111,7 @@ class ChapiPortedRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             client_doc_id="111",
             max_id=50,
             priority="u=3, i",
+            order="date_followed_latest",
         )
 
         self.assertIn("data", result)
@@ -5124,11 +5125,16 @@ class ChapiPortedRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         variables = captured["variables"]
         self.assertEqual(variables["user_id"], "42")
         self.assertEqual(variables["max_id"], 50)
+        self.assertEqual(variables["order"], "date_followed_latest")
         self.assertEqual(
             variables["request_data"],
             {"rank_token": "rank-1", "enableGroups": True},
         )
         self.assertEqual(variables["search_surface"], "follow_list_page")
+        self.assertTrue(variables["skip_suggested_users"])
+        self.assertTrue(variables["skip_page_size"])
+        self.assertTrue(variables["skip_pending_admins"])
+        self.assertEqual(captured["extra_headers"]["X-FB-RMD"], "state=URL_ELIGIBLE")
 
     async def test_private_graphql_following_list_builds_variables(self):
         client = self.build_client()
@@ -5139,16 +5145,26 @@ class ChapiPortedRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             return {"data": {}}
 
         client.private_graphql_query_request = fake_call
-        await client.private_graphql_following_list(user_id="77", rank_token="rank-2")
+        await client.private_graphql_following_list(
+            user_id="77",
+            rank_token="rank-2",
+            order="date_followed_earliest",
+        )
 
         self.assertEqual(captured["friendly_name"], "FollowingList")
         self.assertEqual(
             captured["root_field_name"],
             "xdt_api__v1__friendships__following",
         )
+        self.assertEqual(captured["client_doc_id"], "161046392817718486717479294775")
         self.assertEqual(captured["variables"]["user_id"], "77")
+        self.assertEqual(captured["variables"]["order"], "date_followed_earliest")
         self.assertEqual(captured["variables"]["request_data"]["rank_token"], "rank-2")
         self.assertTrue(captured["variables"]["request_data"]["includes_hashtags"])
+        self.assertTrue(captured["variables"]["skip_use_clickable_see_more"])
+        self.assertTrue(captured["variables"]["skip_page_size"])
+        self.assertTrue(captured["variables"]["skip_friend_requests"])
+        self.assertEqual(captured["extra_headers"]["X-FB-RMD"], "state=URL_ELIGIBLE")
 
     async def test_private_graphql_clips_profile_includes_initial_stream_count(
         self,

--- a/tests/live/smoke.py
+++ b/tests/live/smoke.py
@@ -174,11 +174,19 @@ async def main():
             ("feed_user_stream_item", lambda: cl.feed_user_stream_item(instagram_pk)),
             (
                 "private_graphql_followers_list",
-                lambda: cl.private_graphql_followers_list(instagram_pk, rank_token=rank_token),
+                lambda: cl.private_graphql_followers_list(
+                    instagram_pk,
+                    rank_token=rank_token,
+                    order="date_followed_latest",
+                ),
             ),
             (
                 "private_graphql_following_list",
-                lambda: cl.private_graphql_following_list(instagram_pk, rank_token=rank_token),
+                lambda: cl.private_graphql_following_list(
+                    instagram_pk,
+                    rank_token=rank_token,
+                    order="date_followed_earliest",
+                ),
             ),
             (
                 "private_graphql_clips_profile",


### PR DESCRIPTION
## Summary
- mirror instagrapi private GraphQL follow-list payload updates in aiograpi
- add optional `order` for `private_graphql_followers_list` / `private_graphql_following_list`
- refresh default doc ids, mobile payload flags, and `X-FB-RMD` header
- document ordered follow-list calls and add regression/smoke coverage

## Tests
- `.venv/bin/python -m pytest tests/legacy.py -k 'private_graphql_followers_list_builds_variables or private_graphql_following_list_builds_variables'`\n- `.venv/bin/python -m pytest tests/legacy.py::ChapiPortedRegressionTestCase`\n- `.venv/bin/ruff check aiograpi tests/legacy.py tests/live/smoke.py`\n\nNote: full `.venv/bin/python -m pytest tests/legacy.py` currently reaches live/proxy-backed tests and fails in this local environment with proxy `302 Found` / public `401` errors, unrelated to this offline GraphQL wrapper change.