### PR TITLE
Fix comment pin endpoint slash

### DIFF
--- a/aiograpi/mixins/comment.py
+++ b/aiograpi/mixins/comment.py
@@ -723,7 +723,7 @@ class CommentMixin(ClientMixin):
         data = self.with_action_data({"_uid": self.user_id, "_uuid": self.uuid})
         name = "unpin" if revert else "pin"
 
-        result = await self.private_request(f"media/{media_id}/{name}_comment/{comment_pk}", data)
+        result = await self.private_request(f"media/{media_id}/{name}_comment/{comment_pk}/", data)
         return result["status"] == "ok"
 
     async def comment_unpin(self, media_id: str, comment_pk: int):

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -2363,6 +2363,21 @@ class ClientCommentExtendTestCase(ClientPrivateTestCase):
         for field in ["pk", "username", "full_name", "profile_pic_url"]:
             self.assertIn(field, user_fields)
 
+    async def test_comment_pin_and_unpin(self):
+        text = "Pin live fixture [%s]" % datetime.now().strftime("%s")
+        caption_text = "Comment pin media fixture [%s]" % datetime.now().strftime("%s")
+        path = self.copy_media_fixture("examples/kanada.jpg")
+        self.addCleanup(cleanup, path)
+        media = await self.cl.photo_upload(path, caption_text)
+        self.addAsyncCleanup(self.cleanup_media, media.id)
+        await self.assertUploadedMediaAccessible(media, media_type=1, caption_text=caption_text)
+        comment = await self.cl.media_comment(media.id, text)
+        self.addAsyncCleanup(self.cleanup_comment, media.id, comment.pk)
+        await self.assertCommentAccessible(media.id, comment.pk, text)
+
+        self.assertTrue(await self.cl.comment_pin(media.id, comment.pk))
+        self.assertTrue(await self.cl.comment_unpin(media.id, comment.pk))
+
     async def test_comment_like_and_unlike(self):
         media_pk = await self.cl.media_pk_from_url("https://www.instagram.com/p/B3mr1-OlWMG/")
         comment = (await self.cl.media_comments_v1(media_pk))[0]

--- a/tests/regression/test_comments.py
+++ b/tests/regression/test_comments.py
@@ -91,6 +91,30 @@ class CommentRepliesRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         assert all(isinstance(reply, Comment) for reply in replies)
         assert replies[0].replied_to_comment_id == "100"
 
+    async def test_comment_pin_posts_to_slash_terminated_endpoint(self):
+        client = self._build_logged_in_client()
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        result = await client.comment_pin("123_456", 789)
+
+        self.assertTrue(result)
+        endpoint, data = client.private_request.await_args.args
+        self.assertEqual(endpoint, "media/123_456/pin_comment/789/")
+        self.assertEqual(data["_uid"], client.user_id)
+        self.assertEqual(data["_uuid"], client.uuid)
+
+    async def test_comment_unpin_posts_to_slash_terminated_endpoint(self):
+        client = self._build_logged_in_client()
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        result = await client.comment_unpin("123_456", 789)
+
+        self.assertTrue(result)
+        endpoint, data = client.private_request.await_args.args
+        self.assertEqual(endpoint, "media/123_456/unpin_comment/789/")
+        self.assertEqual(data["_uid"], client.user_id)
+        self.assertEqual(data["_uuid"], client.uuid)
+
     async def test_media_comment_replies_chunk_returns_child_cursor(self):
         client = Client()
         client.private_request = AsyncMock(


### PR DESCRIPTION
## Summary
- keep comment pin/unpin requests on the slash-terminated mobile endpoints
- add async regression coverage for pin/unpin request paths
- add a live upload/comment/pin/unpin smoke test

## Verification
- `.venv/bin/python -m pytest tests/regression/test_comments.py tests/legacy.py::ClientCommentExtendTestCase::test_comment_pin_and_unpin`
- `.venv/bin/python -m ruff check aiograpi/mixins/comment.py tests/regression/test_comments.py tests/legacy.py`