### PR TITLE
Skip non-track music search results

### DIFF
--- a/aiograpi/mixins/fbsearch.py
+++ b/aiograpi/mixins/fbsearch.py
@@ -63,7 +63,7 @@ class FbSearchMixin(ClientMixin):
             "browse_session_id": self.generate_uuid(),
         }
         result = await self.private_request("music/audio_global_search/", params=params)
-        return [extract_track(item["track"]) for item in result["items"]]
+        return [extract_track(item["track"]) for item in result["items"] if item.get("track")]
 
     async def search_hashtags(self, query: str) -> List[Hashtag]:
         params = {

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -4938,6 +4938,43 @@ class ChapiPortedRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(users, [])
 
+    async def test_search_music_skips_non_track_items(self):
+        client = self.build_client()
+        client.private_request = AsyncMock(
+            return_value={
+                "items": [
+                    {"artist": {"pk": "123", "username": "hanszimmer"}, "track": None},
+                    {"playlist": {"id": "456", "title": "Hans Zimmer Essentials"}},
+                    {
+                        "track": {
+                            "id": "789",
+                            "title": "Time",
+                            "subtitle": "Hans Zimmer",
+                            "display_artist": "Hans Zimmer",
+                            "audio_cluster_id": 111,
+                            "cover_artwork_uri": None,
+                            "cover_artwork_thumbnail_uri": None,
+                            "highlight_start_times_in_ms": [0],
+                            "is_explicit": False,
+                            "dash_manifest": "",
+                            "has_lyrics": False,
+                            "audio_asset_id": 222,
+                            "duration_in_ms": 123000,
+                            "allows_saving": True,
+                        }
+                    },
+                ]
+            }
+        )
+
+        tracks = await client.search_music("Hans Zimmer")
+
+        self.assertEqual([track.title for track in tracks], ["Time"])
+        client.private_request.assert_awaited_once()
+        args, kwargs = client.private_request.call_args
+        self.assertEqual(args[0], "music/audio_global_search/")
+        self.assertIn("params", kwargs)
+
     # --- track ---
 
     async def test_track_stream_info_by_id_uses_clips_pivot_endpoint(self):


### PR DESCRIPTION
## Summary
- skip artist/playlist/null entries returned by `music/audio_global_search/`
- keep `search_music()` returning only valid `Track` objects
- add a regression test for mixed music search results

## Test plan
- `.venv/bin/python -m pytest tests/legacy.py::ChapiPortedRegressionTestCase::test_search_music_skips_non_track_items tests/legacy.py::ChapiPortedRegressionTestCase`
- `.venv/bin/ruff check aiograpi/mixins/fbsearch.py tests/legacy.py`
- `.venv/bin/ruff check .`
- `./scripts/check-mypy-baseline.sh`
- `git diff --check`

Mirrors subzeroid/instagrapi#2521.
