### PR TITLE
Refresh media comment action payload

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,6 +7,17 @@ on:
   push:
     branches: [ "main" ]
   pull_request: {}
+  workflow_dispatch:
+    inputs:
+      test_target:
+        description: "Live target to run"
+        required: false
+        default: "smoke"
+        type: choice
+        options:
+          - smoke
+          - comment
+          - all
 
 env:
   PYTHON_VERSION: "3.13.5"
@@ -129,7 +140,7 @@ jobs:
     # Live IG tests via pooled accounts. Only on canonical-repo pushes
     # — PRs from forks don't have access to the TEST_ACCOUNTS_URL secret.
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.repository == 'subzeroid/aiograpi'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.repository == 'subzeroid/aiograpi'
     strategy:
       matrix:
         python-version: [ "3.10" ]
@@ -146,6 +157,7 @@ jobs:
         with:
           test: "true"
       - name: Run end-to-end smoke
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.test_target == 'smoke' || github.event.inputs.test_target == 'all'
         # Required: login(TOTP) + private_v1 + private_v2_gql +
         # user_short_gql + hashtag_info_v1 + user_medias_v1 +
         # user_medias_gql + user_followers + highlight_info.
@@ -163,6 +175,14 @@ jobs:
         # by the unit-test job; user_followers and highlight_info are
         # covered by the smoke above.
         run: PYTHONPATH=. python tests/live/smoke.py
+      - name: Run comment write test
+        if: github.event_name == 'workflow_dispatch' && (github.event.inputs.test_target == 'comment' || github.event.inputs.test_target == 'all')
+        run: |
+          if [ -z "${TEST_ACCOUNTS_URL}" ]; then
+            echo "SKIP: TEST_ACCOUNTS_URL secret is not configured"
+            exit 0
+          fi
+          PYTHONPATH=. pytest -sv tests/legacy.py::ClientCommentExtendTestCase::test_media_comment
 
   build-docs:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ starting with 1.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Mirrored the current `media_comment()` write payload from `instagrapi`,
+  including feed action context fields used by recent app requests.
+- Fixed pooled live account URL construction so an existing `count` query
+  parameter is overridden instead of duplicated.
+
+### Changed
+
+- Added a manual live workflow target for comment writes and updated the live
+  comment test to upload/read back/cleanup its own media fixture.
+- Documented that comment creation is still an Instagram trust-checked write
+  action even with current request metadata.
+
 ## [1.0.3] - 2026-05-19
 
 ### Fixed

