### PR TITLE
Align phone signup behavior with instagrapi

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,6 +17,7 @@ on:
         options:
           - smoke
           - comment
+          - signup
           - all
 
 env:
@@ -146,6 +147,13 @@ jobs:
         python-version: [ "3.10" ]
     env:
       TEST_ACCOUNTS_URL: ${{ secrets.TEST_ACCOUNTS_URL }}
+      IG_SIGNUP_EMAIL: ${{ secrets.IG_SIGNUP_EMAIL }}
+      IG_SIGNUP_EMAIL_COMMAND: ${{ secrets.IG_SIGNUP_EMAIL_COMMAND }}
+      IG_SIGNUP_EMAIL_CODE: ${{ secrets.IG_SIGNUP_EMAIL_CODE }}
+      IG_SIGNUP_EMAIL_CODE_COMMAND: ${{ secrets.IG_SIGNUP_EMAIL_CODE_COMMAND }}
+      IG_SIGNUP_PHONE_NUMBER: ${{ secrets.IG_SIGNUP_PHONE_NUMBER }}
+      IG_SIGNUP_SMS_CODE: ${{ secrets.IG_SIGNUP_SMS_CODE }}
+      IG_SIGNUP_SMS_CODE_COMMAND: ${{ secrets.IG_SIGNUP_SMS_CODE_COMMAND }}
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -183,6 +191,9 @@ jobs:
             exit 0
           fi
           PYTHONPATH=. pytest -sv tests/legacy.py::ClientCommentExtendTestCase::test_media_comment
+      - name: Run signup live tests
+        if: github.event_name == 'workflow_dispatch' && (github.event.inputs.test_target == 'signup' || github.event.inputs.test_target == 'all')
+        run: PYTHONPATH=. pytest -sv tests/live/test_signup_live.py::SignUpTestCase
 
   build-docs:
     runs-on: ubuntu-latest

--- a/aiograpi/mixins/signup.py
+++ b/aiograpi/mixins/signup.py
@@ -64,7 +64,7 @@ class SignUpMixin(ClientMixin):
         day: int = None,
     ) -> UserShort:
         if not (email or phone_number):
-            raise Exception("Use email or phone_number")
+            raise ClientError("Use email or phone_number for signup")
         await self.get_signup_config()
         kwargs = {
             "username": username,
@@ -102,7 +102,7 @@ class SignUpMixin(ClientMixin):
             kwargs["email"] = email
             kwargs["email_code"] = confirmation_result.get("signup_code")
 
-        if phone_number:
+        if phone_number and not email:
             kwargs["phone_number"] = phone_number
             check = await self.check_phone_number(phone_number)
             if check.get("status") != "ok":
@@ -207,6 +207,9 @@ class SignUpMixin(ClientMixin):
         day: int = None,
         **kwargs,
     ) -> dict:
+        if not (email or phone_number):
+            raise ClientError("Use email or phone_number for signup")
+
         timestamp = str(int(time.time()))
         self.username = username
         self.password = password

--- a/docs/usage-guide/challenge_resolver.md
+++ b/docs/usage-guide/challenge_resolver.md
@@ -44,6 +44,8 @@ await cl.login(IG_USERNAME, IG_PASSWORD)
 Login `submit_phone` challenges use `client.phone_number`, then call `challenge_code_handler(username, ChallengeChoice.SMS)` for the received code.
 Signup SMS challenges use the `phone_number` passed to `signup(...)` and call `challenge_code_handler(username, ChallengeChoice.SMS)` for the received code.
 
+Phone-only signup is supported with `await cl.signup(username, password, email="", phone_number="+15551234567")`. If both `email` and `phone_number` are provided, aiograpi keeps the email signup flow and uses the phone number only for signup challenges.
+
 `signup(...)` uses Instagram's legacy account-create flow. On modern Instagram app versions this flow is often rejected with `SignupSpamError` / `feedback_required` because the official app uses additional signup checks that aiograpi does not currently generate. Treat this as a platform rejection, not as a malformed SMS/email code.
 
 For example, you can get the code through the IMAP of Gmail:

