### PR TITLE
Add experimental realtime MQTT client

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 MIT License
 
 Copyright (c) 2024-2026 Mark Subzeroid and aiograpi contributors
+Portions of the realtime MQTT implementation are derived from instagram_mqtt:
+Copyright (c) 2019 Nerixyz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -33,6 +33,7 @@ from aiograpi.mixins.public import (
     PublicRequestMixin,
     TopSearchesPublicMixin,
 )
+from aiograpi.mixins.realtime import RealtimeMixin
 from aiograpi.mixins.share import ShareMixin
 from aiograpi.mixins.signup import SignUpMixin
 from aiograpi.mixins.story import StoryMixin
@@ -77,6 +78,7 @@ class Client(
     CollectionMixin,
     AccountMixin,
     DirectMixin,
+    RealtimeMixin,
     LocationMixin,
     HashtagMixin,
     CommentMixin,

--- a/aiograpi/mixins/realtime.py
+++ b/aiograpi/mixins/realtime.py
@@ -1,0 +1,34 @@
+from typing import Any, Callable
+
+from aiograpi.realtime import RealtimeClient
+
+
+class RealtimeMixin:
+    realtime = None
+
+    def realtime_client(self, transport=None) -> RealtimeClient:
+        return RealtimeClient(self, transport=transport)
+
+    async def realtime_connect(self, transport=None) -> RealtimeClient:
+        if self.realtime is None:
+            self.realtime = self.realtime_client(transport=transport)
+        elif transport is not None:
+            self.realtime.transport = transport
+        await self.realtime.connect()
+        return self.realtime
+
+    async def realtime_disconnect(self) -> None:
+        if self.realtime is None:
+            return
+        await self.realtime.disconnect()
+        self.realtime = None
+
+    def realtime_on(self, event: str, handler: Callable[[Any], Any]) -> None:
+        if self.realtime is None:
+            self.realtime = self.realtime_client()
+        self.realtime.on(event, handler)
+
+    async def realtime_read_once(self) -> Any:
+        if self.realtime is None:
+            raise RuntimeError("Realtime client is not connected")
+        return await self.realtime.read_once()

--- a/aiograpi/realtime/__init__.py
+++ b/aiograpi/realtime/__init__.py
@@ -1,0 +1,3 @@
+from aiograpi.realtime.client import RealtimeClient
+
+__all__ = ["RealtimeClient"]

--- a/aiograpi/realtime/client.py
+++ b/aiograpi/realtime/client.py
@@ -124,6 +124,8 @@ class RealtimeClient:
         packet = decode_packet(await self.transport.recv_packet())
         if packet.packet_type != "publish":
             return packet
+        if packet.topic is None:
+            return packet
         payload = await self.dispatch_packet(packet.topic, packet.payload)
         if packet.qos == 1 and packet.packet_id is not None:
             await self.transport.send(b"\x40\x02" + packet.packet_id.to_bytes(2, "big"))

--- a/aiograpi/realtime/client.py
+++ b/aiograpi/realtime/client.py
@@ -1,0 +1,161 @@
+import inspect
+import json
+import time
+from collections import defaultdict
+from typing import Any, Awaitable, Callable, Dict, Iterable, List
+
+from aiograpi.realtime.mqttot import (
+    AsyncSocketMQTToTTransport,
+    MQTToTConnection,
+    MQTToTTopics,
+    compress_payload,
+    decode_packet,
+    parse_json_payload,
+    try_decompress_payload,
+    write_connect_packet,
+    write_disconnect_packet,
+    write_publish_packet,
+)
+
+REALTIME_HOST = "edge-mqtt.facebook.com"
+IG_REALTIME_APP_ID = 567067343352427
+REALTIME_SUBSCRIBE_TOPICS = [88, 135, 149, 150, 133, 146]
+
+
+class RealtimeClient:
+    def __init__(self, client, transport=None):
+        self.client = client
+        self.transport = transport or AsyncSocketMQTToTTransport(REALTIME_HOST)
+        self.connected = False
+        self._handlers: Dict[str, List[Callable[[Any], Awaitable[None] | None]]] = defaultdict(list)
+        self._packet_id = 0
+
+    def on(self, event: str, handler: Callable[[Any], Awaitable[None] | None]) -> None:
+        self._handlers[event].append(handler)
+
+    async def connect(self) -> None:
+        await self.transport.connect()
+        if isinstance(self.transport, AsyncSocketMQTToTTransport):
+            await self.transport.send(write_connect_packet(self.build_connection()))
+            packet = decode_packet(await self.transport.recv_packet())
+            if packet.packet_type != "connack" or packet.return_code != 0:
+                raise ConnectionError(f"Realtime MQTT connect failed: {packet.return_code}")
+        self.connected = True
+
+    async def disconnect(self) -> None:
+        if isinstance(self.transport, AsyncSocketMQTToTTransport) and self.connected:
+            await self.transport.send(write_disconnect_packet())
+        await self.transport.disconnect()
+        self.connected = False
+
+    def build_connection(self) -> MQTToTConnection:
+        sessionid = self.client.sessionid
+        assert sessionid, "Login required"
+        device_id = self.client.phone_id
+        assert device_id, "Client phone_id is required"
+        user_agent = self.client.user_agent
+        app_version = getattr(self.client, "app_version", "")
+        capabilities = getattr(self.client, "capabilities", "3brTv10=")
+        locale = getattr(self.client, "locale", "en_US")
+        return MQTToTConnection(
+            client_identifier=device_id[:20],
+            client_info={
+                "userId": int(self.client.user_id),
+                "userAgent": user_agent,
+                "clientCapabilities": 183,
+                "endpointCapabilities": 0,
+                "publishFormat": 1,
+                "noAutomaticForeground": False,
+                "makeUserAvailableInForeground": True,
+                "deviceId": device_id,
+                "isInitiallyForeground": True,
+                "networkType": 1,
+                "networkSubtype": 0,
+                "clientMqttSessionId": int(time.time() * 1000) & 0xFFFFFFFF,
+                "subscribeTopics": REALTIME_SUBSCRIBE_TOPICS,
+                "clientType": "cookie_auth",
+                "appId": IG_REALTIME_APP_ID,
+                "deviceSecret": "",
+                "clientStack": 3,
+            },
+            password=f"sessionid={sessionid}",
+            app_specific_info={
+                "app_version": app_version,
+                "X-IG-Capabilities": capabilities,
+                "everclear_subscriptions": json.dumps(
+                    {
+                        "inapp_notification_subscribe_comment": "17899377895239777",
+                        "inapp_notification_subscribe_comment_mention_and_reply": "17899377895239777",
+                        "video_call_participant_state_delivery": "17977239895057311",
+                        "presence_subscribe": "17846944882223835",
+                    },
+                    separators=(",", ":"),
+                ),
+                "User-Agent": user_agent,
+                "Accept-Language": locale.replace("_", "-"),
+                "platform": "android",
+                "ig_mqtt_route": "django",
+                "pubsub_msg_type_blacklist": "direct, typing_type",
+                "auth_cache_enabled": "0",
+            },
+        )
+
+    async def graph_ql_subscribe(self, subscriptions: str | Iterable[str]) -> None:
+        if isinstance(subscriptions, str):
+            subscriptions = [subscriptions]
+        await self.publish_json(MQTToTTopics.REALTIME_SUB, {"sub": list(subscriptions)})
+
+    async def skywalker_subscribe(self, subscriptions: str | Iterable[str]) -> None:
+        if isinstance(subscriptions, str):
+            subscriptions = [subscriptions]
+        await self.publish_json(MQTToTTopics.PUBSUB, {"sub": list(subscriptions)})
+
+    async def publish_json(self, topic: str, data: Dict[str, Any]) -> None:
+        self._packet_id += 1
+        packet = write_publish_packet(
+            topic,
+            compress_payload(json.dumps(data, separators=(",", ":")).encode()),
+            qos=1,
+            packet_id=self._packet_id,
+        )
+        await self.transport.send(packet)
+
+    async def read_once(self) -> Any:
+        packet = decode_packet(await self.transport.recv_packet())
+        if packet.packet_type != "publish":
+            return packet
+        payload = await self.dispatch_packet(packet.topic, packet.payload)
+        if packet.qos == 1 and packet.packet_id is not None:
+            await self.transport.send(b"\x40\x02" + packet.packet_id.to_bytes(2, "big"))
+        return payload
+
+    async def dispatch_packet(self, topic: str, payload: bytes) -> Any:
+        body = try_decompress_payload(payload)
+        parsed = None
+        if topic in {
+            MQTToTTopics.SEND_MESSAGE_RESPONSE,
+            MQTToTTopics.IRIS_SUB_RESPONSE,
+            MQTToTTopics.REALTIME_SUB,
+            MQTToTTopics.MESSAGE_SYNC,
+        }:
+            try:
+                parsed = json.loads(body.decode())
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                parsed = body
+        else:
+            try:
+                parsed = parse_json_payload(payload)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                parsed = body
+        await self.emit("receive", {"topic": topic, "payload": parsed})
+        if topic == MQTToTTopics.MESSAGE_SYNC:
+            await self.emit("message", parsed)
+        if topic == MQTToTTopics.REALTIME_SUB:
+            await self.emit("realtime_sub", parsed)
+        return parsed
+
+    async def emit(self, event: str, payload: Any) -> None:
+        for handler in self._handlers.get(event, []):
+            result = handler(payload)
+            if inspect.isawaitable(result):
+                await result

--- a/aiograpi/realtime/mqttot.py
+++ b/aiograpi/realtime/mqttot.py
@@ -1,0 +1,557 @@
+import asyncio
+import json
+import ssl
+import struct
+import zlib
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+
+class MQTToTTopics:
+    PUBSUB = "88"
+    FOREGROUND_STATE = "102"
+    SEND_MESSAGE = "132"
+    SEND_MESSAGE_RESPONSE = "133"
+    IRIS_SUB = "134"
+    IRIS_SUB_RESPONSE = "135"
+    MESSAGE_SYNC = "146"
+    REALTIME_SUB = "149"
+    REGION_HINT = "150"
+
+
+class ThriftTypes:
+    STOP = 0x00
+    TRUE = 0x01
+    FALSE = 0x02
+    BYTE = 0x03
+    INT_16 = 0x04
+    INT_32 = 0x05
+    INT_64 = 0x06
+    BINARY = 0x08
+    LIST = 0x09
+    MAP = 0x0B
+    STRUCT = 0x0C
+    BOOLEAN = 0xA1
+    LIST_INT_32 = (INT_32 << 8) | LIST
+    LIST_BINARY = (BINARY << 8) | LIST
+    MAP_BINARY_BINARY = (0x88 << 8) | MAP
+
+
+@dataclass(frozen=True)
+class ThriftDescriptor:
+    name: str
+    field: int
+    type: int
+    children: tuple["ThriftDescriptor", ...] = ()
+
+
+@dataclass
+class DecodedMQTToTPacket:
+    packet_type: str
+    payload: bytes
+    protocol_name: Optional[str] = None
+    protocol_level: Optional[int] = None
+    connect_flags: Optional[int] = None
+    keep_alive: Optional[int] = None
+    topic: Optional[str] = None
+    qos: int = 0
+    packet_id: Optional[int] = None
+    return_code: Optional[int] = None
+
+
+@dataclass
+class MQTToTConnection:
+    client_identifier: str
+    client_info: Dict[str, Any]
+    password: str
+    app_specific_info: Optional[Dict[str, str]] = None
+
+    @staticmethod
+    def thrift_descriptors() -> List[ThriftDescriptor]:
+        return [
+            ThriftDescriptor("clientIdentifier", 1, ThriftTypes.BINARY),
+            ThriftDescriptor("willTopic", 2, ThriftTypes.BINARY),
+            ThriftDescriptor("willMessage", 3, ThriftTypes.BINARY),
+            ThriftDescriptor(
+                "clientInfo",
+                4,
+                ThriftTypes.STRUCT,
+                (
+                    ThriftDescriptor("userId", 1, ThriftTypes.INT_64),
+                    ThriftDescriptor("userAgent", 2, ThriftTypes.BINARY),
+                    ThriftDescriptor("clientCapabilities", 3, ThriftTypes.INT_64),
+                    ThriftDescriptor("endpointCapabilities", 4, ThriftTypes.INT_64),
+                    ThriftDescriptor("publishFormat", 5, ThriftTypes.INT_32),
+                    ThriftDescriptor("noAutomaticForeground", 6, ThriftTypes.BOOLEAN),
+                    ThriftDescriptor("makeUserAvailableInForeground", 7, ThriftTypes.BOOLEAN),
+                    ThriftDescriptor("deviceId", 8, ThriftTypes.BINARY),
+                    ThriftDescriptor("isInitiallyForeground", 9, ThriftTypes.BOOLEAN),
+                    ThriftDescriptor("networkType", 10, ThriftTypes.INT_32),
+                    ThriftDescriptor("networkSubtype", 11, ThriftTypes.INT_32),
+                    ThriftDescriptor("clientMqttSessionId", 12, ThriftTypes.INT_64),
+                    ThriftDescriptor("clientIpAddress", 13, ThriftTypes.BINARY),
+                    ThriftDescriptor("subscribeTopics", 14, ThriftTypes.LIST_INT_32),
+                    ThriftDescriptor("clientType", 15, ThriftTypes.BINARY),
+                    ThriftDescriptor("appId", 16, ThriftTypes.INT_64),
+                    ThriftDescriptor("overrideNectarLogging", 17, ThriftTypes.BOOLEAN),
+                    ThriftDescriptor("connectTokenHash", 18, ThriftTypes.BINARY),
+                    ThriftDescriptor("regionPreference", 19, ThriftTypes.BINARY),
+                    ThriftDescriptor("deviceSecret", 20, ThriftTypes.BINARY),
+                    ThriftDescriptor("clientStack", 21, ThriftTypes.BYTE),
+                    ThriftDescriptor("fbnsConnectionKey", 22, ThriftTypes.INT_64),
+                    ThriftDescriptor("fbnsConnectionSecret", 23, ThriftTypes.BINARY),
+                    ThriftDescriptor("fbnsDeviceId", 24, ThriftTypes.BINARY),
+                    ThriftDescriptor("fbnsDeviceSecret", 25, ThriftTypes.BINARY),
+                    ThriftDescriptor("anotherUnknown", 26, ThriftTypes.INT_64),
+                ),
+            ),
+            ThriftDescriptor("password", 5, ThriftTypes.BINARY),
+            ThriftDescriptor("getDiffsRequests", 6, ThriftTypes.LIST_BINARY),
+            ThriftDescriptor("zeroRatingTokenHash", 9, ThriftTypes.BINARY),
+            ThriftDescriptor("appSpecificInfo", 10, ThriftTypes.MAP_BINARY_BINARY),
+        ]
+
+    def to_thrift(self) -> bytes:
+        payload: Dict[str, Any] = {
+            "clientIdentifier": self.client_identifier,
+            "clientInfo": self.client_info,
+            "password": self.password,
+        }
+        if self.app_specific_info:
+            payload["appSpecificInfo"] = self.app_specific_info
+        return write_thrift_object(payload, self.thrift_descriptors())
+
+
+def compress_payload(data: bytes) -> bytes:
+    return zlib.compress(data, level=9)
+
+
+def try_decompress_payload(data: bytes) -> bytes:
+    if not data or data[0] != 0x78:
+        return data
+    try:
+        return zlib.decompress(data)
+    except zlib.error:
+        return data
+
+
+def write_connect_packet(connection: MQTToTConnection, keep_alive: int = 20) -> bytes:
+    payload = compress_payload(connection.to_thrift())
+    variable_header = _write_utf8("MQTToT") + bytes([3, 0xC2]) + struct.pack("!H", keep_alive)
+    remaining = variable_header + payload
+    return bytes([0x10]) + _encode_remaining_length(len(remaining)) + remaining
+
+
+def write_publish_packet(topic: str, payload: bytes, qos: int = 1, packet_id: int = 1) -> bytes:
+    if qos not in (0, 1):
+        raise ValueError("Only QoS 0 and QoS 1 are supported")
+    variable_header = _write_utf8(str(topic))
+    if qos:
+        variable_header += struct.pack("!H", packet_id)
+    body = variable_header + payload
+    fixed_header = bytes([0x30 | (qos << 1)]) + _encode_remaining_length(len(body))
+    return fixed_header + body
+
+
+def write_subscribe_packet(topic: str, packet_id: int = 1, qos: int = 1) -> bytes:
+    body = struct.pack("!H", packet_id) + _write_utf8(str(topic)) + bytes([qos])
+    return bytes([0x82]) + _encode_remaining_length(len(body)) + body
+
+
+def write_pingreq_packet() -> bytes:
+    return b"\xc0\x00"
+
+
+def write_disconnect_packet() -> bytes:
+    return b"\xe0\x00"
+
+
+def decode_packet(packet: bytes) -> DecodedMQTToTPacket:
+    packet_type_id = packet[0] >> 4
+    flags = packet[0] & 0x0F
+    remaining_length, offset = _decode_remaining_length(packet, 1)
+    body = packet[offset : offset + remaining_length]
+    if packet_type_id == 1:
+        protocol_name, pos = _read_utf8(body, 0)
+        protocol_level = body[pos]
+        connect_flags = body[pos + 1]
+        keep_alive = struct.unpack("!H", body[pos + 2 : pos + 4])[0]
+        payload = body[pos + 4 :]
+        return DecodedMQTToTPacket(
+            packet_type="connect",
+            protocol_name=protocol_name,
+            protocol_level=protocol_level,
+            connect_flags=connect_flags,
+            keep_alive=keep_alive,
+            payload=payload,
+        )
+    if packet_type_id == 2:
+        return DecodedMQTToTPacket(
+            packet_type="connack",
+            return_code=body[1],
+            payload=body[2:],
+        )
+    if packet_type_id == 3:
+        topic, pos = _read_utf8(body, 0)
+        qos = (flags >> 1) & 0x03
+        packet_id = None
+        if qos:
+            packet_id = struct.unpack("!H", body[pos : pos + 2])[0]
+            pos += 2
+        return DecodedMQTToTPacket(
+            packet_type="publish",
+            topic=topic,
+            qos=qos,
+            packet_id=packet_id,
+            payload=body[pos:],
+        )
+    return DecodedMQTToTPacket(packet_type=str(packet_type_id), payload=body)
+
+
+def write_thrift_object(data: Dict[str, Any], descriptors: List[ThriftDescriptor]) -> bytes:
+    writer = _ThriftWriter()
+    _write_thrift_struct(writer, data, descriptors)
+    writer.write_stop()
+    return bytes(writer.buffer)
+
+
+def read_thrift_object(data: bytes, descriptors: List[ThriftDescriptor]) -> Dict[str, Any]:
+    return _ThriftReader(data).read_struct(descriptors)
+
+
+class AsyncSocketMQTToTTransport:
+    def __init__(self, host: str, port: int = 443, timeout: float = 30.0, tls_context: Optional[ssl.SSLContext] = None):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.tls_context = tls_context or ssl.create_default_context()
+        self.reader: Optional[asyncio.StreamReader] = None
+        self.writer: Optional[asyncio.StreamWriter] = None
+
+    async def connect(self) -> None:
+        self.reader, self.writer = await asyncio.wait_for(
+            asyncio.open_connection(
+                self.host,
+                self.port,
+                ssl=self.tls_context,
+                server_hostname=self.host,
+            ),
+            timeout=self.timeout,
+        )
+
+    async def send(self, packet: bytes) -> None:
+        if self.writer is None:
+            raise RuntimeError("Transport is not connected")
+        self.writer.write(packet)
+        await self.writer.drain()
+
+    async def recv_packet(self) -> bytes:
+        if self.reader is None:
+            raise RuntimeError("Transport is not connected")
+        first = await self.reader.readexactly(1)
+        remaining = bytearray()
+        while True:
+            byte = await self.reader.readexactly(1)
+            remaining.extend(byte)
+            if byte[0] & 0x80 == 0:
+                break
+        size, _ = _decode_remaining_length(bytes(remaining), 0)
+        return first + bytes(remaining) + await self.reader.readexactly(size)
+
+    async def disconnect(self) -> None:
+        if self.writer is None:
+            return
+        self.writer.close()
+        try:
+            await self.writer.wait_closed()
+        finally:
+            self.reader = None
+            self.writer = None
+
+
+class _ThriftWriter:
+    def __init__(self):
+        self.buffer = bytearray()
+        self._field_stack: List[int] = []
+        self._field = 0
+
+    def write_stop(self) -> None:
+        self.buffer.append(ThriftTypes.STOP)
+        if self._field_stack:
+            self._field = self._field_stack.pop()
+
+    def write_field(self, field: int, field_type: int) -> None:
+        delta = field - self._field
+        thrift_type = field_type & 0x0F
+        if 0 < delta <= 15:
+            self.buffer.append((delta << 4) | thrift_type)
+        else:
+            self.buffer.append(thrift_type)
+            self.write_varint(_zigzag(field, 16))
+        self._field = field
+
+    def write_varint(self, value: int) -> None:
+        while True:
+            if value & ~0x7F == 0:
+                self.buffer.append(value)
+                return
+            self.buffer.append((value & 0x7F) | 0x80)
+            value >>= 7
+
+    def write_varbigint(self, value: int) -> None:
+        self.write_varint(value)
+
+    def write_string_direct(self, value: str) -> None:
+        raw = value.encode()
+        self.write_varint(len(raw))
+        self.buffer.extend(raw)
+
+    def write_string(self, field: int, value: str) -> None:
+        self.write_field(field, ThriftTypes.BINARY)
+        self.write_string_direct(value)
+
+    def write_bool(self, field: int, value: bool) -> None:
+        self.write_field(field, ThriftTypes.TRUE if value else ThriftTypes.FALSE)
+
+    def write_int(self, field: int, value: int, bits: int) -> None:
+        field_type = {8: ThriftTypes.BYTE, 16: ThriftTypes.INT_16, 32: ThriftTypes.INT_32, 64: ThriftTypes.INT_64}[bits]
+        self.write_field(field, field_type)
+        if bits == 8:
+            self.buffer.extend(struct.pack("b", value))
+        elif bits == 64:
+            self.write_varbigint(_zigzag(value, 64))
+        else:
+            self.write_varint(_zigzag(value, bits))
+
+    def push_struct(self, field: int) -> None:
+        self.write_field(field, ThriftTypes.STRUCT)
+        self._field_stack.append(self._field)
+        self._field = 0
+
+
+class _ThriftReader:
+    def __init__(self, data: bytes):
+        self.data = data
+        self.pos = 0
+        self._field_stack: List[int] = []
+        self._field = 0
+
+    def read_struct(self, descriptors: List[ThriftDescriptor]) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        while self.pos < len(self.data):
+            field_type = self.read_field()
+            if field_type == ThriftTypes.STOP:
+                if self._field_stack:
+                    self._field = self._field_stack.pop()
+                break
+            descriptor = _find_descriptor(descriptors, self._field, field_type)
+            value = self.read_value(field_type, descriptor)
+            if descriptor:
+                result[descriptor.name] = value
+        return result
+
+    def read_field(self) -> int:
+        byte = self.read_byte()
+        if byte == ThriftTypes.STOP:
+            return ThriftTypes.STOP
+        delta = (byte & 0xF0) >> 4
+        if delta:
+            self._field += delta
+        else:
+            self._field = _unzigzag(self.read_varint())
+        return byte & 0x0F
+
+    def read_value(self, field_type: int, descriptor: Optional[ThriftDescriptor]) -> Any:
+        if field_type == ThriftTypes.TRUE:
+            return True
+        if field_type == ThriftTypes.FALSE:
+            return False
+        if field_type == ThriftTypes.BYTE:
+            return struct.unpack("b", self.read_bytes(1))[0]
+        if field_type in (ThriftTypes.INT_16, ThriftTypes.INT_32):
+            return _unzigzag(self.read_varint())
+        if field_type == ThriftTypes.INT_64:
+            return _unzigzag(self.read_varint())
+        if field_type == ThriftTypes.BINARY:
+            return self.read_bytes(self.read_varint()).decode()
+        if field_type == ThriftTypes.LIST:
+            return self.read_list()
+        if field_type == ThriftTypes.MAP:
+            return self.read_map()
+        if field_type == ThriftTypes.STRUCT:
+            self._field_stack.append(self._field)
+            self._field = 0
+            return self.read_struct(list(descriptor.children) if descriptor else [])
+        raise ValueError(f"Unsupported thrift type: {field_type}")
+
+    def read_list(self) -> List[Any]:
+        header = self.read_byte()
+        size = header >> 4
+        item_type = header & 0x0F
+        if size == 0x0F:
+            size = self.read_varint()
+        items = []
+        for _ in range(size):
+            items.append(self.read_value(item_type, None))
+        return items
+
+    def read_map(self) -> Dict[str, str]:
+        size = self.read_varint()
+        if not size:
+            return {}
+        item_types = self.read_byte()
+        key_type = (item_types & 0xF0) >> 4
+        value_type = item_types & 0x0F
+        result = {}
+        for _ in range(size):
+            key = self.read_value(key_type, None)
+            value = self.read_value(value_type, None)
+            result[key] = value
+        return result
+
+    def read_byte(self) -> int:
+        value = self.data[self.pos]
+        self.pos += 1
+        return value
+
+    def read_bytes(self, size: int) -> bytes:
+        value = self.data[self.pos : self.pos + size]
+        self.pos += size
+        return value
+
+    def read_varint(self) -> int:
+        shift = 0
+        result = 0
+        while self.pos < len(self.data):
+            byte = self.read_byte()
+            result |= (byte & 0x7F) << shift
+            if byte & 0x80 == 0:
+                break
+            shift += 7
+        return result
+
+
+def _write_thrift_struct(writer: _ThriftWriter, data: Dict[str, Any], descriptors: List[ThriftDescriptor]) -> None:
+    by_name = {descriptor.name: descriptor for descriptor in descriptors}
+    for name, value in data.items():
+        if value is None:
+            continue
+        descriptor = by_name[name]
+        thrift_type = descriptor.type & 0xFF
+        if thrift_type == ThriftTypes.BOOLEAN:
+            writer.write_bool(descriptor.field, bool(value))
+        elif thrift_type == ThriftTypes.BYTE:
+            writer.write_int(descriptor.field, int(value), 8)
+        elif thrift_type == ThriftTypes.INT_16:
+            writer.write_int(descriptor.field, int(value), 16)
+        elif thrift_type == ThriftTypes.INT_32:
+            writer.write_int(descriptor.field, int(value), 32)
+        elif thrift_type == ThriftTypes.INT_64:
+            writer.write_int(descriptor.field, int(value), 64)
+        elif thrift_type == ThriftTypes.BINARY:
+            writer.write_string(descriptor.field, str(value))
+        elif thrift_type == ThriftTypes.STRUCT:
+            writer.push_struct(descriptor.field)
+            _write_thrift_struct(writer, value, list(descriptor.children))
+            writer.write_stop()
+        elif thrift_type == ThriftTypes.LIST:
+            writer.write_field(descriptor.field, ThriftTypes.LIST)
+            item_type = descriptor.type >> 8
+            _write_thrift_list(writer, item_type, value)
+        elif thrift_type == ThriftTypes.MAP:
+            _write_thrift_map(writer, descriptor.field, value)
+        else:
+            raise ValueError(f"Unsupported thrift type: {descriptor.type}")
+
+
+def _write_thrift_list(writer: _ThriftWriter, item_type: int, values: List[Any]) -> None:
+    size = len(values)
+    if size < 0x0F:
+        writer.buffer.append((size << 4) | item_type)
+    else:
+        writer.buffer.append(0xF0 | item_type)
+        writer.write_varint(size)
+    for value in values:
+        if item_type == ThriftTypes.INT_32:
+            writer.write_varint(_zigzag(int(value), 32))
+        elif item_type == ThriftTypes.BINARY:
+            writer.write_string_direct(str(value))
+        else:
+            raise ValueError(f"Unsupported thrift list type: {item_type}")
+
+
+def _write_thrift_map(writer: _ThriftWriter, field: int, values: Dict[str, str]) -> None:
+    writer.write_field(field, ThriftTypes.MAP)
+    writer.write_varint(len(values))
+    if not values:
+        return
+    writer.buffer.append((ThriftTypes.BINARY << 4) | ThriftTypes.BINARY)
+    for key, value in values.items():
+        writer.write_string_direct(str(key))
+        writer.write_string_direct(str(value))
+
+
+def _find_descriptor(
+    descriptors: List[ThriftDescriptor],
+    field: int,
+    field_type: int,
+) -> Optional[ThriftDescriptor]:
+    for descriptor in descriptors:
+        descriptor_type = descriptor.type & 0x0F
+        if descriptor.field != field:
+            continue
+        if descriptor_type == field_type or (
+            descriptor.type == ThriftTypes.BOOLEAN and field_type in (ThriftTypes.TRUE, ThriftTypes.FALSE)
+        ):
+            return descriptor
+    return None
+
+
+def _write_utf8(value: str) -> bytes:
+    raw = value.encode()
+    return struct.pack("!H", len(raw)) + raw
+
+
+def _read_utf8(data: bytes, offset: int) -> tuple[str, int]:
+    size = struct.unpack("!H", data[offset : offset + 2])[0]
+    offset += 2
+    return data[offset : offset + size].decode(), offset + size
+
+
+def _encode_remaining_length(value: int) -> bytes:
+    encoded = bytearray()
+    while True:
+        byte = value % 128
+        value //= 128
+        if value:
+            byte |= 0x80
+        encoded.append(byte)
+        if not value:
+            return bytes(encoded)
+
+
+def _decode_remaining_length(data: bytes, offset: int) -> tuple[int, int]:
+    multiplier = 1
+    value = 0
+    while True:
+        encoded_byte = data[offset]
+        offset += 1
+        value += (encoded_byte & 127) * multiplier
+        if encoded_byte & 128 == 0:
+            return value, offset
+        multiplier *= 128
+
+
+def _zigzag(value: int, bits: int) -> int:
+    return (value << 1) ^ (value >> (bits - 1))
+
+
+def _unzigzag(value: int) -> int:
+    return (value >> 1) ^ -(value & 1)
+
+
+def parse_json_payload(payload: bytes) -> Any:
+    return json.loads(try_decompress_payload(payload).decode())
+
+
+RealtimeHandler = Callable[[Any], Awaitable[None] | None]

--- a/docs/usage-guide/realtime.md
+++ b/docs/usage-guide/realtime.md
@@ -1,0 +1,58 @@
+# Realtime MQTT
+
+!!! warning
+    Realtime MQTT support is experimental. Instagram can change this private transport without notice.
+
+The realtime client opens Instagram's MQTToT connection for receiving live events after login.
+It is useful when you need callbacks for realtime payloads instead of polling HTTP endpoints.
+Use the Direct methods for sending messages, reactions, and media.
+
+| Method | Return | Description |
+| --- | --- | --- |
+| `await realtime_connect(transport=None)` | `RealtimeClient` | Create and connect the stateful realtime client |
+| `await realtime_disconnect()` | `None` | Disconnect the active realtime client |
+| `realtime_on(event, handler)` | `None` | Register an event handler on the active realtime client |
+| `await realtime_read_once()` | `Any` | Read one packet from the active realtime client |
+
+`RealtimeClient` also exposes lower-level helpers:
+
+| Method | Description |
+| --- | --- |
+| `on(event, handler)` | Register a sync or async handler for `receive`, `message`, or `realtime_sub` |
+| `await graph_ql_subscribe(subscriptions)` | Publish raw GraphQL realtime subscriptions |
+| `await skywalker_subscribe(subscriptions)` | Publish raw Skywalker subscriptions |
+| `await publish_json(topic, data)` | Publish a JSON payload to a raw MQTToT topic |
+| `await read_once()` | Read and dispatch one packet |
+
+Basic receive loop:
+
+``` python
+from aiograpi import Client
+
+cl = Client()
+await cl.login(USERNAME, PASSWORD)
+
+
+async def handle_receive(event):
+    print(event["topic"], event["payload"])
+
+
+cl.realtime_on("receive", handle_receive)
+rt = await cl.realtime_connect()
+
+while True:
+    await cl.realtime_read_once()
+```
+
+Subscribe to raw realtime topics:
+
+``` python
+await rt.graph_ql_subscribe(["<graphql-subscription>"])
+await rt.skywalker_subscribe(["<skywalker-subscription>"])
+```
+
+Events:
+
+* `receive` is emitted for every decoded publish packet as `{"topic": topic, "payload": payload}`.
+* `message` is emitted for message-sync payloads.
+* `realtime_sub` is emitted for realtime subscription payloads.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
     - Collection: usage-guide/collection.md
     - Comment: usage-guide/comment.md
     - Direct: usage-guide/direct.md
+    - Realtime MQTT: usage-guide/realtime.md
     - Explore: usage-guide/explore.md
     - Fundraiser: usage-guide/fundraiser.md
     - Hashtag: usage-guide/hashtag.md

--- a/tests/regression/test_realtime.py
+++ b/tests/regression/test_realtime.py
@@ -1,0 +1,123 @@
+import json
+import unittest
+import zlib
+from unittest.mock import AsyncMock, Mock
+
+from aiograpi import Client
+from aiograpi.realtime import RealtimeClient
+from aiograpi.realtime.mqttot import (
+    MQTToTConnection,
+    MQTToTTopics,
+    decode_packet,
+    read_thrift_object,
+    write_connect_packet,
+    write_publish_packet,
+)
+
+
+def _build_logged_in_client():
+    client = Client()
+    client.authorization_data = {"ds_user_id": "12345", "sessionid": "12345:session"}
+    client.phone_id = "phone-id-12345678901234567890"
+    client.uuid = "uuid-1"
+    client.user_agent = "Instagram 428.0.0.47.67 Android"
+    client.app_version = "428.0.0.47.67"
+    client.capabilities = "3brTvw=="
+    client.locale = "en_US"
+    return client
+
+
+def test_mqttot_connect_packet_uses_custom_protocol_and_zipped_thrift_payload():
+    connection = MQTToTConnection(
+        client_identifier="phone-id-123456789",
+        client_info={
+            "userId": 12345,
+            "userAgent": "Instagram 428",
+            "clientCapabilities": 183,
+            "endpointCapabilities": 0,
+            "publishFormat": 1,
+            "deviceId": "phone-id-12345678901234567890",
+            "isInitiallyForeground": True,
+            "subscribeTopics": [88, 135, 149, 150, 133, 146],
+            "clientType": "cookie_auth",
+            "appId": 567067343352427,
+            "clientStack": 3,
+        },
+        password="sessionid=12345:session",
+        app_specific_info={
+            "app_version": "428.0.0.47.67",
+            "platform": "android",
+            "ig_mqtt_route": "django",
+        },
+    )
+
+    packet = write_connect_packet(connection, keep_alive=20)
+
+    assert packet[0] == 0x10
+    decoded = decode_packet(packet)
+    assert decoded.packet_type == "connect"
+    assert decoded.protocol_name == "MQTToT"
+    assert decoded.protocol_level == 3
+    assert decoded.connect_flags == 0xC2
+    assert decoded.keep_alive == 20
+
+    thrift_payload = zlib.decompress(decoded.payload)
+    thrift = read_thrift_object(thrift_payload, MQTToTConnection.thrift_descriptors())
+    assert thrift["clientIdentifier"] == "phone-id-123456789"
+    assert thrift["password"] == "sessionid=12345:session"
+    assert thrift["clientInfo"]["clientType"] == "cookie_auth"
+    assert thrift["clientInfo"]["subscribeTopics"] == [88, 135, 149, 150, 133, 146]
+    assert thrift["appSpecificInfo"]["ig_mqtt_route"] == "django"
+
+
+def test_publish_packet_round_trips_topic_and_zipped_payload():
+    payload = zlib.compress(json.dumps({"sub": ["1/graphqlsubscriptions/test/{}"]}).encode())
+
+    packet = write_publish_packet(MQTToTTopics.REALTIME_SUB, payload, qos=1, packet_id=7)
+
+    decoded = decode_packet(packet)
+    assert decoded.packet_type == "publish"
+    assert decoded.topic == MQTToTTopics.REALTIME_SUB
+    assert decoded.qos == 1
+    assert decoded.packet_id == 7
+    assert json.loads(zlib.decompress(decoded.payload)) == {"sub": ["1/graphqlsubscriptions/test/{}"]}
+
+
+def test_realtime_client_builds_cookie_auth_connection_from_instagram_session():
+    client = _build_logged_in_client()
+    realtime = RealtimeClient(client)
+
+    connection = realtime.build_connection()
+
+    assert connection.client_identifier == "phone-id-12345678901"
+    assert connection.password == "sessionid=12345:session"
+    assert connection.client_info["userId"] == 12345
+    assert connection.client_info["clientType"] == "cookie_auth"
+    assert connection.client_info["appId"] == 567067343352427
+    assert connection.client_info["subscribeTopics"] == [88, 135, 149, 150, 133, 146]
+    assert connection.app_specific_info["app_version"] == "428.0.0.47.67"
+    assert connection.app_specific_info["platform"] == "android"
+
+
+class RealtimeMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_client_exposes_stateful_realtime_helpers(self):
+        client = _build_logged_in_client()
+        transport = AsyncMock()
+        await client.realtime_connect(transport=transport)
+
+        assert isinstance(client.realtime, RealtimeClient)
+        transport.connect.assert_awaited_once()
+
+        await client.realtime_disconnect()
+        transport.disconnect.assert_awaited_once()
+
+    async def test_realtime_connect_preserves_handlers_registered_before_connect(self):
+        client = _build_logged_in_client()
+        transport = AsyncMock()
+        handler = Mock()
+
+        client.realtime_on("receive", handler)
+        await client.realtime_connect(transport=transport)
+        await client.realtime.emit("receive", {"topic": "146", "payload": {"ok": True}})
+
+        handler.assert_called_once_with({"topic": "146", "payload": {"ok": True}})


### PR DESCRIPTION
## Summary
- add an experimental async MQTToT packet/thrift codec and TLS stream transport
- add `RealtimeClient` plus stateful async `Client.realtime_*` helpers
- document the receive-only realtime workflow and add MIT attribution for the public reference implementation

## Scope
This is the aiograpi companion to the receive-only foundation for https://github.com/subzeroid/instagrapi/issues/2230. FBNS device auth, background worker management, and MQTT direct-send actions remain future work.

Reference: https://github.com/Nerixyz/instagram_mqtt

## Tests
- `.venv/bin/ruff check aiograpi/realtime aiograpi/mixins/realtime.py tests/regression/test_realtime.py`
- `.venv/bin/ruff format --check aiograpi/realtime aiograpi/mixins/realtime.py tests/regression/test_realtime.py`
- `.venv/bin/python -m pytest -q tests/regression/test_realtime.py tests/regression/test_direct.py`
- `.venv/bin/mkdocs build --strict`