### PR TITLE
Normalize leading hash in hashtag names

### DIFF
--- a/aiograpi/mixins/hashtag.py
+++ b/aiograpi/mixins/hashtag.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import logging
+import warnings
 from typing import List, Tuple
 
 from aiograpi.exceptions import (
@@ -28,6 +29,21 @@ class HashtagMixin(ClientMixin):
     Helpers for managing Hashtag
     """
 
+    def _normalize_hashtag_name(self, name: str) -> str:
+        normalized = name.strip()
+        if normalized.startswith("#"):
+            normalized = normalized.lstrip("#").strip()
+            if not normalized:
+                raise ValueError("Hashtag name cannot be empty")
+            warnings.warn(
+                f"Hashtag names should not include a leading '#'; normalized to {normalized!r}.",
+                UserWarning,
+                stacklevel=3,
+            )
+        if not normalized:
+            raise ValueError("Hashtag name cannot be empty")
+        return normalized
+
     async def hashtag_info_a1(self, name: str, max_id: str = None) -> Hashtag:
         """
         Get information about a hashtag by Public Web API
@@ -45,6 +61,7 @@ class HashtagMixin(ClientMixin):
         Hashtag
             An object of Hashtag
         """
+        name = self._normalize_hashtag_name(name)
         params = {"max_id": max_id} if max_id else None
         try:
             data = await self.public_a1_request(f"/explore/tags/{name}/", params=params)
@@ -75,6 +92,7 @@ class HashtagMixin(ClientMixin):
         Hashtag
             An object of Hashtag
         """
+        name = self._normalize_hashtag_name(name)
         variables = {"tag_name": name, "show_ranked": False, "first": int(amount)}
         if end_cursor:
             variables["after"] = end_cursor
@@ -97,6 +115,7 @@ class HashtagMixin(ClientMixin):
         Hashtag
             An object of Hashtag
         """
+        name = self._normalize_hashtag_name(name)
         result = await self.private_request(f"tags/{name}/info/")
         return extract_hashtag_v1(result)
 
@@ -114,6 +133,7 @@ class HashtagMixin(ClientMixin):
         Hashtag
             An object of Hashtag
         """
+        name = self._normalize_hashtag_name(name)
         try:
             hashtag = await self.hashtag_info_a1(name)
         except Exception:
@@ -138,6 +158,7 @@ class HashtagMixin(ClientMixin):
         List[Hashtag]
             List of objects of Hashtag
         """
+        name = self._normalize_hashtag_name(name)
         data = await self.public_a1_request(f"/explore/tags/{name}/")
         if not data.get("hashtag"):
             raise HashtagNotFound(name=name, **data)
@@ -165,6 +186,7 @@ class HashtagMixin(ClientMixin):
         Tuple[List[Media], str]
             List of objects of Media and end_cursor
         """
+        name = self._normalize_hashtag_name(name)
         assert tab_key in (
             "recent",
             "top",
@@ -225,6 +247,7 @@ class HashtagMixin(ClientMixin):
         List[Media]
             List of objects of Media
         """
+        name = self._normalize_hashtag_name(name)
         medias, _ = await self.hashtag_medias_a1_chunk(name, amount, tab_key)
         if amount:
             medias = medias[:amount]
@@ -256,6 +279,7 @@ class HashtagMixin(ClientMixin):
         Tuple[List[Media], str]
             List of objects of Media and max_id
         """
+        name = self._normalize_hashtag_name(name)
         assert tab_key in (
             "top",
             "recent",
@@ -329,6 +353,7 @@ class HashtagMixin(ClientMixin):
         List[Media]
             List of objects of Media
         """
+        name = self._normalize_hashtag_name(name)
         medias = []
         max_id = None
         while True:
@@ -358,6 +383,7 @@ class HashtagMixin(ClientMixin):
         List[Media]
             List of objects of Media
         """
+        name = self._normalize_hashtag_name(name)
         return await self.hashtag_medias_a1(name, amount, tab_key="top")
 
     async def hashtag_medias_top_v1(self, name: str, amount: int = 9) -> List[Media]:
@@ -376,6 +402,7 @@ class HashtagMixin(ClientMixin):
         List[Media]
             List of objects of Media
         """
+        name = self._normalize_hashtag_name(name)
         return await self.hashtag_medias_v1(name, amount, tab_key="top")
 
     async def hashtag_medias_top(self, name: str, amount: int = 9) -> List[Media]:
@@ -394,6 +421,7 @@ class HashtagMixin(ClientMixin):
         List[Media]
             List of objects of Media
         """
+        name = self._normalize_hashtag_name(name)
         try:
             medias = await self.hashtag_medias_top_a1(name, amount)
         except ClientError:
@@ -416,6 +444,7 @@ class HashtagMixin(ClientMixin):
         List[Media]
             List of objects of Media
         """
+        name = self._normalize_hashtag_name(name)
         return await self.hashtag_medias_a1(name, amount, tab_key="recent")
 
     async def hashtag_medias_recent_v1(self, name: str, amount: int = 27) -> List[Media]:
@@ -434,6 +463,7 @@ class HashtagMixin(ClientMixin):
         List[Media]
             List of objects of Media
         """
+        name = self._normalize_hashtag_name(name)
         return await self.hashtag_medias_v1(name, amount, tab_key="recent")
 
     async def hashtag_medias_recent(self, name: str, amount: int = 27) -> List[Media]:
@@ -452,6 +482,7 @@ class HashtagMixin(ClientMixin):
         List[Media]
             List of objects of Media
         """
+        name = self._normalize_hashtag_name(name)
         try:
             medias = await self.hashtag_medias_recent_a1(name, amount)
         except ClientError:
@@ -474,6 +505,7 @@ class HashtagMixin(ClientMixin):
         List[Media]
             List of objects of Media
         """
+        name = self._normalize_hashtag_name(name)
         return await self.hashtag_medias_v1(name, amount, tab_key="clips")
 
     async def hashtag_follow(self, hashtag: str, unfollow: bool = False) -> bool:

--- a/docs/usage-guide/hashtag.md
+++ b/docs/usage-guide/hashtag.md
@@ -2,6 +2,8 @@
 
 Viewing hashtag info and medias by hashtag
 
+Pass hashtag names without the leading `#`, for example `pizza`. If a leading `#` is provided, aiograpi strips it and emits a warning; an empty hashtag name raises `ValueError`.
+
 | Method                                             | Return              | Description
 | -------------------------------------------------- | ------------------- | ---------------------------------------
 | hashtag_info(name: str)                            | Hashtag             | Return Hashtag info (id, name, picture)

--- a/tests/regression/test_hashtag.py
+++ b/tests/regression/test_hashtag.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import AsyncMock
+
+from aiograpi import Client
+
+
+class HashtagRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_hashtag_medias_recent_strips_leading_hash_and_warns(self):
+        client = Client()
+        client.hashtag_medias_recent_a1 = AsyncMock(return_value=["media"])
+
+        with self.assertWarnsRegex(UserWarning, "leading '#'"):
+            medias = await client.hashtag_medias_recent("#pizza", amount=1)
+
+        self.assertEqual(medias, ["media"])
+        client.hashtag_medias_recent_a1.assert_awaited_once_with("pizza", 1)
+
+    async def test_hashtag_name_cannot_be_empty_after_normalization(self):
+        client = Client()
+        client.hashtag_medias_recent_a1 = AsyncMock(side_effect=AssertionError("network call should not be attempted"))
+
+        with self.assertRaisesRegex(ValueError, "Hashtag name cannot be empty"):
+            await client.hashtag_medias_recent("#")


### PR DESCRIPTION
## Summary
- strip a leading `#` from hashtag name inputs and emit a warning
- reject empty hashtag names before making a request
- document the accepted hashtag name format

## Tests
- `.venv/bin/python -m pytest tests/regression/test_hashtag.py`
- `.venv/bin/ruff check aiograpi tests/regression/test_hashtag.py`