--- a/tests/live/test_signup_live.py
+++ b/tests/live/test_signup_live.py
@@ -1,0 +1,119 @@
+import os
+import random
+import subprocess
+import unittest
+
+from aiograpi import Client
+from aiograpi.types import UserShort
+from aiograpi.utils import gen_password
+
+
+class SignUpTestCase(unittest.IsolatedAsyncioTestCase):
+    def run_signup_command(self, command, context):
+        env = os.environ.copy()
+        env.update({key: value for key, value in context.items() if value})
+        result = subprocess.run(
+            command,
+            shell=True,
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        return result.stdout.strip()
+
+    def signup_email(self, username):
+        email = os.environ.get("IG_SIGNUP_EMAIL")
+        if email:
+            return email
+        command = os.environ.get("IG_SIGNUP_EMAIL_COMMAND")
+        if not command:
+            self.skipTest("IG_SIGNUP_EMAIL or IG_SIGNUP_EMAIL_COMMAND is required for email signup live test")
+        email = self.run_signup_command(command, {"IG_SIGNUP_USERNAME": username})
+        if not email:
+            self.skipTest("IG_SIGNUP_EMAIL_COMMAND did not return an email address")
+        return email
+
+    def signup_phone_number(self):
+        return os.environ.get("IG_SIGNUP_PHONE_NUMBER") or os.environ.get("IG_PHONE_NUMBER")
+
+    def signup_code_handler(self, code_env, command_env, context):
+        code = os.environ.get(code_env)
+        if code:
+            return code
+        command = os.environ.get(command_env)
+        if not command:
+            self.skipTest(f"{code_env} or {command_env} is required for signup live tests")
+        code = self.run_signup_command(command, context)
+        if not code:
+            self.skipTest(f"{command_env} did not return a signup code")
+        return code
+
+    async def test_email_signup_live(self):
+        cl = Client()
+        username = gen_password()
+        email = self.signup_email(username)
+        password = gen_password(12)
+        phone_number = self.signup_phone_number()
+        full_name = f"John {username}"
+
+        async def challenge_code_handler(username, choice):
+            return self.signup_code_handler(
+                "IG_SIGNUP_EMAIL_CODE",
+                "IG_SIGNUP_EMAIL_CODE_COMMAND",
+                {
+                    "IG_SIGNUP_USERNAME": username,
+                    "IG_SIGNUP_EMAIL": email,
+                },
+            )
+
+        cl.challenge_code_handler = challenge_code_handler
+        user = await cl.signup(
+            username,
+            password,
+            email,
+            phone_number,
+            full_name,
+            year=random.randint(1980, 1990),
+            month=random.randint(1, 12),
+            day=random.randint(1, 30),
+        )
+        self.assertIsInstance(user, UserShort)
+        for key, val in {"username": username, "full_name": full_name}.items():
+            self.assertEqual(getattr(user, key), val)
+        self.assertTrue(user.profile_pic_url.startswith("https://"))
+
+    async def test_phone_signup_live(self):
+        phone_number = self.signup_phone_number()
+        if not phone_number:
+            self.skipTest("IG_SIGNUP_PHONE_NUMBER or IG_PHONE_NUMBER is required for phone signup live test")
+        cl = Client()
+        username = gen_password()
+        password = gen_password(12)
+        full_name = f"John {username}"
+
+        async def challenge_code_handler(username, choice):
+            return self.signup_code_handler(
+                "IG_SIGNUP_SMS_CODE",
+                "IG_SIGNUP_SMS_CODE_COMMAND",
+                {
+                    "IG_SIGNUP_USERNAME": username,
+                    "IG_SIGNUP_PHONE_NUMBER": phone_number,
+                },
+            )
+
+        cl.challenge_code_handler = challenge_code_handler
+        user = await cl.signup(
+            username,
+            password,
+            email="",
+            phone_number=phone_number,
+            full_name=full_name,
+            year=random.randint(1980, 1990),
+            month=random.randint(1, 12),
+            day=random.randint(1, 30),
+        )
+        self.assertIsInstance(user, UserShort)
+        for key, val in {"username": username, "full_name": full_name}.items():
+            self.assertEqual(getattr(user, key), val)
+        self.assertTrue(user.profile_pic_url.startswith("https://"))

--- a/tests/regression/test_signup.py
+++ b/tests/regression/test_signup.py
@@ -7,6 +7,54 @@ from aiograpi.mixins.challenge import ChallengeChoice
 
 
 class SignupHelperRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_signup_requires_email_or_phone_number(self):
+        client = Client()
+
+        with self.assertRaises(ClientError) as ctx:
+            await client.signup("example", "password", email="", phone_number="")
+
+        self.assertIn("email or phone_number", str(ctx.exception))
+
+    async def test_signup_with_phone_number_uses_sms_flow(self):
+        client = Client()
+        client.wait_seconds = 0
+        client.get_signup_config = AsyncMock(return_value={})
+        client.check_email = AsyncMock()
+        client.check_phone_number = AsyncMock(return_value={"status": "ok"})
+        client.send_signup_sms_code = AsyncMock(return_value={"status": "ok"})
+        client.challenge_code_handler = AsyncMock(return_value="123456")
+        client.accounts_create = AsyncMock(return_value={"created_user": {"pk": "1", "username": "example"}})
+        client.parse_authorization = Mock(return_value={})
+        client.last_response = Mock(headers={"ig-set-authorization": ""})
+
+        with unittest.mock.patch("aiograpi.mixins.signup.extract_user_short", return_value="created-user"):
+            result = await client.signup(
+                username="example",
+                password="password",
+                email="",
+                phone_number="+15551234567",
+                full_name="Example User",
+                year=2000,
+                month=5,
+                day=12,
+            )
+
+        self.assertEqual(result, "created-user")
+        client.check_email.assert_not_awaited()
+        client.check_phone_number.assert_awaited_once_with("+15551234567")
+        client.send_signup_sms_code.assert_awaited_once_with("+15551234567")
+        client.challenge_code_handler.assert_awaited_once_with("example", ChallengeChoice.SMS)
+        client.accounts_create.assert_awaited_once_with(
+            username="example",
+            password="password",
+            full_name="Example User",
+            year=2000,
+            month=5,
+            day=12,
+            phone_number="+15551234567",
+            phone_code="123456",
+        )
+
     async def test_accounts_create_primary_signup_omits_secondary_account_flag(self):
         client = Client()
         client.phone_id = "phone-id"
@@ -34,6 +82,49 @@ class SignupHelperRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["username"], "example")
         self.assertEqual(data["force_sign_up_code"], "signup-code")
         client.private_request.assert_awaited_once()
