### PR TITLE
Add password reset request helper

### DIFF
--- a/aiograpi/mixins/account.py
+++ b/aiograpi/mixins/account.py
@@ -1,10 +1,7 @@
 import json
-from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import Dict
 
-from aiograpi import httpx_ext
-from aiograpi.exceptions import ClientLoginRequired, ResetPasswordError
 from aiograpi.extractors import extract_account, extract_user_short
 from aiograpi.mixins.base import ClientMixin
 from aiograpi.types import Account, UserShort
@@ -17,36 +14,42 @@ class AccountMixin(ClientMixin):
     Helper class to manage your account
     """
 
-    async def reset_password(self, username: str) -> Dict:
+    async def send_password_reset(self, identifier: str, recaptcha_challenge_field: str = "") -> Dict:
         """
-        Reset your password
+        Send a password reset link or code to the account email or phone.
+
+        Parameters
+        ----------
+        identifier: str
+            Username, email address, or phone number for the account.
+        recaptcha_challenge_field: str, default ""
+            Recaptcha challenge token when Instagram asks for one.
 
         Returns
         -------
         Dict
             Jsonified response from Instagram
         """
-        response = await httpx_ext.request(
-            "post",
+        csrf_token = self.public.cookies_dict().get("csrftoken") or gen_token()
+        return await self.public_request(
             "https://www.instagram.com/accounts/account_recovery_send_ajax/",
-            data={"email_or_username": username, "recaptcha_challenge_field": ""},
+            data={"email_or_username": identifier, "recaptcha_challenge_field": recaptcha_challenge_field},
             headers={
                 "x-requested-with": "XMLHttpRequest",
-                "x-csrftoken": gen_token(),
-                "Connection": "Keep-Alive",
-                "Accept": "*/*",
-                "Accept-Encoding": "gzip,deflate",
-                "Accept-Language": "en-US",
-                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1.2 Safari/605.1.15",
+                "x-csrftoken": csrf_token,
             },
-            proxy=self.public.proxy,
+            return_json=True,
+            update_headers=False,
         )
-        try:
-            return response.json()
-        except JSONDecodeError as e:
-            if "/login/" in response.url:
-                raise ClientLoginRequired(e, response=response)
-            raise ResetPasswordError(e, response=response)
+
+    async def reset_password(self, username: str) -> Dict:
+        """
+        Send a password reset link or code.
+
+        This method is kept for backward compatibility. Use
+        :meth:`send_password_reset` in new code.
+        """
+        return await self.send_password_reset(username)
 
     async def account_info(self) -> Account:
         """

--- a/docs/usage-guide/account.md
+++ b/docs/usage-guide/account.md
@@ -7,6 +7,8 @@ Viewing and managing your profile
 | account_info()                               | Account   | Get private info for your account (e.g. email, phone_number)
 | account_edit(email: str, phone_number: str, username: str, full_name: str, biography: str, external_url: str) | Account | Change profile data
 | account_change_picture(path: Path)           | UserShort | Change Profile picture
+| send_password_reset(identifier: str, recaptcha_challenge_field: str = "") | dict | Send an Instagram password reset link or code to the account email or phone
+| reset_password(username: str)                | dict      | Backward-compatible alias for `send_password_reset()`
 | send_confirm_email(email: str)               | dict      | Send confirmation code to new email address
 | confirm_email(email: str, code: str)         | dict      | Confirm a new email address with the received code
 | send_confirm_phone_number(phone_number: str) | dict      | Send confirmation code to new phone number
@@ -44,6 +46,9 @@ PosixPath('/tmp/example_1560364774164147051.jpg')
 >>> await cl.account_change_picture(profile_pic_path)
 UserShort(pk=1903424587, username='example', ...)
 
+>>> await cl.send_password_reset("example")
+{'status': 'ok'}
+
 >>> await cl.send_confirm_email("addr@example.com")
 {
     'is_email_legit': False,
@@ -66,6 +71,10 @@ UserShort(pk=1903424587, username='example', ...)
     'status': 'ok'
 }
 ```
+
+Notes:
+
+* `send_password_reset()` starts Instagram's recovery flow by requesting a reset link or code. It does not set a new password by itself; continue with the link/code flow that Instagram sends to the account email or phone.
 
 Low level methods:
 

--- a/tests/regression/test_account.py
+++ b/tests/regression/test_account.py
@@ -5,6 +5,45 @@ from aiograpi import Client
 
 
 class AccountRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_send_password_reset_posts_recovery_payload(self):
+        client = Client()
+        client.public_request = AsyncMock(return_value={"status": "ok"})
+
+        result = await client.send_password_reset("user@example.com")
+
+        self.assertEqual(result, {"status": "ok"})
+        client.public_request.assert_awaited_once()
+        args, kwargs = client.public_request.call_args
+        self.assertEqual(args, ("https://www.instagram.com/accounts/account_recovery_send_ajax/",))
+        self.assertEqual(
+            kwargs["data"],
+            {
+                "email_or_username": "user@example.com",
+                "recaptcha_challenge_field": "",
+            },
+        )
+        self.assertEqual(kwargs["headers"]["x-requested-with"], "XMLHttpRequest")
+        self.assertIn("x-csrftoken", kwargs["headers"])
+        self.assertTrue(kwargs["return_json"])
+        self.assertFalse(kwargs["update_headers"])
+
+    async def test_send_password_reset_accepts_recaptcha_challenge_field(self):
+        client = Client()
+        client.public_request = AsyncMock(return_value={"status": "ok"})
+
+        await client.send_password_reset("user@example.com", recaptcha_challenge_field="challenge")
+
+        self.assertEqual(client.public_request.call_args.kwargs["data"]["recaptcha_challenge_field"], "challenge")
+
+    async def test_reset_password_delegates_to_send_password_reset(self):
+        client = Client()
+        client.send_password_reset = AsyncMock(return_value={"status": "ok"})
+
+        result = await client.reset_password("username")
+
+        self.assertEqual(result, {"status": "ok"})
+        client.send_password_reset.assert_awaited_once_with("username")
+
     async def test_confirm_email_posts_verify_email_code_payload(self):
         client = Client()
         client.phone_id = "phone-id"


### PR DESCRIPTION
## Summary
- mirror instagrapi's `send_password_reset()` helper for requesting an Instagram password reset link or code
- keep `reset_password()` as a backward-compatible alias
- route the request through `public_request()` so configured public transport, proxy, TLS verification, retry, and logging behavior are reused
- document that this starts Instagram's recovery flow but does not set a new password without the reset link/code flow

Mirrors subzeroid/instagrapi#2553.

## Tests
- `/Users/colinfrl/work/sub/aiograpi/.venv/bin/python -m pytest tests/regression/test_account.py -q`
- `/Users/colinfrl/work/sub/aiograpi/.venv/bin/python -m pytest tests/legacy.py -k 'public_request_uses_post_for_post_bodies or public_request_uses_client_retry_defaults' -q`
- `/Users/colinfrl/work/sub/aiograpi/.venv/bin/ruff check aiograpi/mixins/account.py tests/regression/test_account.py`
- `/Users/colinfrl/work/sub/aiograpi/.venv/bin/mkdocs build --strict`
