### PR TITLE
Bump version to 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ starting with 1.0.0.
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-05-20
+
+### Added
+
+- Added async Bloks backup-code support for
+  `Client.login(..., verification_code=...)`, including 8-digit codes copied as
+  `1234 5678`.
+- Added `bloks_two_step_verification_enter_backup_code(...)` for manual
+  backup-code verification flows.
+
+### Changed
+
+- Synced the recorded upstream baseline to `instagrapi` 2.7.7.
+
 ## [1.0.6] - 2026-05-20
 
 ### Added
@@ -1437,6 +1451,7 @@ for incremental changes since 0.0.3.
 
 Initial release.
 
+[1.0.7]: https://github.com/subzeroid/aiograpi/releases/tag/1.0.7
 [1.0.6]: https://github.com/subzeroid/aiograpi/releases/tag/1.0.6
 [1.0.5]: https://github.com/subzeroid/aiograpi/releases/tag/1.0.5
 [1.0.4]: https://github.com/subzeroid/aiograpi/releases/tag/1.0.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.0.6"
+version = "1.0.7"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]


### PR DESCRIPTION
## Summary
- bump package version to 1.0.7
- add changelog notes for async backup-code 2FA support

## Tests
- `PYTHONPATH=$PWD .venv/bin/pytest tests/regression/test_auth.py tests/regression/test_bloks.py -q`
- `PYTHONPATH=$PWD .venv/bin/ruff check pyproject.toml CHANGELOG.md aiograpi/mixins/auth.py aiograpi/mixins/bloks.py aiograpi/mixins/base.py tests/regression/test_auth.py tests/regression/test_bloks.py`