### PR TITLE
Clarify legacy signup spam rejection

### DIFF
--- a/aiograpi/exceptions.py
+++ b/aiograpi/exceptions.py
@@ -106,6 +106,10 @@ class FeedbackRequired(PrivateError):
     pass
 
 
+class SignupSpamError(FeedbackRequired):
+    """Raised when Instagram rejects the legacy signup flow as spam."""
+
+
 class ChallengeError(PrivateError):
     pass
 

--- a/aiograpi/mixins/signup.py
+++ b/aiograpi/mixins/signup.py
@@ -15,7 +15,9 @@ from aiograpi.exceptions import (
     EmailInvalidError,
     EmailNotAvailableError,
     EmailVerificationSendError,
+    FeedbackRequired,
     InvalidNonce,
+    SignupSpamError,
 )
 from aiograpi.extractors import extract_user_short
 from aiograpi.mixins.base import ClientMixin
@@ -209,7 +211,6 @@ class SignUpMixin(ClientMixin):
         self.username = username
         self.password = password
         data = {
-            "is_secondary_account_creation": "true",
             "jazoest": str(random.randint(22300, 22399)),
             "tos_version": "row",
             "suggestedUsername": "",
@@ -252,17 +253,27 @@ class SignUpMixin(ClientMixin):
             nonce_bytes = secrets.token_bytes(24)
             nonce = f"{phone_number}|{timestamp}|".encode() + nonce_bytes
             sn_nonce = base64.encodebytes(nonce).decode().strip()
-            data = dict(
-                data,
-                **{
-                    "phone_number": phone_number,
-                    "is_secondary_account_creation": ("true" if data.get("logged_in_user_id") else "false"),
-                    "verification_code": phone_code,
-                    "force_sign_up_code": "",
-                    "has_sms_consent": "true",
-                },
-            )
-        return await self.private_request(endpoint, data)
+            phone_data = {
+                "phone_number": phone_number,
+                "verification_code": phone_code,
+                "force_sign_up_code": "",
+                "has_sms_consent": "true",
+            }
+            if data.get("logged_in_user_id"):
+                phone_data["is_secondary_account_creation"] = "true"
+            data = dict(data, **phone_data)
+        try:
+            return await self.private_request(endpoint, data)
+        except FeedbackRequired as exc:
+            if getattr(exc, "spam", False):
+                details = vars(exc).copy()
+                details.pop("message", None)
+                raise SignupSpamError(
+                    "Instagram rejected the legacy signup flow as spam. "
+                    "Modern app signup uses additional device trust checks that aiograpi does not currently generate.",
+                    **details,
+                ) from exc
+            raise
 
     async def challenge_flow(
         self,

--- a/docs/usage-guide/challenge_resolver.md
+++ b/docs/usage-guide/challenge_resolver.md
@@ -44,6 +44,8 @@ await cl.login(IG_USERNAME, IG_PASSWORD)
 Login `submit_phone` challenges use `client.phone_number`, then call `challenge_code_handler(username, ChallengeChoice.SMS)` for the received code.
 Signup SMS challenges use the `phone_number` passed to `signup(...)` and call `challenge_code_handler(username, ChallengeChoice.SMS)` for the received code.
 
+`signup(...)` uses Instagram's legacy account-create flow. On modern Instagram app versions this flow is often rejected with `SignupSpamError` / `feedback_required` because the official app uses additional signup checks that aiograpi does not currently generate. Treat this as a platform rejection, not as a malformed SMS/email code.
+
 For example, you can get the code through the IMAP of Gmail:
 
 ``` python

--- a/tests/regression/test_signup.py
+++ b/tests/regression/test_signup.py
@@ -2,11 +2,67 @@ import unittest
 from unittest.mock import AsyncMock, Mock
 
 from aiograpi import Client
-from aiograpi.exceptions import ChallengeRequired, ClientError
+from aiograpi.exceptions import ChallengeRequired, ClientError, FeedbackRequired, SignupSpamError
 from aiograpi.mixins.challenge import ChallengeChoice
 
 
 class SignupHelperRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_accounts_create_primary_signup_omits_secondary_account_flag(self):
+        client = Client()
+        client.phone_id = "phone-id"
+        client.uuid = "uuid"
+        client.android_device_id = "android-id"
+        client.adid = "adid"
+        client.waterfall_id = "waterfall-id"
+        client.password_encrypt = AsyncMock(return_value="enc-password")
+        client.private_request = AsyncMock(return_value={"created_user": {"pk": "1"}})
+
+        result = await client.accounts_create(
+            username="example",
+            password="password",
+            email="addr@example.com",
+            email_code="signup-code",
+            full_name="Example User",
+            year=2000,
+            month=5,
+            day=12,
+        )
+
+        self.assertEqual(result, {"created_user": {"pk": "1"}})
+        data = client.private_request.call_args.args[1]
+        self.assertNotIn("is_secondary_account_creation", data)
+        self.assertEqual(data["username"], "example")
+        self.assertEqual(data["force_sign_up_code"], "signup-code")
+        client.private_request.assert_awaited_once()
+
+    async def test_accounts_create_spam_feedback_raises_signup_specific_error(self):
+        client = Client()
+        client.phone_id = "phone-id"
+        client.uuid = "uuid"
+        client.android_device_id = "android-id"
+        client.adid = "adid"
+        client.waterfall_id = "waterfall-id"
+        client.password_encrypt = AsyncMock(return_value="enc-password")
+        client.private_request = AsyncMock(
+            side_effect=FeedbackRequired(
+                message="feedback_required: Try Again Later",
+                feedback_message="We limit how often you can do certain things on Instagram.",
+                spam=True,
+            )
+        )
+
+        with self.assertRaises(SignupSpamError) as ctx:
+            await client.accounts_create(
+                username="example",
+                password="password",
+                email="addr@example.com",
+                email_code="signup-code",
+            )
+
+        self.assertIn("legacy signup flow", str(ctx.exception))
+        self.assertTrue(ctx.exception.spam)
+        self.assertEqual(ctx.exception.feedback_message, "We limit how often you can do certain things on Instagram.")
+
     async def test_challenge_api_rejects_external_api_path(self):
         client = Client()
         client.uuid = "uuid"

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -2,4 +2,4 @@ import aiograpi
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.7.6"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.7.8"


### PR DESCRIPTION
## Summary
- mirror instagrapi signup spam diagnostics in aiograpi
- remove the secondary-account flag from primary legacy signup payloads
- raise SignupSpamError when Instagram rejects legacy signup with feedback_required/spam:true
- document that signup(...) is a legacy flow and modern app signup may be rejected by device trust checks

## Tests
- .venv/bin/python -m pytest tests/regression/test_signup.py -q
- .venv/bin/python -m ruff check aiograpi/mixins/signup.py aiograpi/exceptions.py tests/regression/test_signup.py
- .venv/bin/python -m ruff format --check aiograpi/mixins/signup.py aiograpi/exceptions.py tests/regression/test_signup.py
- git diff --check