### PR TITLE
Bump version to 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ starting with 1.0.0.
 
 ## [Unreleased]
 
+## [1.0.5] - 2026-05-20
+
 ### Added
 
 - Added automatic async Bloks two-factor login fallback for
   `Client.login(..., verification_code=...)` when Instagram provides
   `two_step_verification_context`.
+
+### Changed
+
+- Synced the recorded upstream baseline to `instagrapi` 2.7.5.
 
 ## [1.0.4] - 2026-05-20
 
@@ -1417,6 +1423,7 @@ for incremental changes since 0.0.3.
 
 Initial release.
 
+[1.0.5]: https://github.com/subzeroid/aiograpi/releases/tag/1.0.5
 [1.0.4]: https://github.com/subzeroid/aiograpi/releases/tag/1.0.4
 [1.0.3]: https://github.com/subzeroid/aiograpi/releases/tag/1.0.3
 [1.0.2]: https://github.com/subzeroid/aiograpi/releases/tag/1.0.2

--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -45,7 +45,7 @@ from aiograpi.mixins.video import DownloadVideoMixin, UploadVideoMixin
 # Used as fallback logger if another is not provided.
 DEFAULT_LOGGER = logging.getLogger("aiograpi")
 
-__upstream_instagrapi_version__ = "2.7.4"
+__upstream_instagrapi_version__ = "2.7.5"
 
 
 class Client(

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -7,15 +7,15 @@ ported through.
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.7.4
+instagrapi 2.7.5
 ```
 
-`aiograpi 1.0.4` includes the video dependency split, MoviePy 2 helper migration, Reel Facebook cross-post payload
+`aiograpi 1.0.5` includes the video dependency split, MoviePy 2 helper migration, Reel Facebook cross-post payload
 follow-up, client TLS verification setting, public A1 API removal, current flow request metadata alignment, and social
 action payload updates from `instagrapi` through 2.7.1, the async Direct/music/signup sync through 2.7.2, and the story
 upload read-back fallback from 2.7.3. It also includes the submit-phone challenge step, refreshed comment action
 metadata, upload read-back/live-test hardening, Reel music live read-back verification, and low-level Bloks two-factor
-helpers from 2.7.4.
+helpers from 2.7.4, plus the automatic Bloks two-factor login fallback from 2.7.5.
 
 ## Release policy
 
@@ -26,7 +26,7 @@ helpers from 2.7.4.
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
 `aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent
 `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance
-ports. `aiograpi 1.0.4` records the current SemVer baseline synced through `instagrapi 2.7.4`.
+ports. `aiograpi 1.0.5` records the current SemVer baseline synced through `instagrapi 2.7.5`.
 
 ## Porting rules
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.0.4"
+version = "1.0.5"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -2,4 +2,4 @@ import aiograpi
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.7.4"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.7.5"


### PR DESCRIPTION
## Summary
- bump aiograpi package version to 1.0.5
- record upstream instagrapi baseline 2.7.5
- move Bloks login fallback changelog entry into the 1.0.5 release section

## Tests
- .venv/bin/ruff check --fix pyproject.toml aiograpi/__init__.py tests/regression/test_upstream_sync.py docs/upstream-sync.md CHANGELOG.md
- ./scripts/check-mypy-baseline.sh
- .venv/bin/python -m pytest tests/regression/test_upstream_sync.py tests/legacy.py::AuthAndStoryRegressionTestCase tests/regression/test_bloks.py -q
- .venv/bin/mkdocs build --strict