### PR TITLE
Add per-slide album usertags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ starting with 1.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added per-slide album usertags: `album_upload(..., usertags=[[...]])` now tags each carousel item by index.
+
+### Changed
+
+- Preserved album resource usertags from carousel media responses so per-slide tags are available on `media.resources[index].usertags`.
+
 ## [1.0.9] - 2026-05-21
 
 ### Added

--- a/aiograpi/extractors.py
+++ b/aiograpi/extractors.py
@@ -170,6 +170,7 @@ def extract_media_gql(data):
 
 
 def extract_resource_v1(data):
+    data = deepcopy(data)
     if "video_versions" in data:
         data["video_url"] = sorted(data["video_versions"], key=lambda o: o["height"] * o["width"])[-1]["url"]
     candidates = data.get("image_versions2", {}).get("candidates", [])
@@ -180,6 +181,11 @@ def extract_resource_v1(data):
         )[-1]["url"]
         if candidates
         else None
+    )
+    usertags = data.get("usertags") or {}
+    data["usertags"] = sorted(
+        [extract_usertag(usertag) for usertag in usertags.get("in", [])],
+        key=lambda tag: tag.user.pk,
     )
     return Resource(**data)
 

--- a/aiograpi/mixins/album.py
+++ b/aiograpi/mixins/album.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, cast
 from urllib.parse import urlparse
 
 from aiograpi.exceptions import (
@@ -127,7 +127,7 @@ class UploadAlbumMixin(ClientMixin):
         self,
         paths: List[Path],
         caption: str,
-        usertags: List[Usertag] = [],
+        usertags: Union[List[Usertag], List[List[Usertag]]] = [],
         location: Location = None,
         configure_timeout: int = 3,
         configure_handler=None,
@@ -144,8 +144,9 @@ class UploadAlbumMixin(ClientMixin):
             List of paths for media to upload
         caption: str
             Media caption
-        usertags: List[Usertag], optional
-            List of users to be tagged on this upload, default is empty list.
+        usertags: List[Usertag] or List[List[Usertag]], optional
+            List of users to tag. A flat list tags the first carousel item for backward compatibility.
+            Use a nested list to tag each carousel item by index: ``usertags[0]`` applies to ``paths[0]``.
         location: Location, optional
             Location tag for this upload, default is none
         configure_timeout: int
@@ -242,7 +243,7 @@ class UploadAlbumMixin(ClientMixin):
         paths: List[Path],
         caption: str,
         track: Union[Track, Dict],
-        usertags: List[Usertag] = [],
+        usertags: Union[List[Usertag], List[List[Usertag]]] = [],
         location: Location = None,
         configure_timeout: int = 3,
         configure_handler=None,
@@ -265,8 +266,9 @@ class UploadAlbumMixin(ClientMixin):
             Media caption.
         track: Track or dict
             Track from music search/browser response or a compatible dict.
-        usertags: List[Usertag], optional
-            List of users to be tagged on this upload.
+        usertags: List[Usertag] or List[List[Usertag]], optional
+            List of users to tag. A flat list tags the first carousel item for backward compatibility.
+            Use a nested list to tag each carousel item by index: ``usertags[0]`` applies to ``paths[0]``.
         location: Location, optional
             Location tag for this upload.
         configure_timeout: int
@@ -319,7 +321,7 @@ class UploadAlbumMixin(ClientMixin):
         self,
         childs: List,
         caption: str,
-        usertags: List[Usertag] = [],
+        usertags: Union[List[Usertag], List[List[Usertag]]] = [],
         location: Location = None,
         extra_data: Dict[str, str] = {},
     ) -> Dict:
@@ -332,8 +334,9 @@ class UploadAlbumMixin(ClientMixin):
             List of media/resources of an album
         caption: str
             Media caption
