### PR TITLE
Bump version to 1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ starting with 1.0.0.
 
 ## [Unreleased]
 
+## [1.0.6] - 2026-05-20
+
+### Added
+
+- Added automatic async CAA/Bloks login fallback for
+  `Client.login(..., verification_code=...)` when legacy login does not expose
+  `two_step_verification_context` directly.
+- Added low-level async helpers for inspecting CAA/Bloks login responses and
+  extracting the returned two-factor context.
+
+### Changed
+
+- Synced the recorded upstream baseline to `instagrapi` 2.7.6.
+
 ## [1.0.5] - 2026-05-20
 
 ### Added
@@ -1423,6 +1437,7 @@ for incremental changes since 0.0.3.
 
 Initial release.
 
+[1.0.6]: https://github.com/subzeroid/aiograpi/releases/tag/1.0.6
 [1.0.5]: https://github.com/subzeroid/aiograpi/releases/tag/1.0.5
 [1.0.4]: https://github.com/subzeroid/aiograpi/releases/tag/1.0.4
 [1.0.3]: https://github.com/subzeroid/aiograpi/releases/tag/1.0.3

--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -45,7 +45,7 @@ from aiograpi.mixins.video import DownloadVideoMixin, UploadVideoMixin
 # Used as fallback logger if another is not provided.
 DEFAULT_LOGGER = logging.getLogger("aiograpi")
 
-__upstream_instagrapi_version__ = "2.7.5"
+__upstream_instagrapi_version__ = "2.7.6"
 
 
 class Client(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.0.5"
+version = "1.0.6"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -2,4 +2,4 @@ import aiograpi
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.7.5"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.7.6"


### PR DESCRIPTION
## Summary
- bump package version to 1.0.6
- record upstream baseline as instagrapi 2.7.6
- update changelog for the CAA/Bloks login fallback mirror

## Tests
- git diff --check
- PYTHONPATH=$PWD .venv/bin/pytest tests/regression/test_bloks.py tests/regression/test_auth.py -q