+
+    async def test_accounts_create_phone_signup_uses_validated_endpoint(self):
+        client = Client()
+        client.phone_id = "phone-id"
+        client.uuid = "uuid"
+        client.android_device_id = "android-id"
+        client.adid = "adid"
+        client.waterfall_id = "waterfall-id"
+        client.password_encrypt = AsyncMock(return_value="enc-password")
+        client.private_request = AsyncMock(return_value={"created_user": {"pk": "1"}})
+
+        result = await client.accounts_create(
+            username="example",
+            password="password",
+            phone_number="+15551234567",
+            phone_code="123456",
+            full_name="Example User",
+            year=2000,
+            month=5,
+            day=12,
+        )
+
+        self.assertEqual(result, {"created_user": {"pk": "1"}})
+        endpoint, data = client.private_request.call_args.args
+        self.assertEqual(endpoint, "accounts/create_validated/")
+        self.assertNotIn("is_secondary_account_creation", data)
+        self.assertNotIn("email", data)
+        self.assertEqual(data["username"], "example")
+        self.assertEqual(data["phone_number"], "+15551234567")
+        self.assertEqual(data["verification_code"], "123456")
+        self.assertEqual(data["force_sign_up_code"], "")
+        self.assertEqual(data["has_sms_consent"], "true")
+        client.private_request.assert_awaited_once()
+
+    async def test_accounts_create_requires_email_or_phone_number(self):
+        client = Client()
+        client.private_request = AsyncMock()
+
+        with self.assertRaises(ClientError) as ctx:
+            await client.accounts_create(username="example", password="password")
+
+        self.assertIn("email or phone_number", str(ctx.exception))
+        client.private_request.assert_not_awaited()
 
     async def test_accounts_create_spam_feedback_raises_signup_specific_error(self):
         client = Client()