-        usertags: List[Usertag], optional
-            List of users to be tagged on this upload, default is empty list.
+        usertags: List[Usertag] or List[List[Usertag]], optional
+            List of users to tag. A flat list tags the first carousel item for backward compatibility.
+            Use a nested list to tag each carousel item by index: ``usertags[0]`` applies to ``childs[0]``.
         location: Location, optional
             Location tag for this upload, default is None
         extra_data: Dict[str, str], optional
@@ -346,8 +349,18 @@ class UploadAlbumMixin(ClientMixin):
         """
         upload_id = str(int(time.time() * 1000))
         if usertags:
-            usertags = [{"user_id": tag.user.pk, "position": [tag.x, tag.y]} for tag in usertags]
-            childs[0]["usertags"] = dumps({"in": usertags})
+            if isinstance(usertags[0], list):
+                carousel_usertags = cast(List[List[Usertag]], usertags)
+                for child, child_usertags in zip(childs, carousel_usertags):
+                    if not child_usertags:
+                        continue
+                    child["usertags"] = dumps(
+                        {"in": [{"user_id": tag.user.pk, "position": [tag.x, tag.y]} for tag in child_usertags]}
+                    )
+            else:
+                flat_usertags = cast(List[Usertag], usertags)
+                child_usertags = [{"user_id": tag.user.pk, "position": [tag.x, tag.y]} for tag in flat_usertags]
+                childs[0]["usertags"] = dumps({"in": child_usertags})
         data = {
             "timezone_offset": str(self.timezone_offset),
             "source_type": "4",

--- a/aiograpi/types.py
+++ b/aiograpi/types.py
@@ -21,6 +21,7 @@ class Resource(TypesBaseModel):
     video_url: Optional[HttpUrl] = None  # for Video and IGTV
     thumbnail_url: Optional[HttpUrl] = None
     media_type: int
+    usertags: List["Usertag"] = []
 
 
 class BioLink(TypesBaseModel):

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -7,7 +7,7 @@ ported through.
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.7.5
+instagrapi 2.7.9
 ```
 
 `aiograpi 1.0.5` includes the video dependency split, MoviePy 2 helper migration, Reel Facebook cross-post payload
@@ -16,6 +16,9 @@ action payload updates from `instagrapi` through 2.7.1, the async Direct/music/s
 upload read-back fallback from 2.7.3. It also includes the submit-phone challenge step, refreshed comment action
 metadata, upload read-back/live-test hardening, Reel music live read-back verification, and low-level Bloks two-factor
 helpers from 2.7.4, plus the automatic Bloks two-factor login fallback from 2.7.5.
+
+Subsequent 1.0.x releases continue that baseline through `instagrapi 2.7.9`, including Bloks login fallback updates,
+backup-code 2FA, email confirmation helpers, password reset helpers, and album per-slide usertags.
 
 ## Release policy
 
@@ -26,7 +29,7 @@ helpers from 2.7.4, plus the automatic Bloks two-factor login fallback from 2.7.
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
 `aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent
 `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance
-ports. `aiograpi 1.0.5` records the current SemVer baseline synced through `instagrapi 2.7.5`.
+ports. `aiograpi 1.0.x` records the current SemVer baseline synced through `instagrapi 2.7.9`.
 
 ## Porting rules
 

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -266,7 +266,7 @@ Upload medias to your feed. Common arguments:
 
 * `path` - Path to source file
 * `caption`  - Text for you post
-* `usertags` - List[Usertag] of mention users (see `Usertag` in [types.py](https://github.com/subzeroid/aiograpi/blob/main/aiograpi/types.py))
+* `usertags` - List[Usertag] of mention users (see `Usertag` in [types.py](https://github.com/subzeroid/aiograpi/blob/main/aiograpi/types.py)); album uploads also accept `List[List[Usertag]]` for per-slide tags
 * `location` - Location (e.g. `Location(name='Test', lat=42.0, lng=42.0)`)
 
 | Method                                                                                                                                 | Return  | Description
@@ -274,8 +274,8 @@ Upload medias to your feed. Common arguments:
 | photo_upload(path: Path, caption: str, upload_id: str, usertags: List[Usertag], location: Location, extra_data: Dict = {})             | Media   | Upload photo (Support JPG files)
 | photo_upload_with_music(path: Path, caption: str, track: Track, extra_data: Dict = {}) | Media | Upload feed photo with music metadata
 | video_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {})            | Media   | Upload video (Support MP4 files)
-| album_upload(paths: List[Path], caption: str, usertags: List[Usertag], location: Location, extra_data: Dict = {})                      | Media   | Upload Album (Support JPG/MP4 files)
-| album_upload_with_music(paths: List[Path], caption: str, track: Track, extra_data: Dict = {}) | Media | Upload feed album/carousel with music metadata
+| album_upload(paths: List[Path], caption: str, usertags: List[Usertag] or List[List[Usertag]], location: Location, extra_data: Dict = {}) | Media   | Upload Album (Support JPG/MP4 files)
+| album_upload_with_music(paths: List[Path], caption: str, track: Track, usertags: List[Usertag] or List[List[Usertag]], extra_data: Dict = {}) | Media | Upload feed album/carousel with music metadata
 | igtv_upload(path: Path, title: str, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}) | Media   | Upload IGTV (Support MP4 files)
 | clip_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, trial: bool = False, share_to_facebook: bool = False) | Media | Upload Reels Clip (Support MP4 files), optionally as a Trial Reel or cross-posted to Facebook
 | clip_music_extra_data(track: Track or dict, extra_data: Dict = {}) | dict | Build Reels music configure fields for manual `clip_upload(..., extra_data=...)`
@@ -417,6 +417,16 @@ Now let's mention users (Usertag) and location:
     location=Location(name='Russia, Saint-Petersburg', lat=59.96, lng=30.29)
 )
 
+>>> other = await cl.user_info_by_username('other')
+>>> album = await cl.album_upload(
+    ["/app/image.jpg", "/app/image2.jpg"],
+    "Album with per-slide tags",
+    usertags=[
+        [Usertag(user=example, x=0.5, y=0.5)],
+        [Usertag(user=other, x=0.25, y=0.75)],
+    ],
+)
+
 >>> media.dict()
 {'pk': 2573355619819242434,
  'id': '2573355619819242434_1903424587',
@@ -454,6 +464,10 @@ Now let's mention users (Usertag) and location:
  'title': '',
  'resources': []}
 ```
+
+For `album_upload`, nested `usertags` are matched by index with `paths`: `usertags[0]` applies to `paths[0]`, `usertags[1]` applies to `paths[1]`, and so on. A flat `List[Usertag]` is still accepted for backward compatibility and tags only the first carousel item.
+
+When reading an album, the same index rule applies to resources: tags for the first carousel item are in `media.resources[0].usertags`, tags for the second item are in `media.resources[1].usertags`, etc.
 
 Reels:
 

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -2690,6 +2690,25 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, ClientPrivateTestCa
                 itm = round(itm, 2)
             self.assertEqual(itm, val)
 
+    async def assertAlbumResourceUsertagsAccessible(self, media, expected_usertags, attempts=8, delay=5):
+        last_resources = []
+        for attempt in range(attempts):
+            if attempt:
+                await asyncio.sleep(delay)
+            info = await self.cl.media_info_v1(media.pk)
+            last_resources = info.resources
+            if len(last_resources) < len(expected_usertags):
+                continue
+            for resource, expected_tag in zip(last_resources, expected_usertags):
+                if not resource.usertags:
+                    break
+                tag = resource.usertags[0]
+                if str(tag.user.pk) != str(expected_tag.user.pk) or tag.x != expected_tag.x or tag.y != expected_tag.y:
+                    break
+            else:
+                return info
+        self.fail(f"Album resource usertags were not visible after {attempts} media_info_v1 attempts: {last_resources}")
+
     async def test_photo_upload_without_location(self):
         media_pk = await self.cl.media_pk_from_url("https://www.instagram.com/p/BVDOOolFFxg/")
         path = await self.cl.photo_download(media_pk)
@@ -2748,6 +2767,34 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, ClientPrivateTestCa
         finally:
             cleanup(*paths)
             self.assertTrue(await self.cl.media_delete(media.id))
+
+    async def test_album_upload_with_per_slide_usertags_visible_after_media_info(self):
+        paths = [
+            self.copy_media_fixture("examples/kanada.jpg"),
+            self.copy_media_fixture("examples/background.png"),
+        ]
+        [self.assertIsInstance(path, Path) for path in paths]
+        media = None
+        try:
+            instagram = await self.user_info_by_username("instagram")
+            first_tag = Usertag(user=instagram, x=0.25, y=0.75)
+            second_tag = Usertag(user=instagram, x=0.75, y=0.25)
+            caption_text = "Test caption for album per-slide tags"
+            media = await self.cl.album_upload(
+                paths,
+                caption_text,
+                usertags=[[first_tag], [second_tag]],
+                location=await self.get_location(),
+            )
+            self.assertIsInstance(media, Media)
+            self.assertEqual(media.caption_text, caption_text)
+            info = await self.assertAlbumResourceUsertagsAccessible(media, [first_tag, second_tag])
+            self.assertEqual(info.caption_text, caption_text)
+            self.assertEqual(len(info.resources), 2)
+        finally:
+            cleanup(*paths)
+            if media:
+                self.assertTrue(await self.cl.media_delete(media.id))
 
     async def test_igtv_upload(self):
         media_pk = await self.cl.media_pk_from_url("https://www.instagram.com/tv/B91gKCcpnTk/")

--- a/tests/regression/test_album_usertags.py
+++ b/tests/regression/test_album_usertags.py
@@ -1,0 +1,126 @@
+import json
+import unittest
+from unittest.mock import AsyncMock
+
+from aiograpi import Client
+from aiograpi.extractors import extract_media_v1
+from aiograpi.types import UserShort, Usertag
+
+
+def _build_client():
+    client = Client()
+    client.settings = {}
+    client._user_id = "1"
+    client.uuid = "uuid"
+    client.android_device_id = "device"
+    client.client_session_id = "client-session"
+    client.timezone_offset = 0
+    client.last_json = {}
+    client.last_response = None
+    client.set_device({})
+    client.with_default_data = lambda data: data
+    return client
+
+
+def _media_payload():
+    return {
+        "pk": "1",
+        "id": "1_1",
+        "code": "abc",
+        "taken_at": 1710000000,
+        "media_type": 8,
+        "caption": {"text": "caption"},
+        "user": {
+            "pk": "1",
+            "username": "example",
+            "profile_pic_url": "https://example.com/profile.jpg",
+        },
+        "like_count": 0,
+        "carousel_media": [
+            {
+                "pk": "10",
+                "id": "10_2",
+                "media_type": 1,
+                "image_versions2": {
+                    "candidates": [{"url": "https://example.com/one.jpg", "width": 100, "height": 100}],
+                },
+                "usertags": {
+                    "in": [
+                        {
+                            "user": {
+                                "pk": "100",
+                                "username": "first",
+                                "profile_pic_url": "https://example.com/first.jpg",
+                            },
+                            "position": [0.25, 0.75],
+                        }
+                    ]
+                },
+            },
+            {
+                "pk": "20",
+                "id": "20_2",
+                "media_type": 1,
+                "image_versions2": {
+                    "candidates": [{"url": "https://example.com/two.jpg", "width": 100, "height": 100}],
+                },
+                "usertags": {
+                    "in": [
+                        {
+                            "user": {
+                                "pk": "200",
+                                "username": "second",
+                                "profile_pic_url": "https://example.com/second.jpg",
+                            },
+                            "position": [0.5, 0.5],
+                        }
+                    ]
+                },
+            },
+        ],
+    }
+
+
+class AlbumUsertagsRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_album_configure_assigns_nested_usertags_by_carousel_index(self):
+        client = _build_client()
+        first_user = UserShort(pk="10", username="first")
+        second_user = UserShort(pk="20", username="second")
+        children = [{"upload_id": "1"}, {"upload_id": "2"}]
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        await client.album_configure(
+            children,
+            "caption",
+            usertags=[
+                [Usertag(user=first_user, x=0.25, y=0.75)],
+                [Usertag(user=second_user, x=0.5, y=0.5)],
+            ],
+        )
+
+        metadata = client.private_request.call_args.args[1]["children_metadata"]
+        first_tags = json.loads(metadata[0]["usertags"])
+        second_tags = json.loads(metadata[1]["usertags"])
+        self.assertEqual(first_tags, {"in": [{"user_id": "10", "position": [0.25, 0.75]}]})
+        self.assertEqual(second_tags, {"in": [{"user_id": "20", "position": [0.5, 0.5]}]})
+
+    async def test_album_configure_keeps_flat_usertags_on_first_carousel_item(self):
+        client = _build_client()
+        user = UserShort(pk="10", username="first")
+        children = [{"upload_id": "1"}, {"upload_id": "2"}]
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        await client.album_configure(children, "caption", usertags=[Usertag(user=user, x=0.25, y=0.75)])
+
+        metadata = client.private_request.call_args.args[1]["children_metadata"]
+        first_tags = json.loads(metadata[0]["usertags"])
+        self.assertEqual(first_tags, {"in": [{"user_id": "10", "position": [0.25, 0.75]}]})
+        self.assertNotIn("usertags", metadata[1])
+
+    async def test_extract_media_v1_preserves_album_resource_usertags(self):
+        media = extract_media_v1(_media_payload())
+
+        self.assertEqual(media.resources[0].usertags[0].user.pk, "100")
+        self.assertEqual(media.resources[0].usertags[0].x, 0.25)
+        self.assertEqual(media.resources[1].usertags[0].user.pk, "200")
+        self.assertEqual(media.resources[1].usertags[0].y, 0.5)

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -2,4 +2,4 @@ import aiograpi
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.7.8"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.7.9"


### PR DESCRIPTION
## Summary
- Port per-slide album usertags from `instagrapi`: `album_upload(..., usertags=[[...]])` now maps tags to carousel items by index.
- Preserve `usertags` on album resources when extracting carousel media, exposed as `media.resources[index].usertags`.
- Add live upload coverage that reads the uploaded album back through `media_info_v1` and checks per-resource usertags.
- Update media docs, upstream sync docs, changelog, and the recorded upstream baseline test.

## Test Plan
- [x] `pytest -q tests/regression/test_album_usertags.py` (RED first: failed on nested usertags and missing `Resource.usertags`)
- [x] `pytest -q tests/regression/test_album_usertags.py tests/legacy.py::UploadRegressionTestCase tests/legacy.py::ExtractorsRegressionTestCase`
- [x] `pytest -q tests/regression`
- [x] `ruff check aiograpi/types.py aiograpi/extractors.py aiograpi/mixins/album.py tests/regression/test_album_usertags.py tests/regression/test_upstream_sync.py`
- [x] `ruff check tests/legacy.py`
- [x] `TEST_ACCOUNTS_URL= IG_USERNAME= IG_PASSWORD= IG_SESSIONID= python -m pytest -q tests/legacy.py::ClienUploadTestCase::test_album_upload_with_per_slide_usertags_visible_after_media_info`
- [x] `PATH=/Users/colinfrl/work/sub/aiograpi/.venv/bin:$PATH ./scripts/check-mypy-baseline.sh`
- [x] `mkdocs build --strict`
