### PR TITLE
Support submit_phone login challenge

### DIFF
--- a/aiograpi/mixins/challenge.py
+++ b/aiograpi/mixins/challenge.py
@@ -462,8 +462,16 @@ class ChallengeResolveMixin(ClientMixin):
                 },
             )
             return True
-        elif step_name in ("verify_email", "verify_email_code", "select_verify_method"):
-            choice = ChallengeChoice.EMAIL
+        elif step_name in (
+            "verify_email",
+            "verify_email_code",
+            "verify_phone",
+            "verify_phone_code",
+            "verify_sms",
+            "verify_sms_code",
+            "select_verify_method",
+        ):
+            choice = ChallengeChoice.SMS if "phone" in step_name or "sms" in step_name else ChallengeChoice.EMAIL
             if step_name == "select_verify_method":
                 """
                 {'step_name': 'select_verify_method',
@@ -503,6 +511,18 @@ class ChallengeResolveMixin(ClientMixin):
             assert self.last_json.get("action", "") == "close"
             assert self.last_json.get("status", "") == "ok"
             return True
+        elif step_name == "submit_phone":
+            phone_number = getattr(self, "phone_number", None)
+            if not phone_number:
+                raise ChallengeRequired(
+                    "Phone number required to continue submit_phone challenge. "
+                    "Set client.phone_number or complete the flow manually.",
+                    **{key: value for key, value in self.last_json.items() if key != "message"},
+                )
+            await self._send_private_request(challenge_url, {"phone_number": phone_number})
+            if self.last_json.get("step_name") == step_name:
+                raise ChallengeError(f"submit_phone challenge did not advance after phone submission: {self.last_json}")
+            return await self.challenge_resolve_simple(challenge_url)
         elif step_name == "":
             assert self.last_json.get("action", "") == "close"
             assert self.last_json.get("status", "") == "ok"

--- a/docs/usage-guide/challenge_resolver.md
+++ b/docs/usage-guide/challenge_resolver.md
@@ -36,10 +36,12 @@ async def challenge_code_handler(username, choice):
     return False
 
 cl = Client()
+cl.phone_number = "+15551234567"  # required for submit_phone challenges
 cl.challenge_code_handler = challenge_code_handler
 await cl.login(IG_USERNAME, IG_PASSWORD)
 ```
 
+Login `submit_phone` challenges use `client.phone_number`, then call `challenge_code_handler(username, ChallengeChoice.SMS)` for the received code.
 Signup SMS challenges use the `phone_number` passed to `signup(...)` and call `challenge_code_handler(username, ChallengeChoice.SMS)` for the received code.
 
 For example, you can get the code through the IMAP of Gmail:

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -53,6 +53,7 @@ from aiograpi.extractors import (
     extract_resource_v1,
     extract_story_v1,
 )
+from aiograpi.mixins.challenge import ChallengeChoice
 from aiograpi.mixins.user import UserMixin
 from aiograpi.story import StoryBuilder
 from aiograpi.types import (
@@ -954,6 +955,70 @@ class ChallengeRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             await client.challenge_resolve_simple("/challenge/test/")
 
         self.assertIn("Unexpected final challenge step", str(cm.exception))
+
+    async def test_challenge_resolve_simple_submit_phone_posts_number_then_sms_code(
+        self,
+    ):
+        client = Client()
+        client.username = "example"
+        client.phone_number = "+15551234567"
+        client.last_json = {
+            "step_name": "submit_phone",
+            "step_data": {"phone_number": "+1 *** *** 4567"},
+            "challenge_context": "{}",
+            "status": "ok",
+        }
+
+        async def fake_send_private_request(endpoint, data):
+            if "phone_number" in data:
+                client.last_json = {
+                    "step_name": "verify_phone",
+                    "step_data": {"phone_number": "+1 *** *** 4567"},
+                    "challenge_context": "{}",
+                    "status": "ok",
+                }
+            elif "security_code" in data:
+                client.last_json = {"action": "close", "status": "ok"}
+
+        client._send_private_request = AsyncMock(side_effect=fake_send_private_request)
+        client.challenge_code_or_raised = AsyncMock(return_value="123456")
+
+        result = await client.challenge_resolve_simple("/challenge/test/")
+
+        self.assertTrue(result)
+        self.assertEqual(
+            client._send_private_request.call_args_list[0].args,
+            ("/challenge/test/", {"phone_number": "+15551234567"}),
+        )
+        client.challenge_code_or_raised.assert_called_once_with(
+            ChallengeChoice.SMS,
+            wait_seconds=5,
+            attempts=24,
+            challenge_url="/challenge/test/",
+            sessionid=client.sessionid,
+        )
+        self.assertEqual(
+            client._send_private_request.call_args_list[1].args,
+            ("/challenge/test/", {"security_code": "123456"}),
+        )
+
+    async def test_challenge_resolve_simple_submit_phone_requires_configured_phone_number(
+        self,
+    ):
+        client = Client()
+        client.username = "example"
+        client.phone_number = None
+        client.last_json = {
+            "step_name": "submit_phone",
+            "step_data": {"phone_number": "+1 *** *** 4567"},
+            "challenge_context": "{}",
+            "status": "ok",
+        }
+
+        with self.assertRaises(ChallengeRequired) as cm:
+            await client.challenge_resolve_simple("/challenge/test/")
+
+        self.assertIn("Phone number required", str(cm.exception))
 
     @unittest.skip(_CONTACT_FORM_SKIP_REASON)
     def test_challenge_resolve_contact_form_raises_clear_error_for_unexpected_verify_step(


### PR DESCRIPTION
## Summary
- handle login challenge `submit_phone` by submitting `client.phone_number`
- continue phone/SMS verify steps through the configured challenge code handler
- document `client.phone_number` usage and cover the flow with regression tests

Mirrors subzeroid/instagrapi#2537.

## Tests
- `.venv/bin/python -m pytest tests/legacy.py::ChallengeRegressionTestCase -q`
- `.venv/bin/python -m pytest tests/legacy.py::SignUpTestCase -q`
- `.venv/bin/python -m ruff check aiograpi tests`
- `.venv/bin/python -m ruff format --check aiograpi tests`
- `.venv/bin/python -m pytest -sv tests/legacy.py::ExtractorsRegressionTestCase tests/legacy.py::ImageUtilSafeRemoteFetchTestCase tests/legacy.py::DirectExtractorRegressionTestCase tests/legacy.py::PublicRegressionTestCase tests/legacy.py::PolarisProfileNormalizationTestCase tests/legacy.py::CaptchaHandlerMixinRegressionTestCase tests/legacy.py::NoteMixinRegressionTestCase tests/legacy.py::LocationMixinRegressionTestCase tests/legacy.py::ChallengeRegressionTestCase tests/legacy.py::AuthAndStoryRegressionTestCase tests/legacy.py::ClientTestCase tests/legacy.py::DownloadRegressionTestCase tests/legacy.py::DirectMixinRegressionTestCase tests/legacy.py::UserMixinRegressionTestCase tests/legacy.py::TimelineRegressionTestCase tests/legacy.py::StoryConfigureRegressionTestCase tests/legacy.py::UploadRegressionTestCase tests/legacy.py::SignUpTestCase tests/legacy.py::NotificationMixinRegressionTestCase tests/legacy.py::ChapiPortedRegressionTestCase tests/regression`
- `./scripts/check-mypy-baseline.sh`
- `.venv/bin/python -m mkdocs build --strict`
- `.venv/bin/python -m build`