@@ -227,6 +318,8 @@ class SignupHelperRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(result, "created-user")
+        client.check_phone_number.assert_not_awaited()
+        client.send_signup_sms_code.assert_not_awaited()
         client.challenge_flow.assert_awaited_once_with(
             challenge,
             phone_number="+15551234567",

--- a/tests/regression/test_signup.py
+++ b/tests/regression/test_signup.py
@@ -1,12 +1,25 @@
+import importlib.util
 import os
 import subprocess
 import unittest
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
 from aiograpi import Client
 from aiograpi.exceptions import ChallengeRequired, ClientError, FeedbackRequired, SignupSpamError
 from aiograpi.mixins.challenge import ChallengeChoice
-from tests.live.test_signup_live import SignUpTestCase
+
+
+def _load_live_signup_module():
+    signup_path = Path(__file__).resolve().parents[1] / "live" / "test_signup_live.py"
+    spec = importlib.util.spec_from_file_location("aiograpi_live_signup", signup_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+LIVE_SIGNUP_MODULE = _load_live_signup_module()
+SignUpTestCase = LIVE_SIGNUP_MODULE.SignUpTestCase
 
 
 class SignupHelperRegressionTestCase(unittest.IsolatedAsyncioTestCase):
@@ -336,7 +349,7 @@ class SignupLiveHelperRegressionTestCase(unittest.TestCase):
         completed = subprocess.CompletedProcess(args="email-command", returncode=0, stdout="fresh@example.test\n")
 
         with unittest.mock.patch.dict(os.environ, {"IG_SIGNUP_EMAIL_COMMAND": "email-command"}, clear=True):
-            with unittest.mock.patch("tests.live.test_signup_live.subprocess.run", return_value=completed) as run:
+            with unittest.mock.patch.object(LIVE_SIGNUP_MODULE.subprocess, "run", return_value=completed) as run:
                 email = case.signup_email("freshuser")
 
         self.assertEqual(email, "fresh@example.test")
@@ -347,7 +360,7 @@ class SignupLiveHelperRegressionTestCase(unittest.TestCase):
         completed = subprocess.CompletedProcess(args="code-command", returncode=0, stdout="123456\n")
 
         with unittest.mock.patch.dict(os.environ, {"IG_SIGNUP_EMAIL_CODE_COMMAND": "code-command"}, clear=True):
-            with unittest.mock.patch("tests.live.test_signup_live.subprocess.run", return_value=completed) as run:
+            with unittest.mock.patch.object(LIVE_SIGNUP_MODULE.subprocess, "run", return_value=completed) as run:
                 code = case.signup_code_handler(
                     "IG_SIGNUP_EMAIL_CODE",
                     "IG_SIGNUP_EMAIL_CODE_COMMAND",

--- a/tests/regression/test_signup.py
+++ b/tests/regression/test_signup.py
@@ -1,9 +1,12 @@
+import os
+import subprocess
 import unittest
 from unittest.mock import AsyncMock, Mock
 
 from aiograpi import Client
 from aiograpi.exceptions import ChallengeRequired, ClientError, FeedbackRequired, SignupSpamError
 from aiograpi.mixins.challenge import ChallengeChoice
+from tests.live.test_signup_live import SignUpTestCase
 
 
 class SignupHelperRegressionTestCase(unittest.IsolatedAsyncioTestCase):
@@ -325,3 +328,57 @@ class SignupHelperRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             phone_number="+15551234567",
             username="example",
         )
+
+
+class SignupLiveHelperRegressionTestCase(unittest.TestCase):
+    def test_signup_email_command_receives_username_context(self):
+        case = SignUpTestCase("test_email_signup_live")
+        completed = subprocess.CompletedProcess(args="email-command", returncode=0, stdout="fresh@example.test\n")
+
+        with unittest.mock.patch.dict(os.environ, {"IG_SIGNUP_EMAIL_COMMAND": "email-command"}, clear=True):
+            with unittest.mock.patch("tests.live.test_signup_live.subprocess.run", return_value=completed) as run:
+                email = case.signup_email("freshuser")
+
+        self.assertEqual(email, "fresh@example.test")
+        self.assertEqual(run.call_args.kwargs["env"]["IG_SIGNUP_USERNAME"], "freshuser")
+
+    def test_signup_code_command_receives_signup_context(self):
+        case = SignUpTestCase("test_email_signup_live")
+        completed = subprocess.CompletedProcess(args="code-command", returncode=0, stdout="123456\n")
+
+        with unittest.mock.patch.dict(os.environ, {"IG_SIGNUP_EMAIL_CODE_COMMAND": "code-command"}, clear=True):
+            with unittest.mock.patch("tests.live.test_signup_live.subprocess.run", return_value=completed) as run:
+                code = case.signup_code_handler(
+                    "IG_SIGNUP_EMAIL_CODE",
+                    "IG_SIGNUP_EMAIL_CODE_COMMAND",
+                    {
+                        "IG_SIGNUP_USERNAME": "freshuser",
+                        "IG_SIGNUP_EMAIL": "fresh@example.test",
+                    },
+                )
+
+        self.assertEqual(code, "123456")
+        self.assertEqual(run.call_args.kwargs["env"]["IG_SIGNUP_USERNAME"], "freshuser")
+        self.assertEqual(run.call_args.kwargs["env"]["IG_SIGNUP_EMAIL"], "fresh@example.test")
+
+    def test_signup_email_skips_without_static_email_or_command(self):
+        case = SignUpTestCase("test_email_signup_live")
+
+        with unittest.mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(unittest.SkipTest):
+                case.signup_email("freshuser")
+
+    def test_signup_phone_number_prefers_signup_specific_env(self):
+        case = SignUpTestCase("test_phone_signup_live")
+
+        with unittest.mock.patch.dict(
+            os.environ,
+            {
+                "IG_PHONE_NUMBER": "+15550000000",
+                "IG_SIGNUP_PHONE_NUMBER": "+15551234567",
+            },
+            clear=True,
+        ):
+            phone_number = case.signup_phone_number()
+
+        self.assertEqual(phone_number, "+15551234567")


### PR DESCRIPTION
## Summary
- keep aiograpi phone signup behavior aligned with instagrapi
- preserve email+phone signup compatibility: email signup remains primary, phone number is used for signup challenges
- raise ClientError for missing signup identity in signup/accounts_create
- document phone-only signup behavior

## Tests
- .venv/bin/python -m pytest tests/regression/test_signup.py -q
- .venv/bin/python -m ruff check aiograpi/mixins/signup.py tests/regression/test_signup.py
- .venv/bin/python -m ruff format --check aiograpi/mixins/signup.py tests/regression/test_signup.py
- git diff --check

Mirrors subzeroid/instagrapi#2550