--- a/aiograpi/mixins/comment.py
+++ b/aiograpi/mixins/comment.py
@@ -574,8 +574,16 @@ class CommentMixin(ClientMixin):
             raise PreLoginRequired
         data = {
             "delivery_class": "organic",
-            "feed_position": "0",
-            "container_module": "self_comments_v2_feed_contextual_self_profile",
+            "feed_position": str(random.randint(0, 6)),
+            "container_module": "feed_timeline",
+            "media_id": media_id,
+            "_uid": str(self.user_id),
+            "tap_source": "button",
+            "is_2m_enabled": "false",
+            "is_carousel_bumped_post": "false",
+            "is_from_swipe": "false",
+            "floating_context_items": "[]",
+            "media_pct_watched": "0",
             "user_breadcrumb": self.gen_user_breadcrumb(len(text)),
             "idempotence_token": self.generate_uuid(),
             "comment_text": text,

--- a/docs/usage-guide/comment.md
+++ b/docs/usage-guide/comment.md
@@ -2,6 +2,10 @@
 
 Post comment, viewing, like and unlike comments
 
+Comment creation is a write action and can still trigger Instagram spam or
+trust checks. Reuse saved sessions, keep volume low on new accounts, and stop
+when Instagram returns feedback/challenge responses.
+
 | Method                                                                                  | Return             | Description
 | --------------------------------------------------------------------------------------- | ------------------ | --------------------------
 | media_comment(media_id: str, text: str, replied_to_comment_id: Optional[int] = None) | Comment            | Add new comment to media

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -159,7 +159,7 @@ class ClientPrivateTestCase(BaseClientMixin, unittest.IsolatedAsyncioTestCase):
             self.skipTest("TEST_ACCOUNTS_URL not configured")
         parts = urlsplit(TEST_ACCOUNTS_URL)
         query = dict(parse_qsl(parts.query, keep_blank_values=True))
-        query.setdefault("count", "5")
+        query["count"] = "5"
         return urlunsplit(
             (
                 parts.scheme,
@@ -242,6 +242,30 @@ class ClientPrivateTestCase(BaseClientMixin, unittest.IsolatedAsyncioTestCase):
         else:
             await self.cl.login(ACCOUNT_USERNAME, ACCOUNT_PASSWORD, relogin=True)
         self.cl.dump_settings(filename)
+
+    def copy_media_fixture(self, filename):
+        fd, temp_path = tempfile.mkstemp(suffix=Path(filename).suffix)
+        os.close(fd)
+        path = Path(temp_path)
+        path.write_bytes(Path(filename).read_bytes())
+        return path
+
+    async def assertUploadedMediaAccessible(self, media, media_type=None, caption_text=None, attempts=5, delay=3):
+        last_error = None
+        for attempt in range(attempts):
+            if attempt:
+                await asyncio.sleep(delay)
+            try:
+                info = await self.cl.media_info_v1(media.id)
+            except Exception as exc:
+                last_error = exc
+                continue
+            if media_type is not None:
+                self.assertEqual(info.media_type, media_type)
+            if caption_text is not None:
+                self.assertEqual(info.caption_text, caption_text)
+            return info
+        self.fail(f"Media {media.id} was not readable after {attempts} attempts: {last_error}")
 
 
 class ClientPublicTestCase(BaseClientMixin, unittest.IsolatedAsyncioTestCase):
@@ -2117,11 +2141,47 @@ class ClientCommentTestCase(ClientPrivateTestCase):
 
 
 class ClientCommentExtendTestCase(ClientPrivateTestCase):
+    async def cleanup_comment(self, media_id, comment_pk):
+        try:
+            await self.cl.comment_bulk_delete(media_id, [comment_pk])
+        except Exception as exc:
+            print(f"Comment live cleanup comment_bulk_delete failed: {exc.__class__.__name__} {exc}")
+
+    async def cleanup_media(self, media_id):
+        try:
+            await self.cl.media_delete(media_id)
+        except Exception as exc:
+            print(f"Comment live cleanup media_delete failed: {exc.__class__.__name__} {exc}")
+
+    async def assertCommentAccessible(self, media_id, comment_pk, text, attempts=5, delay=3):
+        last_error = None
+        for attempt in range(attempts):
+            if attempt:
+                await asyncio.sleep(delay)
+            try:
+                comments = await self.cl.media_comments_v1(media_id, amount=20)
+            except Exception as exc:
+                last_error = exc
+                continue
+            for item in comments:
+                if str(item.pk) == str(comment_pk) and item.text == text:
+                    return item
+        self.fail(f"Comment {comment_pk} was not readable after {attempts} attempts: {last_error}")
+
     async def test_media_comment(self):
         text = "Test text [%s]" % datetime.now().strftime("%s")
         now = datetime.now(tz=UTC())
-        comment = self.cl.media_comment_v1(2276404890775267248, text)
+        caption_text = "Comment live fixture [%s]" % datetime.now().strftime("%s")
+        path = self.copy_media_fixture("examples/kanada.jpg")
+        self.addCleanup(cleanup, path)
+        media = await self.cl.photo_upload(path, caption_text)
+        self.addAsyncCleanup(self.cleanup_media, media.id)
+        await self.assertUploadedMediaAccessible(media, media_type=1, caption_text=caption_text)
+        media_id = media.id
+        comment = await self.cl.media_comment(media_id, text)
+        self.addAsyncCleanup(self.cleanup_comment, media_id, comment.pk)
         self.assertIsInstance(comment, Comment)
+        await self.assertCommentAccessible(media_id, comment.pk, text)
         comment = comment.dict()
         for key, val in {
             "text": text,

--- a/tests/live/smoke.py
+++ b/tests/live/smoke.py
@@ -17,14 +17,18 @@ import ssl
 import sys
 import urllib.request
 import uuid
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from aiograpi import Client
 
 
 async def _fetch_accounts(url, count=10):
-    sep = "&" if "?" in url else "?"
+    parts = urlsplit(url)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query["count"] = str(count)
+    url = urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
     req = urllib.request.Request(
-        url + sep + f"count={count}",
+        url,
         headers={"User-Agent": "Mozilla/5.0 aiograpi-smoke"},
     )
     with urllib.request.urlopen(req, context=ssl._create_unverified_context()) as r:

--- a/tests/regression/test_comments.py
+++ b/tests/regression/test_comments.py
@@ -6,6 +6,12 @@ from aiograpi.types import Comment
 
 
 class CommentRepliesRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    def _build_logged_in_client(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "1"}
+        client.android_device_id = "android-device"
+        return client
+
     def _reply_payload(self, pk, text="reply", replied_to_comment_id="100"):
         return {
             "pk": str(pk),
@@ -18,6 +24,35 @@ class CommentRepliesRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             "has_liked_comment": False,
             "comment_like_count": 0,
         }
+
+    async def test_media_comment_posts_current_action_context(self):
+        client = self._build_logged_in_client()
+        expected_comment = self._reply_payload("101", text="hello")
+        client.private_request = AsyncMock(return_value={"comment": expected_comment})
+
+        comment = await client.media_comment("123_456", "hello", replied_to_comment_id=100)
+
+        self.assertIsInstance(comment, Comment)
+        endpoint, data = client.private_request.await_args.args
+        self.assertEqual(endpoint, "media/123_456/comment/")
+        self.assertEqual(data["media_id"], "123_456")
+        self.assertEqual(data["_uid"], "1")
+        self.assertEqual(data["_uuid"], client.uuid)
+        self.assertEqual(data["device_id"], "android-device")
+        self.assertEqual(data["radio_type"], "wifi-none")
+        self.assertEqual(data["delivery_class"], "organic")
+        self.assertEqual(data["tap_source"], "button")
+        self.assertEqual(data["is_2m_enabled"], "false")
+        self.assertEqual(data["is_carousel_bumped_post"], "false")
+        self.assertEqual(data["is_from_swipe"], "false")
+        self.assertEqual(data["floating_context_items"], "[]")
+        self.assertEqual(data["media_pct_watched"], "0")
+        self.assertEqual(data["container_module"], "feed_timeline")
+        self.assertIn(data["feed_position"], {str(i) for i in range(7)})
+        self.assertEqual(data["comment_text"], "hello")
+        self.assertEqual(data["replied_to_comment_id"], 100)
+        self.assertIn("user_breadcrumb", data)
+        self.assertIn("idempotence_token", data)
 
     async def test_media_comments_chunk_fetches_private_comments_page(self):
         client = Client()

--- a/tests/regression/test_live_smoke.py
+++ b/tests/regression/test_live_smoke.py
@@ -4,6 +4,7 @@ import types
 import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qs, urlsplit
 
 
 def _load_live_smoke_module():
@@ -64,6 +65,31 @@ class _FakeLiveClient:
 
 
 class LiveSmokeRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_fetch_accounts_overrides_existing_default_count(self):
+        smoke = _load_live_smoke_module()
+        captured = {}
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self):
+                return b"[]"
+
+        def fake_urlopen(req, context=None):
+            captured["url"] = req.full_url
+            return FakeResponse()
+
+        with patch.object(smoke.urllib.request, "urlopen", side_effect=fake_urlopen):
+            await smoke._fetch_accounts("https://example.test/accounts?count=1&token=abc")
+
+        query = parse_qs(urlsplit(captured["url"]).query)
+        self.assertEqual(query["count"], ["10"])
+        self.assertEqual(query["token"], ["abc"])
+
     async def test_anonymous_public_lookup_throttle_does_not_fail_smoke(self):
         smoke = _load_live_smoke_module()
         fake_logged_client = _FakeLiveClient()


### PR DESCRIPTION
## Summary
- mirror the current `media_comment()` write payload from `instagrapi`, including feed action context fields
- fix pooled live account URL construction so an existing `count` query param is overridden instead of duplicated
- add regression coverage for async comment payload and live account URL construction
- add a manual `comment` live workflow target and update the live comment test to upload/read back/cleanup its own media fixture
- document that comment creation remains a write action subject to Instagram spam/trust checks

Mirrors subzeroid/instagrapi#2538.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_comments.py::CommentRepliesRegressionTestCase::test_media_comment_posts_current_action_context tests/regression/test_live_smoke.py::LiveSmokeRegressionTestCase::test_fetch_accounts_overrides_existing_default_count -q`
- `.venv/bin/python -m pytest tests/regression/test_comments.py tests/regression/test_live_smoke.py -q`
- `.venv/bin/python -m ruff check aiograpi tests`
- `.venv/bin/python -m ruff format --check aiograpi tests`
- `.venv/bin/python -m pytest -sv tests/legacy.py::ExtractorsRegressionTestCase tests/legacy.py::ImageUtilSafeRemoteFetchTestCase tests/legacy.py::DirectExtractorRegressionTestCase tests/legacy.py::PublicRegressionTestCase tests/legacy.py::PolarisProfileNormalizationTestCase tests/legacy.py::CaptchaHandlerMixinRegressionTestCase tests/legacy.py::NoteMixinRegressionTestCase tests/legacy.py::LocationMixinRegressionTestCase tests/legacy.py::ChallengeRegressionTestCase tests/legacy.py::AuthAndStoryRegressionTestCase tests/legacy.py::ClientTestCase tests/legacy.py::DownloadRegressionTestCase tests/legacy.py::DirectMixinRegressionTestCase tests/legacy.py::UserMixinRegressionTestCase tests/legacy.py::TimelineRegressionTestCase tests/legacy.py::StoryConfigureRegressionTestCase tests/legacy.py::UploadRegressionTestCase tests/legacy.py::SignUpTestCase tests/legacy.py::NotificationMixinRegressionTestCase tests/legacy.py::ChapiPortedRegressionTestCase tests/regression`
- `.venv/bin/python -m mkdocs build --strict`
- `./scripts/check-mypy-baseline.sh`
- `.venv/bin/python -m build`

## Live verification
- Local `tests/legacy.py::ClientCommentExtendTestCase::test_media_comment` did not reach the comment endpoint because account setup failed on proxy `302 Found` during `launcher/sync/`.
- Manual GitHub workflow target now handles missing `TEST_ACCOUNTS_URL` as an explicit skip instead of falling back to dummy credentials: https://github.com/subzeroid/aiograpi/actions/runs/26125558847
- Real comment-write live verification passed in the upstream sync PR for `instagrapi`: https://github.com/subzeroid/instagrapi/actions/runs/26124367512