### PR TITLE
Document Facebook Reel destination source caveat

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -310,7 +310,7 @@ contains availability flags, not the full Account Center destination state, and 
 with `clip_share_to_fb_extra_data(...)`. If neither the preflight/config data nor the caller provides a destination,
 aiograpi raises `ClientError` before uploading video bytes. The Reel cross-post `attempt_id` is generated automatically;
 only pass it to `clip_share_to_fb_extra_data(...)` when replaying or testing a specific low-level payload.
-`bloks_fxcal_link_reels_share()` exposes the raw Account Center Bloks link action seen on the Reel composer surface, but it starts an app linking flow and does not replace the interactive Facebook linking step in Instagram.
+`bloks_fxcal_link_reels_share()` exposes the raw Account Center Bloks link action seen on the Reel composer surface, but it starts an app linking flow and does not replace the interactive Facebook linking step in Instagram. Treat Account Center Bloks `fbid`, auth, and linking values as linking context, not as `fb_destination_id`; only use them as a Reel publish destination after verifying that the final Reel configure request sends the same value as `share_to_fb_destination_id`. See [subzeroid/instagrapi#2556](https://github.com/subzeroid/instagrapi/issues/2556) for tracking automatic destination discovery.
 
 ``` python
 media = await cl.clip_upload(


### PR DESCRIPTION
## Summary
- document that Account Center Bloks linking values are not a verified Reel publish destination source
- link the upstream automatic Facebook Reel destination discovery tracking issue

## Test Plan
- .venv/bin/mkdocs build --strict