### PR TITLE
Align social action payloads

### DIFF
--- a/aiograpi/mixins/media.py
+++ b/aiograpi/mixins/media.py
@@ -608,12 +608,19 @@ class MediaMixin(ClientMixin):
         """
         if not self.user_id:
             raise PreLoginRequired
-        media_id = self.media_pk(media_id)
+        media_id = str(media_id)
         data = {
             "inventory_source": "media_or_ad",
             "media_id": media_id,
+            "_uid": str(self.user_id),
             "radio_type": "wifi-none",
+            "delivery_class": "organic",
+            "tap_source": "button",
+            "is_2m_enabled": "false",
+            "is_from_swipe": "false",
             "is_carousel_bumped_post": "false",
+            "floating_context_items": "[]",
+            "media_pct_watched": "0",
             "container_module": "feed_timeline",
             "feed_position": str(random.randint(0, 6)),
         }

--- a/aiograpi/mixins/user.py
+++ b/aiograpi/mixins/user.py
@@ -1191,7 +1191,14 @@ class UserMixin(ClientMixin):
         if user_id in self._users_following.get(self.user_id, []):
             self.logger.debug("User %s already followed", user_id)
             return False
-        data = self.with_action_data({"user_id": user_id})
+        data = self.with_action_data(
+            {
+                "user_id": user_id,
+                "_uid": str(self.user_id),
+                "include_follow_friction_check": "1",
+                "container_module": "profile",
+            }
+        )
         result = await self.private_request(f"friendships/create/{user_id}/", data)
         if self.user_id in self._users_following:
             self._users_following.pop(self.user_id)  # reset
@@ -1213,7 +1220,13 @@ class UserMixin(ClientMixin):
         if not self.user_id:
             raise PreLoginRequired
         user_id = str(user_id)
-        data = self.with_action_data({"user_id": user_id})
+        data = self.with_action_data(
+            {
+                "user_id": user_id,
+                "_uid": str(self.user_id),
+                "container_module": "profile",
+            }
+        )
         result = await self.private_request(f"friendships/destroy/{user_id}/", data)
         if self.user_id in self._users_following:
             self._users_following[self.user_id].pop(user_id, None)

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import AsyncMock
+
+from aiograpi import Client
+
+
+class MediaActionPayloadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    def _build_logged_in_client(self):
+        client = Client()
+        client._user_id = "1"
+        client.uuid = "uuid"
+        client.android_device_id = "android-device"
+        return client
+
+    async def test_media_like_preserves_full_media_id_and_posts_current_action_context(self):
+        client = self._build_logged_in_client()
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        self.assertTrue(await client.media_like("123_456"))
+
+        endpoint, data = client.private_request.call_args.args
+        self.assertEqual(endpoint, "media/123_456/like/")
+        self.assertEqual(data["media_id"], "123_456")
+        self.assertEqual(data["_uid"], "1")
+        self.assertEqual(data["device_id"], "android-device")
+        self.assertEqual(data["radio_type"], "wifi-none")
+        self.assertEqual(data["delivery_class"], "organic")
+        self.assertEqual(data["tap_source"], "button")
+        self.assertEqual(data["is_2m_enabled"], "false")
+        self.assertEqual(data["is_from_swipe"], "false")
+        self.assertEqual(data["floating_context_items"], "[]")
+        self.assertEqual(data["media_pct_watched"], "0")
+        self.assertEqual(data["container_module"], "feed_timeline")
+        self.assertIn(data["feed_position"], {str(i) for i in range(7)})

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -13,6 +13,13 @@ class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.with_action_data = lambda data: data
         return client
 
+    def _build_action_client(self):
+        client = Client()
+        client._user_id = "1"
+        client.uuid = "uuid"
+        client.android_device_id = "android-device"
+        return client
+
     async def test_username_from_user_id_fallback_awaits_user_info(self):
         client = Client()
         client.username_from_user_id_gql = AsyncMock(side_effect=ClientError("graphql failed"))
@@ -139,3 +146,32 @@ class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result, {"1": False, "2": True})
         client.user_follow_request_decline.assert_has_awaits([unittest.mock.call("1"), unittest.mock.call("2")])
+
+    async def test_user_follow_posts_current_action_context(self):
+        client = self._build_action_client()
+        client.private_request = AsyncMock(return_value={"friendship_status": {"following": True}})
+
+        self.assertTrue(await client.user_follow("42"))
+
+        endpoint, data = client.private_request.call_args.args
+        self.assertEqual(endpoint, "friendships/create/42/")
+        self.assertEqual(data["user_id"], "42")
+        self.assertEqual(data["_uid"], "1")
+        self.assertEqual(data["device_id"], "android-device")
+        self.assertEqual(data["radio_type"], "wifi-none")
+        self.assertEqual(data["include_follow_friction_check"], "1")
+        self.assertEqual(data["container_module"], "profile")
+
+    async def test_user_unfollow_posts_current_action_context(self):
+        client = self._build_action_client()
+        client.private_request = AsyncMock(return_value={"friendship_status": {"following": False}})
+
+        self.assertTrue(await client.user_unfollow("42"))
+
+        endpoint, data = client.private_request.call_args.args
+        self.assertEqual(endpoint, "friendships/destroy/42/")
+        self.assertEqual(data["user_id"], "42")
+        self.assertEqual(data["_uid"], "1")
+        self.assertEqual(data["device_id"], "android-device")
+        self.assertEqual(data["radio_type"], "wifi-none")
+        self.assertEqual(data["container_module"], "profile")


### PR DESCRIPTION
## Summary
- Mirror the instagrapi social action payload alignment for async `media_like` / `media_unlike` and `user_follow` / `user_unfollow`.
- Preserve full media IDs when callers pass them to media like/unlike.
- Add async regression coverage for the current action-context payloads.

Mirrors subzeroid/instagrapi#2526.

## Test Plan
- `pytest -q tests/regression`
- `ruff check aiograpi/mixins/media.py aiograpi/mixins/user.py tests/regression/test_media.py tests/regression/test_user.py`
- `git diff --check`
- Targeted async live smoke: media like/unlike and user follow/unfollow
