### PR TITLE
Document sessionid login limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ cl = Client()
 await cl.login_by_sessionid("<your_sessionid>")
 ```
 
-`login_by_sessionid()` is a lightweight compatibility path. For long-lived
-automation prefer the regular `login()` → `dump_settings()` →
-`load_settings()` / `set_settings()` flow.
+`login_by_sessionid()` is a lightweight compatibility path. For long-lived automation prefer the regular `login()` → `dump_settings()` → `load_settings()` / `set_settings()` flow.
+
+If a browser/web `sessionid` returns `login_required` or logs the browser out, Instagram rejected that session for the private mobile API. Use a stable password login once, save settings with `dump_settings()`, and reuse those settings instead of repeatedly importing browser cookies.
 
 ### Typical Tasks
 

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -67,9 +67,11 @@ We recommend using [these proxies](https://soax.com/?r=sEysufQI)
 | login(username: str, password: str)  | bool    | Login by username and password (get new cookies if it does not exist in settings)
 | login(username: str, password: str, verification\_code: str) | bool | Login by username and password with 2FA verification code (use Google Authenticator or something similar to generate TOTP code, not work with SMS)
 | relogin()                            | bool    | Re-login with clean cookies (required cl.username and cl.password)
-| login\_by\_sessionid(sessionid: str) | bool    | Login by sessionid from Instagram site
+| login\_by\_sessionid(sessionid: str) | bool    | Lightweight compatibility login using a session cookie value
 | inject\_sessionid\_to\_public()      | bool    | Inject sessionid from Private Session to Public Session
 | logout()                             | bool    | Logout
+
+`login_by_sessionid()` only works when Instagram accepts that `sessionid` for the private mobile API. A browser/web `sessionid` can be rejected with `login_required` or invalidated server-side; for long-lived automation, prefer `login()` once, then `dump_settings()` and reuse the saved settings.
 
 You can pass settings to the Client (and save cookies), it has the following format:
 

--- a/tests/live/smoke.py
+++ b/tests/live/smoke.py
@@ -92,6 +92,21 @@ async def main():
     if cl is None:
         failures.append(("login", "all pool accounts unusable"))
     else:
+        try:
+            if not cl.sessionid:
+                raise RuntimeError("logged-in client did not expose sessionid")
+            by_session = Client()
+            proxy = getattr(cl, "proxy", None)
+            if isinstance(proxy, str) and proxy:
+                by_session.set_proxy(proxy)
+            await by_session.login_by_sessionid(cl.sessionid)
+            account = await by_session.account_info()
+            assert str(account.pk) == str(cl.user_id)
+            await by_session.get_timeline_feed("cold_start_fetch")
+            print("REQ sessionid_login: account_info/timeline")
+        except Exception as e:
+            failures.append(("sessionid_login", f"{type(e).__name__}: {str(e)[:140]}"))
+
         for name, fn in [
             ("private_v1", lambda: cl.user_info_by_username_v1("instagram")),
             ("private_v2_gql", lambda: cl.user_info_by_username_v2_gql("instagram")),

--- a/tests/regression/test_live_smoke.py
+++ b/tests/regression/test_live_smoke.py
@@ -16,6 +16,18 @@ def _load_live_smoke_module():
 
 class _FakeLiveClient:
     user_id = "1"
+    sessionid = "1%3Asession"
+    proxy = None
+
+    async def login_by_sessionid(self, sessionid):
+        self.sessionid = sessionid
+        return True
+
+    async def account_info(self):
+        return types.SimpleNamespace(pk=self.user_id)
+
+    async def get_timeline_feed(self, reason="cold_start_fetch"):
+        return {"reason": reason}
 
     async def user_info_by_username_gql(self, username):
         raise RuntimeError("429 Too Many Requests")


### PR DESCRIPTION
## Summary
- clarify that login_by_sessionid only works when Instagram accepts the session for private mobile API calls
- document browser/web sessionid login_required and invalidation behavior
- add a targeted sessionid_login check to the live smoke path

## Verification
- .venv/bin/python -m ruff check README.md docs/usage-guide/interactions.md tests/live/smoke.py
- .venv/bin/python -m mkdocs build --strict
- sk.test targeted sessionid live script: password login, login_by_sessionid, account_info, timeline all passed

Note: full aiograpi smoke also reached and passed REQ sessionid_login, then failed on an unrelated existing required user_short_gql web GraphQL 429.