### PR TITLE
Prime upload headers after sessionid login

### DIFF
--- a/aiograpi/mixins/auth.py
+++ b/aiograpi/mixins/auth.py
@@ -516,7 +516,10 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             # ClientUnauthorizedError
             user = await self.user_short_gql(int(user_id))
         self.username = user.username
+        self.authorization_data["ds_user_id"] = str(user.pk)
         self.private.set_cookies({"ds_user_id": str(user.pk)})
+        self.private.headers.update(self.base_headers)
+        self.private.headers.update({"Authorization": self.authorization})
         return True
 
     async def login(

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -1181,6 +1181,33 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(client.username, "example")
         self.assertEqual(client.cookie_dict["ds_user_id"], "1234567890123456789")
 
+    async def test_login_by_sessionid_primes_authorization_header_for_direct_uploads(
+        self,
+    ):
+        client = Client()
+        sessionid = "1234567890123456789012345678901%3Atoken"
+        user = User(
+            pk="1234567890123456789",
+            username="example",
+            full_name="Example",
+            is_private=False,
+            profile_pic_url="https://example.com/pic.jpg",
+            is_verified=False,
+            media_count=0,
+            follower_count=0,
+            following_count=0,
+            is_business=False,
+        )
+        client.user_info_v1 = AsyncMock(return_value=user)
+        client.user_short_gql = AsyncMock()
+
+        result = await client.login_by_sessionid(sessionid)
+
+        self.assertTrue(result)
+        self.assertEqual(client.private.headers.get("IG-U-DS-USER-ID"), "1234567890123456789")
+        self.assertEqual(client.private.headers.get("IG-INTENDED-USER-ID"), "1234567890123456789")
+        self.assertEqual(client.private.headers.get("Authorization"), client.authorization)
+
     async def test_login_by_sessionid_falls_back_to_user_short_gql_on_validation_error(
         self,
     ):


### PR DESCRIPTION
## Summary
- refresh authenticated private headers after `login_by_sessionid()`
- keep `authorization_data`, `ds_user_id` cookie, and upload session headers aligned
- mirror instagrapi regression coverage for direct upload requests that bypass `private_request()`

## Tests
- `.venv/bin/python -m pytest tests/legacy.py::AuthAndStoryRegressionTestCase tests/legacy.py::UploadRegressionTestCase`
- `.venv/bin/ruff check aiograpi/mixins/auth.py tests/legacy.py`