### PR TITLE
Add email confirmation code helper

### DIFF
--- a/aiograpi/mixins/account.py
+++ b/aiograpi/mixins/account.py
@@ -333,6 +333,26 @@ class AccountMixin(ClientMixin):
             self.with_extra_data({"send_source": "personal_information", "email": email}),
         )
 
+    async def confirm_email(self, email: str, code: str) -> dict:
+        """
+        Confirm new email address by code
+
+        Parameters
+        ----------
+        email: str
+            Email address
+        code: str
+            Confirmation code
+
+        Returns
+        -------
+        dict
+        """
+        return await self.private_request(
+            "accounts/verify_email_code/",
+            self.with_extra_data({"email": email, "code": code}),
+        )
+
     async def send_confirm_phone_number(self, phone_number: str) -> dict:
         """
         Send confirmation code to new phone number

--- a/docs/usage-guide/account.md
+++ b/docs/usage-guide/account.md
@@ -8,6 +8,7 @@ Viewing and managing your profile
 | account_edit(email: str, phone_number: str, username: str, full_name: str, biography: str, external_url: str) | Account | Change profile data
 | account_change_picture(path: Path)           | UserShort | Change Profile picture
 | send_confirm_email(email: str)               | dict      | Send confirmation code to new email address
+| confirm_email(email: str, code: str)         | dict      | Confirm a new email address with the received code
 | send_confirm_phone_number(phone_number: str) | dict      | Send confirmation code to new phone number
 
 Example:
@@ -51,6 +52,9 @@ UserShort(pk=1903424587, username='example', ...)
     'error_type': 'email_unchanged',
     'status': 'ok'
 }
+
+>>> await cl.confirm_email("addr@example.com", "123456")
+{'status': 'ok'}
 
 >>> await cl.send_confirm_phone_number("+5599999999")
 {

--- a/tests/regression/test_account.py
+++ b/tests/regression/test_account.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import AsyncMock
+
+from aiograpi import Client
+
+
+class AccountRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_confirm_email_posts_verify_email_code_payload(self):
+        client = Client()
+        client.phone_id = "phone-id"
+        client.authorization_data = {"ds_user_id": "123"}
+        client.uuid = "uuid"
+        client.android_device_id = "android-id"
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        result = await client.confirm_email("addr@example.com", "123456")
+
+        self.assertEqual(result, {"status": "ok"})
+        client.private_request.assert_awaited_once_with(
+            "accounts/verify_email_code/",
+            {
+                "_uuid": "uuid",
+                "device_id": "android-id",
+                "phone_id": "phone-id",
+                "_uid": "123",
+                "guid": "uuid",
+                "email": "addr@example.com",
+                "code": "123456",
+            },
+        )


### PR DESCRIPTION
## Summary
- add async `confirm_email(email, code)` for profile email code verification
- use the Android 428 `accounts/verify_email_code/` endpoint with standard device payload
- document the new flow next to `send_confirm_email`

Mirrors subzeroid/instagrapi#2548.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_account.py -q`
- `.venv/bin/python -m ruff check aiograpi/mixins/account.py tests/regression/test_account.py`
- `.venv/bin/python -m ruff format --check aiograpi/mixins/account.py tests/regression/test_account.py`
- `git diff --check`
