### PR TITLE
feat: sync instagrapi 2.8.2 realtime MQTT/FBNS

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,6 +17,7 @@ on:
         options:
           - smoke
           - comment
+          - realtime
           - signup
           - all
 
@@ -147,6 +148,7 @@ jobs:
         python-version: [ "3.10" ]
     env:
       TEST_ACCOUNTS_URL: ${{ secrets.TEST_ACCOUNTS_URL }}
+      IG_REALTIME_PROXY: ${{ secrets.IG_REALTIME_PROXY }}
       IG_SIGNUP_EMAIL: ${{ secrets.IG_SIGNUP_EMAIL }}
       IG_SIGNUP_EMAIL_COMMAND: ${{ secrets.IG_SIGNUP_EMAIL_COMMAND }}
       IG_SIGNUP_EMAIL_CODE: ${{ secrets.IG_SIGNUP_EMAIL_CODE }}
@@ -191,6 +193,9 @@ jobs:
             exit 0
           fi
           PYTHONPATH=. pytest -sv tests/legacy.py::ClientCommentExtendTestCase::test_media_comment
+      - name: Run realtime MQTT live tests
+        if: github.event_name == 'workflow_dispatch' && (github.event.inputs.test_target == 'realtime' || github.event.inputs.test_target == 'all')
+        run: PYTHONPATH=. pytest -sv tests/live/test_realtime.py::ClientRealtimeLiveTestCase tests/live/test_fbns.py::ClientFbnsLiveTestCase
       - name: Run signup live tests
         if: github.event_name == 'workflow_dispatch' && (github.event.inputs.test_target == 'signup' || github.event.inputs.test_target == 'all')
         run: PYTHONPATH=. pytest -sv tests/live/test_signup_live.py::SignUpTestCase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ starting with 1.0.0.
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-02
+
+### Added
+
+- Added experimental async Realtime MQTT / MQTToT support through `Client.realtime_*` helpers and
+  `aiograpi.realtime.RealtimeClient`.
+- Added async Direct message sync over MQTT, including `direct_subscribe()` and event callbacks for `message`,
+  `direct`, `typing`, `seen`, and `presence`.
+- Added lightweight async Direct MQTT actions: `direct_send_text()`, `direct_send_reaction()`,
+  `direct_mark_seen()`, and `direct_indicate_activity()`.
+- Added async FBNS push MQTT support through `Client.fbns_*` helpers and `aiograpi.realtime.FbnsClient`,
+  including device-auth persistence in `settings["fbns_auth"]`, token registration, and `push` callbacks.
+- Added async `confirm_phone_number(...)`, `hashtag_following(...)`, and `media_share_to_story(...)`.
+- Added async Bloks challenge navigation helper that preserves opaque `challenge_context` values.
+
+### Fixed
+
+- Improved Reel/clip upload failures so early upload stages include stage, HTTP status, response JSON, and response text.
+
+### Changed
+
+- Added `PySocks` as a runtime dependency for realtime MQTT proxy transport.
+- Synced the recorded upstream baseline to `instagrapi` 2.8.2.
+
 ## [1.0.11] - 2026-05-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Android users should see [Pydroid and ffmpeg](docs/usage-guide/pydroid.md) and [
 [![License](https://img.shields.io/pypi/l/aiograpi)](LICENSE)
 [![Package](https://github.com/subzeroid/aiograpi/actions/workflows/python-package.yml/badge.svg)](https://github.com/subzeroid/aiograpi/actions/workflows/python-package.yml)
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://subzeroid.github.io/aiograpi/latest/)
-[![SemVer](https://img.shields.io/badge/semver-1.0.0-blue)](https://semver.org/spec/v2.0.0.html)
+[![SemVer](https://img.shields.io/badge/semver-1.1.0-blue)](https://semver.org/spec/v2.0.0.html)
 
 
 Features:
@@ -45,6 +45,7 @@ Features:
 * Management of proxy servers, mobile devices and challenge resolver
 * Login by username and password, sessionid, 2FA, 8-digit backup codes, and Bloks 2FA fallback/helpers
 * Managing messages, reactions and threads for Direct and attach files
+* Experimental Realtime MQTT/MQTToT for Direct message sync, lightweight Direct actions, and FBNS push callbacks
 * Download and upload a Photo, Video, IGTV, Reels, Albums, Stories and Trial Reels
 * Work with Users, Posts, Comments, Insights, Collections, Location and Hashtag
 * Insights by account, posts and stories
@@ -72,7 +73,8 @@ Support chat in Telegram: https://t.me/aiograpi_support
 6. [Like](https://subzeroid.github.io/aiograpi/latest/usage-guide/media/), [Follow](https://subzeroid.github.io/aiograpi/latest/usage-guide/user/), [Edit account](https://subzeroid.github.io/aiograpi/latest/usage-guide/account/) (Bio) and much more else
 7. [Insights](https://subzeroid.github.io/aiograpi/latest/usage-guide/insight/) by account, posts and stories
 8. [Build stories](https://subzeroid.github.io/aiograpi/latest/usage-guide/story/) with custom background, font animation, link sticker and mention users
-9. Account [registration](https://github.com/subzeroid/aiograpi/blob/main/aiograpi/mixins/signup.py) and captcha passing will appear
+9. [Realtime MQTT](https://subzeroid.github.io/aiograpi/latest/usage-guide/realtime/) for Direct message sync, lightweight Direct MQTT actions, and FBNS push notifications
+10. Account [registration](https://github.com/subzeroid/aiograpi/blob/main/aiograpi/mixins/signup.py) and captcha passing will appear
 
 ### Versioning policy
 
@@ -95,6 +97,10 @@ What you can rely on instead:
 
 ### What's new in 1.0.0 and recent releases
 
+- **1.1.0 MQTT/FBNS sync** — synced with `instagrapi 2.8.2`, adding experimental async Realtime MQTT/MQTToT,
+  Direct message sync, lightweight Direct MQTT actions, FBNS push token registration/callbacks, phone confirmation,
+  followed hashtag helpers, feed-media share-to-story, opaque Bloks challenge context handling, and clearer Reel upload
+  failure details.
 - **1.0.0 SemVer baseline** — synced with `instagrapi 2.7.0`, removed the dead public `?__a=1`
   API surface, kept `media_info_gql()` GraphQL-only, and moved high-level hashtag/location helpers
   to authenticated private/mobile flows.
@@ -151,6 +157,34 @@ cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 See the [public transport guide](docs/usage-guide/public-transport.md) for live comparison results and caveats.
 
 TLS certificate verification is enabled by default. For a trusted debugging MITM proxy, prefer `Client(tls_verify="/path/to/proxy-ca.pem")`; use `Client(tls_verify=False)` only for temporary local debugging because it allows session interception.
+
+### Realtime MQTT and Direct
+
+`aiograpi 1.1.0` adds experimental async Realtime MQTT/MQTToT helpers. They can receive Direct message sync payloads,
+publish lightweight Direct actions over MQTT, and subscribe to FBNS push notifications.
+
+```python
+from aiograpi import Client
+
+cl = Client()
+await cl.login(USERNAME, PASSWORD)
+
+
+def handle_message(payload):
+    print(payload)
+
+
+cl.realtime_on("message", handle_message)
+rt = await cl.realtime_connect()
+await rt.direct_subscribe()
+
+await rt.direct_send_text(thread_id, "Hello from MQTT")
+
+while True:
+    await cl.realtime_read_once()
+```
+
+See the [Realtime MQTT guide](docs/usage-guide/realtime.md) for Direct sync, MQTT Direct actions, and FBNS push examples.
 
 ### Basic Usage
 

--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -33,6 +33,7 @@ from aiograpi.mixins.public import (
     PublicRequestMixin,
     TopSearchesPublicMixin,
 )
+from aiograpi.mixins.realtime import RealtimeMixin
 from aiograpi.mixins.share import ShareMixin
 from aiograpi.mixins.signup import SignUpMixin
 from aiograpi.mixins.story import StoryMixin
@@ -45,7 +46,7 @@ from aiograpi.mixins.video import DownloadVideoMixin, UploadVideoMixin
 # Used as fallback logger if another is not provided.
 DEFAULT_LOGGER = logging.getLogger("aiograpi")
 
-__upstream_instagrapi_version__ = "2.7.17"
+__upstream_instagrapi_version__ = "2.8.2"
 
 
 class Client(
@@ -91,6 +92,7 @@ class Client(
     BloksMixin,
     TOTPMixin,
     FundraiserMixin,
+    RealtimeMixin,
 ):
     proxy = None
 

--- a/aiograpi/mixins/account.py
+++ b/aiograpi/mixins/account.py
@@ -475,3 +475,29 @@ class AccountMixin(ClientMixin):
                 }
             ),
         )
+
+    async def confirm_phone_number(self, phone_number: str, code: str, has_sms_consent: bool = False) -> dict:
+        """
+        Confirm new phone number by SMS code
+
+        Parameters
+        ----------
+        phone_number: str
+            Phone number
+        code: str
+            Confirmation code
+        has_sms_consent: bool, default False
+            Whether to include Instagram's SMS consent flag
+
+        Returns
+        -------
+        dict
+            Jsonified response from Instagram
+        """
+        data = {"phone_number": phone_number, "verification_code": code}
+        if has_sms_consent:
+            data["has_sms_consent"] = "true"
+        return await self.private_request(
+            "accounts/verify_sms_code/",
+            self.with_extra_data(data),
+        )

--- a/aiograpi/mixins/account.py
+++ b/aiograpi/mixins/account.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from aiograpi.extractors import extract_account, extract_user_short
 from aiograpi.mixins.base import ClientMixin
@@ -315,7 +315,7 @@ class AccountMixin(ClientMixin):
         """
         return await self.private_request("accounts/account_security_info/", self.with_default_data({}))
 
-    async def account_edit(self, **data: Dict) -> Account:
+    async def account_edit(self, **data: Any) -> Account:
         """
         Edit your profile (authorized account)
 

--- a/aiograpi/mixins/bloks.py
+++ b/aiograpi/mixins/bloks.py
@@ -65,6 +65,45 @@ class BloksMixin(ClientMixin):
         data = self._bloks_payload(params, bloks_versioning_id=bloks_versioning_id)
         return await self.private_request(f"bloks/apps/{app}/", data=data, with_signature=False)
 
+    async def bloks_challenge_take_challenge(
+        self,
+        challenge_context: str = "",
+        choice: Optional[int] = None,
+        has_follow_up_screens: int = 0,
+        extra_data: Optional[Dict[str, Any]] = None,
+        bloks_versioning_id: str = "",
+    ) -> Dict:
+        """
+        Submit a challenge-navigation Bloks request.
+
+        Instagram may return ``challenge_context`` as an opaque string instead
+        of JSON. Pass it through unchanged; it is not decoded by the client.
+
+        Returns
+        -------
+        Dict
+            Raw Instagram response.
+        """
+        versioning_id = bloks_versioning_id or self.bloks_versioning_id
+        assert versioning_id, "Client.bloks_versioning_id is empty (hash is expected)"
+        data = {
+            "_uuid": self.uuid,
+            "has_follow_up_screens": str(has_follow_up_screens),
+            "bk_client_context": dumps({"bloks_version": versioning_id, "styles_id": "instagram"}),
+            "bloks_versioning_id": versioning_id,
+        }
+        if challenge_context is not None:
+            data["challenge_context"] = challenge_context
+        if choice is not None:
+            data["choice"] = str(choice)
+        if extra_data:
+            data.update(extra_data)
+        return await self.private_request(
+            "bloks/apps/com.instagram.challenge.navigation.take_challenge/",
+            data=data,
+            with_signature=False,
+        )
+
     async def bloks_fxcal_link_reels_share(
         self,
         flow: str = "ig_fb_reels_composer_rowshare",
@@ -626,26 +665,28 @@ class BloksMixin(ClientMixin):
         result = await self.private_request(f"bloks/apps/{action}/", self.with_default_data(data))
         return result["status"] == "ok"
 
-    async def bloks_change_password(self, password: str, challenge_context: dict) -> bool:
+    async def bloks_change_password(self, password: str, challenge_context: str) -> bool:
         """
         Change password for challenge
 
         Parameters
         ----------
-        passwrd: str
+        password: str
             New password
+        challenge_context: str
+            Challenge context returned by Instagram. The value may be opaque
+            and is sent back unchanged.
 
         Returns
         -------
         bool
         """
-        assert self.bloks_versioning_id, "Client.bloks_versioning_id is empty (hash is expected)"
         enc_password = await self.password_encrypt(password)
-        data = {
-            "bk_client_context": dumps({"bloks_version": self.bloks_versioning_id, "styles_id": "instagram"}),
-            "challenge_context": challenge_context,
-            "bloks_versioning_id": self.bloks_versioning_id,
-            "enc_new_password1": enc_password,
-            "enc_new_password2": enc_password,
-        }
-        return await self.bloks_action("com.instagram.challenge.navigation.take_challenge", data)
+        result = await self.bloks_challenge_take_challenge(
+            challenge_context=challenge_context,
+            extra_data={
+                "enc_new_password1": enc_password,
+                "enc_new_password2": enc_password,
+            },
+        )
+        return result["status"] == "ok"

--- a/aiograpi/mixins/clip.py
+++ b/aiograpi/mixins/clip.py
@@ -878,13 +878,13 @@ def crop_thumbnail(path: Path) -> bool:
     bool
         A boolean value
     """
-    im = Image.open(str(path))
+    im: Image.Image = Image.open(str(path))
     width, height = im.size
     offset = (height / 1.78) / 2
     center = width / 2
     # Crop the center of the image
     im = im.crop((center - offset, 0, center + offset, height))
-    with open(path, "w") as fp:
+    with open(path, "wb") as fp:
         im.save(fp)
         im.close()
     return True

--- a/aiograpi/mixins/clip.py
+++ b/aiograpi/mixins/clip.py
@@ -33,6 +33,30 @@ class ClipMixin(ClientMixin):
     Helpers for CLIP/Reel actions
     """
 
+    def _raise_clip_upload_error(self, response, stage: str) -> None:
+        self.last_response = response
+        status_code = getattr(response, "status_code", None)
+        response_text = getattr(response, "text", "") or ""
+        error_response = {}
+        try:
+            parsed = response.json()
+        except Exception:
+            parsed = None
+        if isinstance(parsed, dict):
+            error_response = parsed
+            self.last_json = parsed
+        else:
+            self.last_json = {}
+        details = response_text or error_response
+        raise ClipNotUpload(
+            f"Clip upload failed during {stage}: HTTP {status_code}: {details}",
+            response=response,
+            stage=stage,
+            status_code=status_code,
+            error_response=error_response,
+            response_text=response_text,
+        )
+
     async def clip_pin(self, media_pk: str, revert: bool = False) -> bool:
         """
         Pin Reel to the Reels tab/profile Reels grid
@@ -481,7 +505,7 @@ class UploadClipMixin(ClientMixin):
         )
         self.request_log(response)
         if response.status_code != 200:
-            raise ClipNotUpload(response=self.last_response, **self.last_json)
+            self._raise_clip_upload_error(response, "upload_settings")
         rupload_params = {
             "provenance_metadata": json.dumps({"origin": ["EXTERNAL"]}),
             "upload_media_height": str(height),
@@ -515,7 +539,7 @@ class UploadClipMixin(ClientMixin):
         )
         self.request_log(response)
         if response.status_code != 200:
-            raise ClipNotUpload(response=self.last_response, **self.last_json)
+            self._raise_clip_upload_error(response, "rupload_init")
         headers = {
             "Offset": "0",
             "X-Entity-Name": upload_name,
@@ -531,7 +555,7 @@ class UploadClipMixin(ClientMixin):
         )
         self.request_log(response)
         if response.status_code != 200:
-            raise ClipNotUpload(response=self.last_response, **self.last_json)
+            self._raise_clip_upload_error(response, "rupload_upload")
         # CONFIGURE
         # self.igtv_composer_session_id = self.generate_uuid()  #issue
         for attempt in range(50):

--- a/aiograpi/mixins/hashtag.py
+++ b/aiograpi/mixins/hashtag.py
@@ -331,6 +331,56 @@ class HashtagMixin(ClientMixin):
         result = await self.private_request(f"web/tags/{name}/{hashtag}/", domain="www.instagram.com", data=data)
         return result["status"] == "ok"
 
+    async def hashtag_following(self, amount: int = 0) -> List[Hashtag]:
+        """
+        Get hashtags followed by the authenticated account
+
+        Parameters
+        ----------
+        amount: int, optional
+            Maximum number of hashtags to return. Value 0 returns all hashtags
+            returned by Instagram.
+
+        Returns
+        -------
+        List[Hashtag]
+            List of objects of Hashtag
+        """
+        assert self.user_id, "Login required"
+        result = await self.private_graphql_following_list(
+            str(self.user_id),
+            self.rank_token,
+            priority="u=3, i",
+            skip_preview_hashtags=False,
+            skip_hashtag_count=False,
+        )
+        data = result.get("data") or {}
+        following = next(
+            (
+                value
+                for key, value in data.items()
+                if isinstance(value, dict) and "xdt_api__v1__friendships__following" in key
+            ),
+            {},
+        )
+        hashtags = []
+        for item in following.get("preview_hashtags") or []:
+            if not isinstance(item, dict):
+                continue
+            node = item.get("hashtag") or item.get("node") or item
+            if not isinstance(node, dict) or not node:
+                continue
+            node = dict(node)
+            node["id"] = node.get("id") or node.get("pk")
+            node["media_count"] = node.get("media_count") or node.get("post_count") or node.get("postCount")
+            node["profile_pic_url"] = node.get("profile_pic_url") or node.get("profilePictureUrl") or None
+            if not node.get("id") or not node.get("name"):
+                continue
+            hashtags.append(Hashtag(**node))
+        if amount:
+            hashtags = hashtags[:amount]
+        return hashtags
+
     async def hashtag_unfollow(self, hashtag: str) -> bool:
         """
         Unfollow to hashtag

--- a/aiograpi/mixins/hashtag.py
+++ b/aiograpi/mixins/hashtag.py
@@ -347,7 +347,7 @@ class HashtagMixin(ClientMixin):
             List of objects of Hashtag
         """
         assert self.user_id, "Login required"
-        result = await self.private_graphql_following_list(
+        result = await self.private_graphql_following_list(  # type: ignore[attr-defined]
             str(self.user_id),
             self.rank_token,
             priority="u=3, i",

--- a/aiograpi/mixins/media.py
+++ b/aiograpi/mixins/media.py
@@ -365,7 +365,7 @@ class MediaMixin(ClientMixin):
     async def media_share_to_story(
         self,
         media_id: str,
-        background: Path = None,
+        background: Path | None = None,
         caption: str = "",
         x: float = 0.5,
         y: float = 0.4997396,
@@ -420,12 +420,12 @@ class MediaMixin(ClientMixin):
             background = Path(background)
 
         try:
-            return await self.photo_upload_to_story(
+            return await self.photo_upload_to_story(  # type: ignore[attr-defined]
                 background,
                 caption,
                 medias=[
                     StoryMedia(
-                        media_pk=media_pk,
+                        media_pk=int(media_pk),
                         user_id=media_owner_id,
                         x=x,
                         y=y,

--- a/aiograpi/mixins/media.py
+++ b/aiograpi/mixins/media.py
@@ -1,8 +1,10 @@
 import asyncio
 import json
 import random
+import tempfile
 from copy import deepcopy
 from datetime import datetime
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -28,7 +30,7 @@ from aiograpi.extractors import (
 )
 from aiograpi.mixins.base import ClientMixin
 from aiograpi.mixins.graphql import GQL_STUFF
-from aiograpi.types import Location, Media, Story, UserShort, Usertag
+from aiograpi.types import Location, Media, Story, StoryMedia, UserShort, Usertag
 from aiograpi.utils.auth import generate_jazoest
 from aiograpi.utils.ids import InstagramIdCodec
 from aiograpi.utils.serialization import dumps, json_value
@@ -43,6 +45,19 @@ class MediaMixin(ClientMixin):
     """
 
     _medias_cache = {}  # pk -> object
+
+    def _media_share_story_background(self) -> Path:
+        temp = tempfile.NamedTemporaryFile(prefix="aiograpi_story_share_", suffix=".jpg", delete=False)
+        temp.close()
+        path = Path(temp.name)
+        try:
+            from PIL import Image
+
+            Image.new("RGB", (720, 1280), (0, 0, 0)).save(path, format="JPEG", quality=95)
+        except Exception:
+            path.unlink(missing_ok=True)
+            raise
+        return path
 
     @staticmethod
     def _find_profile_timeline_payload(data):
@@ -346,6 +361,84 @@ class MediaMixin(ClientMixin):
         if "_" in media_pk:
             media_pk, _ = media_id.split("_")
         return str(media_pk)
+
+    async def media_share_to_story(
+        self,
+        media_id: str,
+        background: Path = None,
+        caption: str = "",
+        x: float = 0.5,
+        y: float = 0.4997396,
+        width: float = 0.8,
+        height: float = 0.60572916,
+        rotation: float = 0.0,
+        extra_data: Optional[Dict[str, str]] = None,
+    ) -> Story:
+        """
+        Share an existing feed media as a story.
+
+        Parameters
+        ----------
+        media_id: str
+            Media pk or full media id (``pk_userid``) to share
+        background: Path, optional
+            9:16 background image for the story. When omitted, a black 720x1280
+            image is generated temporarily.
+        caption: str, optional
+            Story caption
+        x: float, optional
+            Feed media sticker x position
+        y: float, optional
+            Feed media sticker y position
+        width: float, optional
+            Feed media sticker width
+        height: float, optional
+            Feed media sticker height
+        rotation: float, optional
+            Feed media sticker rotation
+        extra_data: Dict[str, str], optional
+            Additional story configure fields
+
+        Returns
+        -------
+        Story
+            An object of Story
+        """
+        assert self.user_id, "Login required"
+        media_id = str(media_id)
+        media_pk = self.media_pk(media_id)
+        media_owner_id = None
+        if "_" in media_id:
+            _, owner_id = media_id.split("_", 1)
+            media_owner_id = int(owner_id) if owner_id.isdigit() else None
+
+        generated_background = None
+        if background is None:
+            generated_background = self._media_share_story_background()
+            background = generated_background
+        else:
+            background = Path(background)
+
+        try:
+            return await self.photo_upload_to_story(
+                background,
+                caption,
+                medias=[
+                    StoryMedia(
+                        media_pk=media_pk,
+                        user_id=media_owner_id,
+                        x=x,
+                        y=y,
+                        width=width,
+                        height=height,
+                        rotation=rotation,
+                    )
+                ],
+                extra_data=extra_data or {},
+            )
+        finally:
+            if generated_background:
+                generated_background.unlink(missing_ok=True)
 
     def media_code_from_pk(self, media_pk: str) -> str:
         """

--- a/aiograpi/mixins/realtime.py
+++ b/aiograpi/mixins/realtime.py
@@ -36,10 +36,12 @@ class RealtimeMixin:
             raise RuntimeError("Realtime client is not connected")
         return await self.realtime.ping()
 
-    def fbns_client(self, transport=None, auth: FbnsDeviceAuth = None) -> FbnsClient:
+    def fbns_client(self, transport=None, auth: FbnsDeviceAuth | None = None) -> FbnsClient:
         return FbnsClient(self, transport=transport, auth=auth)
 
-    async def fbns_connect(self, transport=None, auth: FbnsDeviceAuth = None, register: bool = True) -> FbnsClient:
+    async def fbns_connect(
+        self, transport=None, auth: FbnsDeviceAuth | None = None, register: bool = True
+    ) -> FbnsClient:
         if not self.fbns:
             self.fbns = self.fbns_client(transport=transport, auth=auth)
         else:

--- a/aiograpi/mixins/realtime.py
+++ b/aiograpi/mixins/realtime.py
@@ -1,0 +1,71 @@
+from aiograpi.realtime import FbnsClient, FbnsDeviceAuth, RealtimeClient
+
+
+class RealtimeMixin:
+    realtime = None
+    fbns = None
+
+    def realtime_client(self, transport=None) -> RealtimeClient:
+        return RealtimeClient(self, transport=transport)
+
+    async def realtime_connect(self, transport=None) -> RealtimeClient:
+        if not self.realtime:
+            self.realtime = self.realtime_client(transport=transport)
+        elif transport is not None:
+            self.realtime.transport = transport
+        await self.realtime.connect()
+        return self.realtime
+
+    async def realtime_disconnect(self) -> None:
+        if self.realtime:
+            await self.realtime.disconnect()
+            self.realtime = None
+
+    def realtime_on(self, event: str, handler) -> None:
+        if not self.realtime:
+            self.realtime = self.realtime_client()
+        self.realtime.on(event, handler)
+
+    async def realtime_read_once(self):
+        if not self.realtime:
+            raise RuntimeError("Realtime client is not connected")
+        return await self.realtime.read_once()
+
+    async def realtime_ping(self) -> bool:
+        if not self.realtime:
+            raise RuntimeError("Realtime client is not connected")
+        return await self.realtime.ping()
+
+    def fbns_client(self, transport=None, auth: FbnsDeviceAuth = None) -> FbnsClient:
+        return FbnsClient(self, transport=transport, auth=auth)
+
+    async def fbns_connect(self, transport=None, auth: FbnsDeviceAuth = None, register: bool = True) -> FbnsClient:
+        if not self.fbns:
+            self.fbns = self.fbns_client(transport=transport, auth=auth)
+        else:
+            if transport is not None:
+                self.fbns.transport = transport
+            if auth is not None:
+                self.fbns.auth = auth
+        await self.fbns.connect(register=register)
+        return self.fbns
+
+    async def fbns_disconnect(self) -> None:
+        if self.fbns:
+            await self.fbns.disconnect()
+            self.fbns = None
+
+    def fbns_on(self, event: str, handler) -> None:
+        if not self.fbns:
+            self.fbns = self.fbns_client()
+        self.fbns.on(event, handler)
+
+    async def fbns_read_once(self):
+        if not self.fbns:
+            raise RuntimeError("FBNS client is not connected")
+        return await self.fbns.read_once()
+
+    async def fbns_ping(self) -> bool:
+        if not self.fbns:
+            raise RuntimeError("FBNS client is not connected")
+        return await self.fbns.ping()

--- a/aiograpi/mixins/user.py
+++ b/aiograpi/mixins/user.py
@@ -2022,6 +2022,8 @@ class UserMixin(ClientMixin):
         order: Union[str, None] = None,
         exclude_field_is_favorite: Optional[bool] = None,
         exclude_unused_fields: Optional[bool] = None,
+        skip_preview_hashtags: bool = True,
+        skip_hashtag_count: bool = True,
     ) -> dict:
         """
         Private-side ``FollowersList`` GraphQL query.
@@ -2099,6 +2101,8 @@ class UserMixin(ClientMixin):
         order: Union[str, None] = None,
         exclude_field_is_favorite: Optional[bool] = None,
         exclude_unused_fields: Optional[bool] = None,
+        skip_preview_hashtags: bool = True,
+        skip_hashtag_count: bool = True,
     ) -> dict:
         """
         Private-side ``FollowingList`` GraphQL query.
@@ -2114,7 +2118,7 @@ class UserMixin(ClientMixin):
         variables = {
             "user_id": str(user_id),
             "skip_use_clickable_see_more": True,
-            "skip_preview_hashtags": True,
+            "skip_preview_hashtags": skip_preview_hashtags,
             "skip_should_limit_list_of_followers": True,
             "skip_pending_admins": True,
             "skip_more_groups_available": True,
@@ -2129,7 +2133,7 @@ class UserMixin(ClientMixin):
             "include_unseen_count": True,
             "skip_has_more": True,
             "enable_groups": True,
-            "skip_hashtag_count": True,
+            "skip_hashtag_count": skip_hashtag_count,
         }
         if exclude_field_is_favorite is not None:
             variables["exclude_field_is_favorite"] = exclude_field_is_favorite

--- a/aiograpi/realtime/__init__.py
+++ b/aiograpi/realtime/__init__.py
@@ -1,0 +1,4 @@
+from aiograpi.realtime.client import RealtimeClient
+from aiograpi.realtime.fbns import FbnsClient, FbnsDeviceAuth
+
+__all__ = ["FbnsClient", "FbnsDeviceAuth", "RealtimeClient"]

--- a/aiograpi/realtime/client.py
+++ b/aiograpi/realtime/client.py
@@ -1,0 +1,460 @@
+import asyncio
+import json
+import time
+import uuid
+from collections import defaultdict
+from typing import Any, Callable, Dict, Iterable, List
+
+from aiograpi.realtime.mqttot import (
+    MQTToTConnection,
+    MQTToTTopics,
+    SocketMQTToTTransport,
+    ThriftDescriptor,
+    ThriftTypes,
+    compress_payload,
+    decode_packet,
+    parse_json_payload,
+    try_decompress_payload,
+    write_connect_packet,
+    write_disconnect_packet,
+    write_pingreq_packet,
+    write_publish_packet,
+    write_thrift_object,
+)
+
+REALTIME_HOST = "edge-mqtt.facebook.com"
+IG_REALTIME_APP_ID = 567067343352427
+REALTIME_SUBSCRIBE_TOPICS = [88, 135, 149, 150, 133, 146]
+
+
+class RealtimeClient:
+    def __init__(self, client, transport=None):
+        self.client = client
+        self.transport = transport or SocketMQTToTTransport(REALTIME_HOST, proxy=getattr(client, "proxy", None))
+        self.connected = False
+        self._handlers: Dict[str, List[Callable[[Any], None]]] = defaultdict(list)
+        self._packet_id = 0
+
+    def on(self, event: str, handler: Callable[[Any], None]) -> None:
+        self._handlers[event].append(handler)
+
+    async def connect(self) -> None:
+        await asyncio.to_thread(self.transport.connect)
+        if isinstance(self.transport, SocketMQTToTTransport):
+            await self._send(write_connect_packet(self.build_connection()))
+            packet = decode_packet(await self._recv_packet())
+            if packet.packet_type != "connack" or packet.return_code != 0:
+                raise ConnectionError(f"Realtime MQTT connect failed: {packet.return_code}")
+        self.connected = True
+
+    async def disconnect(self) -> None:
+        if isinstance(self.transport, SocketMQTToTTransport) and self.connected:
+            await self._send(write_disconnect_packet())
+        await asyncio.to_thread(self.transport.disconnect)
+        self.connected = False
+
+    def build_connection(self) -> MQTToTConnection:
+        sessionid = self.client.sessionid
+        assert sessionid, "Login required"
+        device_id = self.client.phone_id
+        assert device_id, "Client phone_id is required"
+        user_agent = self.client.user_agent
+        app_version = self.client_app_version()
+        capabilities = getattr(self.client, "capabilities", "3brTv10=")
+        locale = getattr(self.client, "locale", "en_US")
+        return MQTToTConnection(
+            client_identifier=device_id[:20],
+            client_info={
+                "userId": int(self.client.user_id),
+                "userAgent": user_agent,
+                "clientCapabilities": 183,
+                "endpointCapabilities": 0,
+                "publishFormat": 1,
+                "noAutomaticForeground": False,
+                "makeUserAvailableInForeground": True,
+                "deviceId": device_id,
+                "isInitiallyForeground": True,
+                "networkType": 1,
+                "networkSubtype": 0,
+                "clientMqttSessionId": int(time.time() * 1000) & 0xFFFFFFFF,
+                "subscribeTopics": REALTIME_SUBSCRIBE_TOPICS,
+                "clientType": "cookie_auth",
+                "appId": IG_REALTIME_APP_ID,
+                "deviceSecret": "",
+                "clientStack": 3,
+            },
+            password=f"sessionid={sessionid}",
+            app_specific_info={
+                "app_version": app_version,
+                "X-IG-Capabilities": capabilities,
+                "everclear_subscriptions": json.dumps(
+                    {
+                        "inapp_notification_subscribe_comment": "17899377895239777",
+                        "inapp_notification_subscribe_comment_mention_and_reply": "17899377895239777",
+                        "video_call_participant_state_delivery": "17977239895057311",
+                        "presence_subscribe": "17846944882223835",
+                    },
+                    separators=(",", ":"),
+                ),
+                "User-Agent": user_agent,
+                "Accept-Language": locale.replace("_", "-"),
+                "platform": "android",
+                "ig_mqtt_route": "django",
+                "pubsub_msg_type_blacklist": "direct, typing_type",
+                "auth_cache_enabled": "0",
+            },
+        )
+
+    async def graph_ql_subscribe(self, subscriptions: str | Iterable[str]) -> None:
+        if isinstance(subscriptions, str):
+            subscriptions = [subscriptions]
+        await self.publish_json(MQTToTTopics.REALTIME_SUB, {"sub": list(subscriptions)})
+
+    async def skywalker_subscribe(self, subscriptions: str | Iterable[str]) -> None:
+        if isinstance(subscriptions, str):
+            subscriptions = [subscriptions]
+        await self.publish_json(MQTToTTopics.PUBSUB, {"sub": list(subscriptions)})
+
+    async def iris_subscribe(self, seq_id: int, snapshot_at_ms: int, snapshot_app_version: str | None = None) -> None:
+        await self.publish_json(
+            MQTToTTopics.IRIS_SUB,
+            {
+                "seq_id": seq_id,
+                "snapshot_at_ms": snapshot_at_ms,
+                "snapshot_app_version": snapshot_app_version or self.client_app_version(),
+            },
+        )
+
+    async def direct_subscribe(self, amount: int = 1) -> Dict[str, Any]:
+        await self.client.direct_threads(amount=amount)
+        seq_id = self.client.last_json.get("seq_id")
+        snapshot_at_ms = self.client.last_json.get("snapshot_at_ms")
+        if seq_id is None or snapshot_at_ms is None:
+            raise RuntimeError("Direct inbox did not return realtime sync state")
+        state = {"seq_id": seq_id, "snapshot_at_ms": snapshot_at_ms}
+        await self.iris_subscribe(**state)
+        return state
+
+    async def direct_send_text(
+        self, thread_id: int | str, text: str, client_context: str | None = None
+    ) -> Dict[str, Any]:
+        return await self._publish_direct_command(
+            "send_item",
+            thread_id,
+            {"item_type": "text", "text": text},
+            client_context=client_context or self.new_client_context(),
+        )
+
+    async def direct_send_reaction(
+        self,
+        thread_id: int | str,
+        item_id: str,
+        emoji: str = "",
+        reaction_type: str = "like",
+        reaction_status: str = "created",
+        target_item_type: str = "text",
+        client_context: str | None = None,
+    ) -> Dict[str, Any]:
+        return await self._publish_direct_command(
+            "send_item",
+            thread_id,
+            {
+                "item_type": "reaction",
+                "item_id": item_id,
+                "node_type": "item",
+                "reaction_type": reaction_type,
+                "reaction_status": reaction_status,
+                "target_item_type": target_item_type,
+                "emoji": emoji,
+            },
+            client_context=client_context or self.new_client_context(),
+        )
+
+    async def direct_mark_seen(self, thread_id: int | str, item_id: str) -> Dict[str, Any]:
+        return await self._publish_direct_command("mark_seen", thread_id, {"item_id": item_id})
+
+    async def direct_indicate_activity(
+        self,
+        thread_id: int | str,
+        is_active: bool = True,
+        client_context: str | None = None,
+    ) -> Dict[str, Any]:
+        return await self._publish_direct_command(
+            "indicate_activity",
+            thread_id,
+            {"activity_status": "1" if is_active else "0"},
+            client_context=client_context or self.new_client_context(),
+        )
+
+    async def send_foreground_state(
+        self,
+        in_foreground_app: bool | None = None,
+        in_foreground_device: bool | None = None,
+        keep_alive_timeout: int | None = None,
+        subscribe_topics: List[str] | None = None,
+        subscribe_generic_topics: List[str] | None = None,
+        unsubscribe_topics: List[str] | None = None,
+        unsubscribe_generic_topics: List[str] | None = None,
+        request_id: int | None = None,
+    ) -> Dict[str, Any]:
+        state = {
+            "inForegroundApp": in_foreground_app,
+            "inForegroundDevice": in_foreground_device,
+            "keepAliveTimeout": keep_alive_timeout,
+            "subscribeTopics": subscribe_topics,
+            "subscribeGenericTopics": subscribe_generic_topics,
+            "unsubscribeTopics": unsubscribe_topics,
+            "unsubscribeGenericTopics": unsubscribe_generic_topics,
+            "requestId": request_id,
+        }
+        state = {key: value for key, value in state.items() if value is not None}
+        await self._publish_bytes(
+            MQTToTTopics.FOREGROUND_STATE,
+            compress_payload(b"\x00" + write_thrift_object(state, self.foreground_state_descriptors())),
+        )
+        return state
+
+    async def _publish_direct_command(
+        self,
+        action: str,
+        thread_id: int | str,
+        data: Dict[str, Any],
+        client_context: str | None = None,
+    ) -> Dict[str, Any]:
+        payload = {"action": action, "thread_id": str(thread_id), **data}
+        if client_context:
+            payload["client_context"] = client_context
+        await self._publish_bytes(
+            MQTToTTopics.SEND_MESSAGE,
+            compress_payload(json.dumps(payload, separators=(",", ":")).encode()),
+        )
+        state = {"thread_id": str(thread_id), "action": action}
+        if client_context:
+            state["client_context"] = client_context
+        return state
+
+    async def publish_json(self, topic: str, data: Dict[str, Any]) -> None:
+        await self._publish_bytes(topic, compress_payload(json.dumps(data, separators=(",", ":")).encode()))
+
+    async def _publish_bytes(self, topic: str, payload: bytes) -> None:
+        self._packet_id += 1
+        packet = write_publish_packet(
+            topic,
+            payload,
+            qos=1,
+            packet_id=self._packet_id,
+        )
+        await self._send(packet)
+
+    async def read_once(self) -> Any:
+        packet = decode_packet(await self._recv_packet())
+        if packet.packet_type != "publish":
+            return packet
+        if packet.topic is None:
+            return packet
+        payload = self.dispatch_packet(packet.topic, packet.payload)
+        if packet.qos == 1 and packet.packet_id is not None:
+            await self._send(b"\x40\x02" + packet.packet_id.to_bytes(2, "big"))
+        return payload
+
+    async def ping(self, max_packets: int = 5) -> bool:
+        if not self.connected:
+            raise RuntimeError("Realtime client is not connected")
+        await self._send(write_pingreq_packet())
+        for _ in range(max_packets):
+            packet = decode_packet(await self._recv_packet())
+            if packet.packet_type == "pingresp":
+                return True
+            if packet.packet_type != "publish" or packet.topic is None:
+                return False
+            self.dispatch_packet(packet.topic, packet.payload)
+            if packet.qos == 1 and packet.packet_id is not None:
+                await self._send(b"\x40\x02" + packet.packet_id.to_bytes(2, "big"))
+        return False
+
+    async def _send(self, packet: bytes) -> None:
+        await asyncio.to_thread(self.transport.send, packet)
+
+    async def _recv_packet(self) -> bytes:
+        return await asyncio.to_thread(self.transport.recv_packet)
+
+    def dispatch_packet(self, topic: str, payload: bytes) -> Any:
+        body = try_decompress_payload(payload)
+        parsed = None
+        if topic in {
+            MQTToTTopics.SEND_MESSAGE_RESPONSE,
+            MQTToTTopics.IRIS_SUB_RESPONSE,
+            MQTToTTopics.REALTIME_SUB,
+            MQTToTTopics.MESSAGE_SYNC,
+        }:
+            try:
+                parsed = json.loads(body.decode())
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                parsed = body
+        else:
+            try:
+                parsed = parse_json_payload(payload)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                parsed = body
+        self.emit("receive", {"topic": topic, "payload": parsed})
+        if topic == MQTToTTopics.SEND_MESSAGE_RESPONSE:
+            self.emit("send_response", parsed)
+        if topic == MQTToTTopics.IRIS_SUB_RESPONSE:
+            self.emit("iris_sub_response", parsed)
+        if topic == MQTToTTopics.MESSAGE_SYNC:
+            self.dispatch_message_sync(parsed)
+        if topic == MQTToTTopics.REALTIME_SUB:
+            self.dispatch_realtime_sub(parsed)
+        return parsed
+
+    def dispatch_message_sync(self, payload: Any) -> None:
+        if not isinstance(payload, list):
+            self.emit("message", payload)
+            return
+        for item in payload:
+            if not isinstance(item, dict):
+                self.emit("iris", item)
+                continue
+            patches = item.get("data")
+            if not isinstance(patches, list):
+                self.emit("iris", item)
+                continue
+            meta = {key: value for key, value in item.items() if key != "data"}
+            if not patches:
+                wrapper = {"message": meta}
+                if item.get("delta_type") == "deltaNewMessage":
+                    self.emit("message", wrapper)
+                else:
+                    self.emit("iris", wrapper)
+                continue
+            for patch in patches:
+                if not isinstance(patch, dict):
+                    self.emit("iris", {**meta, "data": patch})
+                    continue
+                path = patch.get("path")
+                raw_value = patch.get("value")
+                if not path or raw_value is None:
+                    self.emit("iris", {**meta, **patch})
+                    continue
+                try:
+                    value = json.loads(raw_value) if isinstance(raw_value, str) else raw_value
+                except json.JSONDecodeError:
+                    value = {"value": raw_value}
+                wrapper = {
+                    **meta,
+                    "message": {
+                        "path": path,
+                        "op": patch.get("op"),
+                        "thread_id": self.thread_id_from_message_sync_path(path),
+                        **(value if isinstance(value, dict) else {"value": value}),
+                    },
+                }
+                if path.startswith("/direct_v2/threads/"):
+                    self.emit("message", wrapper)
+                else:
+                    self.emit("thread_update", wrapper)
+                self.dispatch_direct_realtime_event({"path": path, "op": patch.get("op"), "value": value})
+
+    def dispatch_realtime_sub(self, payload: Any) -> None:
+        self.emit("realtime_sub", payload)
+        if not isinstance(payload, dict):
+            return
+        message = payload.get("message")
+        if isinstance(message, str):
+            try:
+                self.dispatch_direct_realtime_payload(json.loads(message))
+            except json.JSONDecodeError:
+                return
+            return
+        if not isinstance(message, dict):
+            return
+        if message.get("topic") != "direct":
+            return
+        direct_payload = message.get("json") or message.get("payload")
+        if isinstance(direct_payload, str):
+            try:
+                direct_payload = json.loads(direct_payload)
+            except json.JSONDecodeError:
+                direct_payload = {"value": direct_payload}
+        self.dispatch_direct_realtime_payload(direct_payload)
+
+    def dispatch_direct_realtime_payload(self, payload: Any) -> None:
+        if not isinstance(payload, dict):
+            self.dispatch_direct_realtime_event({"value": payload})
+            return
+        data = payload.get("data")
+        if not isinstance(data, list):
+            self.dispatch_direct_realtime_event(payload)
+            return
+        meta = {key: value for key, value in payload.items() if key != "data"}
+        for item in data:
+            if isinstance(item, dict):
+                self.dispatch_direct_realtime_event({**meta, **item})
+            else:
+                self.dispatch_direct_realtime_event({**meta, "value": item})
+
+    def dispatch_direct_realtime_event(self, event: Dict[str, Any]) -> None:
+        event = dict(event)
+        value = event.get("value")
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except json.JSONDecodeError:
+                pass
+        event["value"] = value
+        path = event.get("path")
+        if path and "thread_id" not in event:
+            event["thread_id"] = self.thread_id_from_message_sync_path(path)
+        self.emit("direct", event)
+        kind = self.direct_realtime_event_kind(event)
+        if kind:
+            self.emit(kind, event)
+
+    @staticmethod
+    def direct_realtime_event_kind(event: Dict[str, Any]) -> str | None:
+        path = str(event.get("path") or "").lower()
+        action = str(event.get("action") or "").lower()
+        value = event.get("value")
+        value_text = json.dumps(value, sort_keys=True).lower() if isinstance(value, dict) else str(value).lower()
+        if "activity_status" in value_text or "activity_indicator" in path or "typing" in path:
+            return "typing"
+        if "presence" in path or "is_active" in value_text or "last_active" in value_text:
+            return "presence"
+        if action == "mark_seen" or "/seen" in path or "seen_" in path or "read" in path or "seen" in value_text:
+            return "seen"
+        return None
+
+    @staticmethod
+    def thread_id_from_message_sync_path(path: str) -> str | None:
+        prefix = "/direct_v2/threads/"
+        if path.startswith(prefix):
+            return path[len(prefix) :].split("/", 1)[0]
+        prefix = "/direct_v2/inbox/threads/"
+        if path.startswith(prefix):
+            return path[len(prefix) :].split("/", 1)[0]
+        return None
+
+    def client_app_version(self) -> str:
+        device_settings = getattr(self.client, "device_settings", None) or {}
+        return getattr(self.client, "app_version", None) or device_settings.get("app_version", "")
+
+    @staticmethod
+    def foreground_state_descriptors() -> List[ThriftDescriptor]:
+        return [
+            ThriftDescriptor("inForegroundApp", 1, ThriftTypes.BOOLEAN),
+            ThriftDescriptor("inForegroundDevice", 2, ThriftTypes.BOOLEAN),
+            ThriftDescriptor("keepAliveTimeout", 3, ThriftTypes.INT_32),
+            ThriftDescriptor("subscribeTopics", 4, ThriftTypes.LIST_BINARY),
+            ThriftDescriptor("subscribeGenericTopics", 5, ThriftTypes.LIST_BINARY),
+            ThriftDescriptor("unsubscribeTopics", 6, ThriftTypes.LIST_BINARY),
+            ThriftDescriptor("unsubscribeGenericTopics", 7, ThriftTypes.LIST_BINARY),
+            ThriftDescriptor("requestId", 8, ThriftTypes.INT_64),
+        ]
+
+    @staticmethod
+    def new_client_context() -> str:
+        return str(uuid.uuid4())
+
+    def emit(self, event: str, payload: Any) -> None:
+        for handler in self._handlers.get(event, []):
+            handler(payload)

--- a/aiograpi/realtime/fbns.py
+++ b/aiograpi/realtime/fbns.py
@@ -1,0 +1,329 @@
+import asyncio
+import json
+import time
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List
+
+from aiograpi.realtime.mqttot import (
+    MQTToTConnection,
+    SocketMQTToTTransport,
+    compress_payload,
+    decode_packet,
+    try_decompress_payload,
+    write_connect_packet,
+    write_disconnect_packet,
+    write_pingreq_packet,
+    write_publish_packet,
+    write_subscribe_packet,
+)
+
+FBNS_HOST = "mqtt-mini.facebook.com"
+IG_FBNS_APP_ID = 567310203415052
+FBNS_PACKAGE_NAME = "com.instagram.android"
+FBNS_SUBSCRIBE_TOPICS = [76, 80, 231]
+
+
+class FBNSTopics:
+    MESSAGE = "76"
+    REG_REQUEST = "79"
+    REG_RESPONSE = "80"
+    EXP_LOGGING = "231"
+    PP = "34"
+
+
+@dataclass
+class FbnsDeviceAuth:
+    client_id: str = ""
+    user_id: int = 0
+    password: str = ""
+    device_id: str = ""
+    device_secret: str = ""
+    server_region: str = ""
+    region_hint: str = ""
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_client(cls, client) -> "FbnsDeviceAuth":
+        settings = getattr(client, "settings", None) or {}
+        stored = settings.get("fbns_auth") or {}
+        phone_id = getattr(client, "phone_id", "") or ""
+        return cls(
+            client_id=stored.get("client_id") or phone_id[:20],
+            user_id=int(stored.get("user_id") or 0),
+            password=stored.get("password") or "",
+            device_id=stored.get("device_id") or "",
+            device_secret=stored.get("device_secret") or "",
+            server_region=stored.get("server_region") or "",
+            region_hint=stored.get("region_hint") or "",
+            raw=stored.get("raw") or {},
+        )
+
+    def read(self, payload: bytes | str | Dict[str, Any]) -> Dict[str, Any]:
+        if isinstance(payload, bytes):
+            if not payload:
+                data = {}
+            else:
+                data = json.loads(_strip_length_prefixed_json(payload).decode())
+        elif isinstance(payload, str):
+            data = json.loads(payload) if payload else {}
+        else:
+            data = dict(payload)
+        self.raw.update(data)
+        if "ck" in data:
+            self.user_id = _optional_int(data.get("ck")) or self.user_id
+        if "cs" in data:
+            self.password = str(data.get("cs") or "")
+        if "di" in data:
+            self.device_id = str(data.get("di") or "")
+            self.client_id = self.device_id[:20]
+        if "ds" in data:
+            self.device_secret = str(data.get("ds") or "")
+        if "sr" in data:
+            self.server_region = str(data.get("sr") or "")
+        if "rc" in data:
+            self.region_hint = str(data.get("rc") or "")
+        return data
+
+    def save(self, client) -> None:
+        settings = getattr(client, "settings", None)
+        if settings is not None:
+            settings["fbns_auth"] = self.to_settings()
+
+    def to_settings(self) -> Dict[str, Any]:
+        return {
+            "client_id": self.client_id,
+            "user_id": self.user_id,
+            "password": self.password,
+            "device_id": self.device_id,
+            "device_secret": self.device_secret,
+            "server_region": self.server_region,
+            "region_hint": self.region_hint,
+            "raw": self.raw,
+        }
+
+
+class FbnsClient:
+    def __init__(self, client, transport=None, auth: FbnsDeviceAuth | None = None):
+        self.client = client
+        self.transport = transport or SocketMQTToTTransport(FBNS_HOST, proxy=getattr(client, "proxy", None))
+        self.auth = auth or FbnsDeviceAuth.from_client(client)
+        self.connected = False
+        self._handlers: Dict[str, List[Callable[[Any], None]]] = defaultdict(list)
+        self._packet_id = 0
+
+    def on(self, event: str, handler: Callable[[Any], None]) -> None:
+        self._handlers[event].append(handler)
+
+    async def connect(self, register: bool = True) -> None:
+        await asyncio.to_thread(self.transport.connect)
+        await self._send(self.connect_packet())
+        packet = decode_packet(await self._recv_packet())
+        if packet.packet_type != "connack" or packet.return_code != 0:
+            raise ConnectionError(f"FBNS MQTT connect failed: {packet.return_code}")
+        self.auth.read(packet.payload)
+        self.auth.save(self.client)
+        self.emit("auth", self.auth.to_settings())
+        self.connected = True
+        if register:
+            await self.subscribe(FBNSTopics.MESSAGE)
+            token = await self.register_token()
+            response = await self.register_push_token(token)
+            self.emit("registered", {"token": token, "response": response})
+
+    async def disconnect(self) -> None:
+        if self.connected:
+            await self._send(write_disconnect_packet())
+        await asyncio.to_thread(self.transport.disconnect)
+        self.connected = False
+
+    def build_connection(self) -> MQTToTConnection:
+        phone_id = getattr(self.client, "phone_id", "") or ""
+        client_id = self.auth.client_id or phone_id[:20]
+        assert client_id, "Client phone_id is required"
+        user_agent = getattr(self.client, "user_agent", "")
+        client_info = {
+            "userId": int(self.auth.user_id),
+            "userAgent": user_agent,
+            "clientCapabilities": 183,
+            "endpointCapabilities": 128,
+            "publishFormat": 1,
+            "noAutomaticForeground": True,
+            "makeUserAvailableInForeground": False,
+            "deviceId": self.auth.device_id,
+            "isInitiallyForeground": False,
+            "networkType": 1,
+            "networkSubtype": 0,
+            "clientMqttSessionId": int(time.time() * 1000) & 0xFFFFFFFF,
+            "subscribeTopics": FBNS_SUBSCRIBE_TOPICS,
+            "clientType": "device_auth",
+            "appId": IG_FBNS_APP_ID,
+            "deviceSecret": self.auth.device_secret,
+            "clientStack": 3,
+            "anotherUnknown": -1,
+        }
+        if self.auth.password:
+            client_info["fbnsConnectionSecret"] = self.auth.password
+        if self.auth.device_id:
+            client_info["fbnsDeviceId"] = self.auth.device_id
+        if self.auth.device_secret:
+            client_info["fbnsDeviceSecret"] = self.auth.device_secret
+        return MQTToTConnection(
+            client_identifier=client_id,
+            client_info=client_info,
+            password=self.auth.password,
+        )
+
+    def connect_packet(self) -> bytes:
+        return write_connect_packet(self.build_connection(), keep_alive=60)
+
+    async def subscribe(self, topic: str) -> None:
+        self._packet_id += 1
+        await self._send(write_subscribe_packet(topic, packet_id=self._packet_id))
+
+    async def register_token(self, max_packets: int = 10) -> str:
+        await self._publish_bytes(
+            FBNSTopics.REG_REQUEST,
+            json.dumps(
+                {
+                    "pkg_name": FBNS_PACKAGE_NAME,
+                    "appid": IG_FBNS_APP_ID,
+                },
+                separators=(",", ":"),
+            ).encode(),
+        )
+        for _ in range(max_packets):
+            packet = decode_packet(await self._recv_packet())
+            if packet.packet_type != "publish":
+                continue
+            if packet.topic == FBNSTopics.REG_RESPONSE:
+                response = self.parse_packet_payload(packet.payload)
+                await self._ack(packet)
+                self.emit("reg_response", response)
+                error = response.get("error") if isinstance(response, dict) else None
+                if error:
+                    raise RuntimeError(f"FBNS registration failed: {error}")
+                token = response.get("token") if isinstance(response, dict) else None
+                if not token:
+                    raise RuntimeError("FBNS registration response did not include token")
+                return str(token)
+            self.dispatch_packet(packet.topic, packet.payload)
+            await self._ack(packet)
+        raise TimeoutError("FBNS registration response was not received")
+
+    async def register_push_token(self, token: str) -> Dict[str, Any]:
+        data = {
+            "device_type": "android_mqtt",
+            "is_main_push_channel": True,
+            "device_sub_type": 2,
+            "device_token": token,
+            "_csrftoken": self.client.token,
+            "guid": self.client.uuid,
+            "uuid": self.client.uuid,
+            "users": str(self.client.user_id),
+            "family_device_id": str(uuid.uuid4()),
+        }
+        return await self.client.private_request("push/register/", data, with_signature=False)
+
+    async def read_once(self) -> Any:
+        packet = decode_packet(await self._recv_packet())
+        if packet.packet_type != "publish" or packet.topic is None:
+            return packet
+        payload = self.dispatch_packet(packet.topic, packet.payload)
+        await self._ack(packet)
+        return payload
+
+    async def ping(self, max_packets: int = 5) -> bool:
+        if not self.connected:
+            raise RuntimeError("FBNS client is not connected")
+        await self._send(write_pingreq_packet())
+        for _ in range(max_packets):
+            packet = decode_packet(await self._recv_packet())
+            if packet.packet_type == "pingresp":
+                return True
+            if packet.packet_type != "publish" or packet.topic is None:
+                return False
+            self.dispatch_packet(packet.topic, packet.payload)
+            await self._ack(packet)
+        return False
+
+    def dispatch_packet(self, topic: str, payload: bytes) -> Any:
+        parsed = self.parse_packet_payload(payload)
+        if topic == FBNSTopics.MESSAGE:
+            parsed = self.dispatch_fbns_message(parsed)
+        elif topic == FBNSTopics.REG_RESPONSE:
+            self.emit("reg_response", parsed)
+        elif topic == FBNSTopics.EXP_LOGGING:
+            self.emit("logging", parsed)
+        elif topic == FBNSTopics.PP:
+            self.emit("pp", parsed)
+        else:
+            self.emit("message", parsed)
+        self.emit("receive", {"topic": topic, "payload": parsed})
+        return parsed
+
+    def dispatch_fbns_message(self, payload: Any) -> Any:
+        if not isinstance(payload, dict):
+            self.emit("message", payload)
+            return payload
+        push = payload.get("fbpushnotif")
+        if push is None:
+            self.emit("message", payload)
+            return payload
+        if isinstance(push, str):
+            try:
+                push = json.loads(push)
+            except json.JSONDecodeError:
+                push = {"value": push}
+        self.emit("push", push)
+        if isinstance(push, dict):
+            collapse_key = push.get("collapse_key")
+            if collapse_key:
+                self.emit(str(collapse_key), push)
+        return push
+
+    @staticmethod
+    def parse_packet_payload(payload: bytes) -> Any:
+        body = _strip_length_prefixed_json(payload)
+        try:
+            return json.loads(body.decode())
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return body
+
+    async def _publish_bytes(self, topic: str, payload: bytes) -> None:
+        self._packet_id += 1
+        await self._send(write_publish_packet(topic, compress_payload(payload), qos=1, packet_id=self._packet_id))
+
+    async def _ack(self, packet) -> None:
+        if packet.qos == 1 and packet.packet_id is not None:
+            await self._send(b"\x40\x02" + packet.packet_id.to_bytes(2, "big"))
+
+    async def _send(self, packet: bytes) -> None:
+        await asyncio.to_thread(self.transport.send, packet)
+
+    async def _recv_packet(self) -> bytes:
+        return await asyncio.to_thread(self.transport.recv_packet)
+
+    def emit(self, event: str, payload: Any) -> None:
+        for handler in self._handlers.get(event, []):
+            handler(payload)
+
+
+def _optional_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _strip_length_prefixed_json(payload: bytes) -> bytes:
+    body = try_decompress_payload(payload)
+    if len(body) < 3:
+        return body
+    size = int.from_bytes(body[:2], "big")
+    if size == len(body) - 2 and body[2:3] in {b"{", b"["}:
+        return body[2:]
+    return body

--- a/aiograpi/realtime/fbns.py
+++ b/aiograpi/realtime/fbns.py
@@ -208,7 +208,8 @@ class FbnsClient:
                 if not token:
                     raise RuntimeError("FBNS registration response did not include token")
                 return str(token)
-            self.dispatch_packet(packet.topic, packet.payload)
+            if packet.topic is not None:
+                self.dispatch_packet(packet.topic, packet.payload)
             await self._ack(packet)
         raise TimeoutError("FBNS registration response was not received")
 

--- a/aiograpi/realtime/mqttot.py
+++ b/aiograpi/realtime/mqttot.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import unquote, urlsplit
 
 try:
-    import socks
+    import socks  # type: ignore[import-untyped]
 except ImportError:  # pragma: no cover - exercised only when proxy transport is used without PySocks
     socks = None
 
@@ -245,7 +245,7 @@ class SocketMQTToTTransport:
         self.timeout = timeout
         self.tls_context = tls_context or ssl.create_default_context()
         self.proxy = proxy
-        self.sock = None
+        self.sock: Optional[socket.socket] = None
 
     def connect(self) -> None:
         raw = (
@@ -256,7 +256,7 @@ class SocketMQTToTTransport:
         self.sock = self.tls_context.wrap_socket(raw, server_hostname=self.host)
         self.sock.settimeout(self.timeout)
 
-    def _create_proxy_connection(self):
+    def _create_proxy_connection(self) -> socket.socket:
         if socks is None:
             raise RuntimeError(
                 "Realtime proxy support requires PySocks. Install aiograpi with its default dependencies."

--- a/aiograpi/realtime/mqttot.py
+++ b/aiograpi/realtime/mqttot.py
@@ -1,0 +1,614 @@
+import json
+import socket
+import ssl
+import struct
+import zlib
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import unquote, urlsplit
+
+try:
+    import socks
+except ImportError:  # pragma: no cover - exercised only when proxy transport is used without PySocks
+    socks = None
+
+
+class MQTToTTopics:
+    PUBSUB = "88"
+    FOREGROUND_STATE = "102"
+    SEND_MESSAGE = "132"
+    SEND_MESSAGE_RESPONSE = "133"
+    IRIS_SUB = "134"
+    IRIS_SUB_RESPONSE = "135"
+    MESSAGE_SYNC = "146"
+    REALTIME_SUB = "149"
+    REGION_HINT = "150"
+
+
+class ThriftTypes:
+    STOP = 0x00
+    TRUE = 0x01
+    FALSE = 0x02
+    BYTE = 0x03
+    INT_16 = 0x04
+    INT_32 = 0x05
+    INT_64 = 0x06
+    BINARY = 0x08
+    LIST = 0x09
+    MAP = 0x0B
+    STRUCT = 0x0C
+    BOOLEAN = 0xA1
+    LIST_INT_32 = (INT_32 << 8) | LIST
+    LIST_BINARY = (BINARY << 8) | LIST
+    MAP_BINARY_BINARY = (0x88 << 8) | MAP
+
+
+@dataclass(frozen=True)
+class ThriftDescriptor:
+    name: str
+    field: int
+    type: int
+    children: tuple["ThriftDescriptor", ...] = ()
+
+
+@dataclass
+class DecodedMQTToTPacket:
+    packet_type: str
+    payload: bytes
+    protocol_name: Optional[str] = None
+    protocol_level: Optional[int] = None
+    connect_flags: Optional[int] = None
+    keep_alive: Optional[int] = None
+    topic: Optional[str] = None
+    qos: int = 0
+    packet_id: Optional[int] = None
+    return_code: Optional[int] = None
+
+
+@dataclass
+class MQTToTConnection:
+    client_identifier: str
+    client_info: Dict[str, Any]
+    password: str
+    app_specific_info: Optional[Dict[str, str]] = None
+
+    @staticmethod
+    def thrift_descriptors() -> List[ThriftDescriptor]:
+        return [
+            ThriftDescriptor("clientIdentifier", 1, ThriftTypes.BINARY),
+            ThriftDescriptor("willTopic", 2, ThriftTypes.BINARY),
+            ThriftDescriptor("willMessage", 3, ThriftTypes.BINARY),
+            ThriftDescriptor(
+                "clientInfo",
+                4,
+                ThriftTypes.STRUCT,
+                (
+                    ThriftDescriptor("userId", 1, ThriftTypes.INT_64),
+                    ThriftDescriptor("userAgent", 2, ThriftTypes.BINARY),
+                    ThriftDescriptor("clientCapabilities", 3, ThriftTypes.INT_64),
+                    ThriftDescriptor("endpointCapabilities", 4, ThriftTypes.INT_64),
+                    ThriftDescriptor("publishFormat", 5, ThriftTypes.INT_32),
+                    ThriftDescriptor("noAutomaticForeground", 6, ThriftTypes.BOOLEAN),
+                    ThriftDescriptor("makeUserAvailableInForeground", 7, ThriftTypes.BOOLEAN),
+                    ThriftDescriptor("deviceId", 8, ThriftTypes.BINARY),
+                    ThriftDescriptor("isInitiallyForeground", 9, ThriftTypes.BOOLEAN),
+                    ThriftDescriptor("networkType", 10, ThriftTypes.INT_32),
+                    ThriftDescriptor("networkSubtype", 11, ThriftTypes.INT_32),
+                    ThriftDescriptor("clientMqttSessionId", 12, ThriftTypes.INT_64),
+                    ThriftDescriptor("clientIpAddress", 13, ThriftTypes.BINARY),
+                    ThriftDescriptor("subscribeTopics", 14, ThriftTypes.LIST_INT_32),
+                    ThriftDescriptor("clientType", 15, ThriftTypes.BINARY),
+                    ThriftDescriptor("appId", 16, ThriftTypes.INT_64),
+                    ThriftDescriptor("overrideNectarLogging", 17, ThriftTypes.BOOLEAN),
+                    ThriftDescriptor("connectTokenHash", 18, ThriftTypes.BINARY),
+                    ThriftDescriptor("regionPreference", 19, ThriftTypes.BINARY),
+                    ThriftDescriptor("deviceSecret", 20, ThriftTypes.BINARY),
+                    ThriftDescriptor("clientStack", 21, ThriftTypes.BYTE),
+                    ThriftDescriptor("fbnsConnectionKey", 22, ThriftTypes.INT_64),
+                    ThriftDescriptor("fbnsConnectionSecret", 23, ThriftTypes.BINARY),
+                    ThriftDescriptor("fbnsDeviceId", 24, ThriftTypes.BINARY),
+                    ThriftDescriptor("fbnsDeviceSecret", 25, ThriftTypes.BINARY),
+                    ThriftDescriptor("anotherUnknown", 26, ThriftTypes.INT_64),
+                ),
+            ),
+            ThriftDescriptor("password", 5, ThriftTypes.BINARY),
+            ThriftDescriptor("getDiffsRequests", 6, ThriftTypes.LIST_BINARY),
+            ThriftDescriptor("zeroRatingTokenHash", 9, ThriftTypes.BINARY),
+            ThriftDescriptor("appSpecificInfo", 10, ThriftTypes.MAP_BINARY_BINARY),
+        ]
+
+    def to_thrift(self) -> bytes:
+        payload: Dict[str, Any] = {
+            "clientIdentifier": self.client_identifier,
+            "clientInfo": self.client_info,
+            "password": self.password,
+        }
+        if self.app_specific_info:
+            payload["appSpecificInfo"] = self.app_specific_info
+        return write_thrift_object(payload, self.thrift_descriptors())
+
+
+def compress_payload(data: bytes) -> bytes:
+    return zlib.compress(data, level=9)
+
+
+def try_decompress_payload(data: bytes) -> bytes:
+    if not data or data[0] != 0x78:
+        return data
+    try:
+        return zlib.decompress(data)
+    except zlib.error:
+        return data
+
+
+def write_connect_packet(connection: MQTToTConnection, keep_alive: int = 20) -> bytes:
+    payload = compress_payload(connection.to_thrift())
+    variable_header = _write_utf8("MQTToT") + bytes([3, 0xC2]) + struct.pack("!H", keep_alive)
+    remaining = variable_header + payload
+    return bytes([0x10]) + _encode_remaining_length(len(remaining)) + remaining
+
+
+def write_publish_packet(topic: str, payload: bytes, qos: int = 1, packet_id: int = 1) -> bytes:
+    if qos not in (0, 1):
+        raise ValueError("Only QoS 0 and QoS 1 are supported")
+    variable_header = _write_utf8(str(topic))
+    if qos:
+        variable_header += struct.pack("!H", packet_id)
+    body = variable_header + payload
+    fixed_header = bytes([0x30 | (qos << 1)]) + _encode_remaining_length(len(body))
+    return fixed_header + body
+
+
+def write_subscribe_packet(topic: str, packet_id: int = 1, qos: int = 1) -> bytes:
+    body = struct.pack("!H", packet_id) + _write_utf8(str(topic)) + bytes([qos])
+    return bytes([0x82]) + _encode_remaining_length(len(body)) + body
+
+
+def write_pingreq_packet() -> bytes:
+    return b"\xc0\x00"
+
+
+def write_disconnect_packet() -> bytes:
+    return b"\xe0\x00"
+
+
+def decode_packet(packet: bytes) -> DecodedMQTToTPacket:
+    packet_type_id = packet[0] >> 4
+    flags = packet[0] & 0x0F
+    remaining_length, offset = _decode_remaining_length(packet, 1)
+    body = packet[offset : offset + remaining_length]
+    if packet_type_id == 1:
+        protocol_name, pos = _read_utf8(body, 0)
+        protocol_level = body[pos]
+        connect_flags = body[pos + 1]
+        keep_alive = struct.unpack("!H", body[pos + 2 : pos + 4])[0]
+        payload = body[pos + 4 :]
+        return DecodedMQTToTPacket(
+            packet_type="connect",
+            protocol_name=protocol_name,
+            protocol_level=protocol_level,
+            connect_flags=connect_flags,
+            keep_alive=keep_alive,
+            payload=payload,
+        )
+    if packet_type_id == 2:
+        return DecodedMQTToTPacket(
+            packet_type="connack",
+            return_code=body[1],
+            payload=body[2:],
+        )
+    if packet_type_id == 3:
+        topic, pos = _read_utf8(body, 0)
+        qos = (flags >> 1) & 0x03
+        packet_id = None
+        if qos:
+            packet_id = struct.unpack("!H", body[pos : pos + 2])[0]
+            pos += 2
+        return DecodedMQTToTPacket(
+            packet_type="publish",
+            topic=topic,
+            qos=qos,
+            packet_id=packet_id,
+            payload=body[pos:],
+        )
+    if packet_type_id == 12:
+        return DecodedMQTToTPacket(packet_type="pingreq", payload=body)
+    if packet_type_id == 13:
+        return DecodedMQTToTPacket(packet_type="pingresp", payload=body)
+    if packet_type_id == 14:
+        return DecodedMQTToTPacket(packet_type="disconnect", payload=body)
+    return DecodedMQTToTPacket(packet_type=str(packet_type_id), payload=body)
+
+
+def write_thrift_object(data: Dict[str, Any], descriptors: List[ThriftDescriptor]) -> bytes:
+    writer = _ThriftWriter()
+    _write_thrift_struct(writer, data, descriptors)
+    writer.write_stop()
+    return bytes(writer.buffer)
+
+
+def read_thrift_object(data: bytes, descriptors: List[ThriftDescriptor]) -> Dict[str, Any]:
+    return _ThriftReader(data).read_struct(descriptors)
+
+
+class SocketMQTToTTransport:
+    def __init__(
+        self,
+        host: str,
+        port: int = 443,
+        timeout: float = 30.0,
+        tls_context: Optional[ssl.SSLContext] = None,
+        proxy: Optional[str] = None,
+    ):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.tls_context = tls_context or ssl.create_default_context()
+        self.proxy = proxy
+        self.sock = None
+
+    def connect(self) -> None:
+        raw = (
+            self._create_proxy_connection()
+            if self.proxy
+            else socket.create_connection((self.host, self.port), timeout=self.timeout)
+        )
+        self.sock = self.tls_context.wrap_socket(raw, server_hostname=self.host)
+        self.sock.settimeout(self.timeout)
+
+    def _create_proxy_connection(self):
+        if socks is None:
+            raise RuntimeError(
+                "Realtime proxy support requires PySocks. Install aiograpi with its default dependencies."
+            )
+        proxy = self.proxy or ""
+        if "://" not in proxy:
+            proxy = f"http://{proxy}"
+        parsed = urlsplit(proxy)
+        proxy_types = {
+            "http": socks.HTTP,
+            "https": socks.HTTP,
+            "socks4": socks.SOCKS4,
+            "socks4a": socks.SOCKS4,
+            "socks5": socks.SOCKS5,
+            "socks5h": socks.SOCKS5,
+        }
+        proxy_type = proxy_types.get(parsed.scheme)
+        if proxy_type is None or not parsed.hostname or parsed.port is None:
+            raise ValueError(f"Unsupported realtime proxy URL: {self.proxy}")
+        raw = socks.socksocket()
+        raw.settimeout(self.timeout)
+        raw.set_proxy(
+            proxy_type,
+            parsed.hostname,
+            parsed.port,
+            rdns=parsed.scheme in {"socks4a", "socks5h"},
+            username=unquote(parsed.username) if parsed.username else None,
+            password=unquote(parsed.password) if parsed.password else None,
+        )
+        raw.connect((self.host, self.port))
+        return raw
+
+    def send(self, packet: bytes) -> None:
+        if self.sock is None:
+            raise RuntimeError("Transport is not connected")
+        self.sock.sendall(packet)
+
+    def recv_packet(self) -> bytes:
+        if self.sock is None:
+            raise RuntimeError("Transport is not connected")
+        first = _recv_exact(self.sock, 1)
+        remaining = bytearray()
+        while True:
+            byte = _recv_exact(self.sock, 1)
+            remaining.extend(byte)
+            if byte[0] & 0x80 == 0:
+                break
+        size, _ = _decode_remaining_length(bytes(remaining), 0)
+        return first + bytes(remaining) + _recv_exact(self.sock, size)
+
+    def disconnect(self) -> None:
+        if self.sock is None:
+            return
+        try:
+            self.sock.close()
+        finally:
+            self.sock = None
+
+
+class _ThriftWriter:
+    def __init__(self):
+        self.buffer = bytearray()
+        self._field_stack: List[int] = []
+        self._field = 0
+
+    def write_stop(self) -> None:
+        self.buffer.append(ThriftTypes.STOP)
+        if self._field_stack:
+            self._field = self._field_stack.pop()
+
+    def write_field(self, field: int, field_type: int) -> None:
+        delta = field - self._field
+        thrift_type = field_type & 0x0F
+        if 0 < delta <= 15:
+            self.buffer.append((delta << 4) | thrift_type)
+        else:
+            self.buffer.append(thrift_type)
+            self.write_varint(_zigzag(field, 16))
+        self._field = field
+
+    def write_varint(self, value: int) -> None:
+        while True:
+            if value & ~0x7F == 0:
+                self.buffer.append(value)
+                return
+            self.buffer.append((value & 0x7F) | 0x80)
+            value >>= 7
+
+    def write_varbigint(self, value: int) -> None:
+        self.write_varint(value)
+
+    def write_string_direct(self, value: str) -> None:
+        raw = value.encode()
+        self.write_varint(len(raw))
+        self.buffer.extend(raw)
+
+    def write_string(self, field: int, value: str) -> None:
+        self.write_field(field, ThriftTypes.BINARY)
+        self.write_string_direct(value)
+
+    def write_bool(self, field: int, value: bool) -> None:
+        self.write_field(field, ThriftTypes.TRUE if value else ThriftTypes.FALSE)
+
+    def write_int(self, field: int, value: int, bits: int) -> None:
+        field_type = {8: ThriftTypes.BYTE, 16: ThriftTypes.INT_16, 32: ThriftTypes.INT_32, 64: ThriftTypes.INT_64}[bits]
+        self.write_field(field, field_type)
+        if bits == 8:
+            self.buffer.extend(struct.pack("b", value))
+        elif bits == 64:
+            self.write_varbigint(_zigzag(value, 64))
+        else:
+            self.write_varint(_zigzag(value, bits))
+
+    def push_struct(self, field: int) -> None:
+        self.write_field(field, ThriftTypes.STRUCT)
+        self._field_stack.append(self._field)
+        self._field = 0
+
+
+class _ThriftReader:
+    def __init__(self, data: bytes):
+        self.data = data
+        self.pos = 0
+        self._field_stack: List[int] = []
+        self._field = 0
+
+    def read_struct(self, descriptors: List[ThriftDescriptor]) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        while self.pos < len(self.data):
+            field_type = self.read_field()
+            if field_type == ThriftTypes.STOP:
+                if self._field_stack:
+                    self._field = self._field_stack.pop()
+                break
+            descriptor = _find_descriptor(descriptors, self._field, field_type)
+            value = self.read_value(field_type, descriptor)
+            if descriptor:
+                result[descriptor.name] = value
+        return result
+
+    def read_field(self) -> int:
+        byte = self.read_byte()
+        if byte == ThriftTypes.STOP:
+            return ThriftTypes.STOP
+        delta = (byte & 0xF0) >> 4
+        if delta:
+            self._field += delta
+        else:
+            self._field = _unzigzag(self.read_varint())
+        return byte & 0x0F
+
+    def read_value(self, field_type: int, descriptor: Optional[ThriftDescriptor]) -> Any:
+        if field_type == ThriftTypes.TRUE:
+            return True
+        if field_type == ThriftTypes.FALSE:
+            return False
+        if field_type == ThriftTypes.BYTE:
+            return struct.unpack("b", self.read_bytes(1))[0]
+        if field_type in (ThriftTypes.INT_16, ThriftTypes.INT_32):
+            return _unzigzag(self.read_varint())
+        if field_type == ThriftTypes.INT_64:
+            return _unzigzag(self.read_varint())
+        if field_type == ThriftTypes.BINARY:
+            return self.read_bytes(self.read_varint()).decode()
+        if field_type == ThriftTypes.LIST:
+            return self.read_list()
+        if field_type == ThriftTypes.MAP:
+            return self.read_map()
+        if field_type == ThriftTypes.STRUCT:
+            self._field_stack.append(self._field)
+            self._field = 0
+            return self.read_struct(list(descriptor.children) if descriptor else [])
+        raise ValueError(f"Unsupported thrift type: {field_type}")
+
+    def read_list(self) -> List[Any]:
+        header = self.read_byte()
+        size = header >> 4
+        item_type = header & 0x0F
+        if size == 0x0F:
+            size = self.read_varint()
+        items = []
+        for _ in range(size):
+            items.append(self.read_value(item_type, None))
+        return items
+
+    def read_map(self) -> Dict[str, str]:
+        size = self.read_varint()
+        if not size:
+            return {}
+        item_types = self.read_byte()
+        key_type = (item_types & 0xF0) >> 4
+        value_type = item_types & 0x0F
+        result = {}
+        for _ in range(size):
+            key = self.read_value(key_type, None)
+            value = self.read_value(value_type, None)
+            result[key] = value
+        return result
+
+    def read_byte(self) -> int:
+        value = self.data[self.pos]
+        self.pos += 1
+        return value
+
+    def read_bytes(self, size: int) -> bytes:
+        value = self.data[self.pos : self.pos + size]
+        self.pos += size
+        return value
+
+    def read_varint(self) -> int:
+        shift = 0
+        result = 0
+        while self.pos < len(self.data):
+            byte = self.read_byte()
+            result |= (byte & 0x7F) << shift
+            if byte & 0x80 == 0:
+                break
+            shift += 7
+        return result
+
+
+def _write_thrift_struct(writer: _ThriftWriter, data: Dict[str, Any], descriptors: List[ThriftDescriptor]) -> None:
+    by_name = {descriptor.name: descriptor for descriptor in descriptors}
+    for name, value in data.items():
+        if value is None:
+            continue
+        descriptor = by_name[name]
+        thrift_type = descriptor.type & 0xFF
+        if thrift_type == ThriftTypes.BOOLEAN:
+            writer.write_bool(descriptor.field, bool(value))
+        elif thrift_type == ThriftTypes.BYTE:
+            writer.write_int(descriptor.field, int(value), 8)
+        elif thrift_type == ThriftTypes.INT_16:
+            writer.write_int(descriptor.field, int(value), 16)
+        elif thrift_type == ThriftTypes.INT_32:
+            writer.write_int(descriptor.field, int(value), 32)
+        elif thrift_type == ThriftTypes.INT_64:
+            writer.write_int(descriptor.field, int(value), 64)
+        elif thrift_type == ThriftTypes.BINARY:
+            writer.write_string(descriptor.field, str(value))
+        elif thrift_type == ThriftTypes.STRUCT:
+            writer.push_struct(descriptor.field)
+            _write_thrift_struct(writer, value, list(descriptor.children))
+            writer.write_stop()
+        elif thrift_type == ThriftTypes.LIST:
+            writer.write_field(descriptor.field, ThriftTypes.LIST)
+            item_type = descriptor.type >> 8
+            _write_thrift_list(writer, item_type, value)
+        elif thrift_type == ThriftTypes.MAP:
+            _write_thrift_map(writer, descriptor.field, value)
+        else:
+            raise ValueError(f"Unsupported thrift type: {descriptor.type}")
+
+
+def _write_thrift_list(writer: _ThriftWriter, item_type: int, values: List[Any]) -> None:
+    size = len(values)
+    if size < 0x0F:
+        writer.buffer.append((size << 4) | item_type)
+    else:
+        writer.buffer.append(0xF0 | item_type)
+        writer.write_varint(size)
+    for value in values:
+        if item_type == ThriftTypes.INT_32:
+            writer.write_varint(_zigzag(int(value), 32))
+        elif item_type == ThriftTypes.BINARY:
+            writer.write_string_direct(str(value))
+        else:
+            raise ValueError(f"Unsupported thrift list type: {item_type}")
+
+
+def _write_thrift_map(writer: _ThriftWriter, field: int, values: Dict[str, str]) -> None:
+    writer.write_field(field, ThriftTypes.MAP)
+    writer.write_varint(len(values))
+    if not values:
+        return
+    writer.buffer.append((ThriftTypes.BINARY << 4) | ThriftTypes.BINARY)
+    for key, value in values.items():
+        writer.write_string_direct(str(key))
+        writer.write_string_direct(str(value))
+
+
+def _find_descriptor(
+    descriptors: List[ThriftDescriptor],
+    field: int,
+    field_type: int,
+) -> Optional[ThriftDescriptor]:
+    for descriptor in descriptors:
+        descriptor_type = descriptor.type & 0x0F
+        if descriptor.field != field:
+            continue
+        if descriptor_type == field_type or (
+            descriptor.type == ThriftTypes.BOOLEAN and field_type in (ThriftTypes.TRUE, ThriftTypes.FALSE)
+        ):
+            return descriptor
+    return None
+
+
+def _write_utf8(value: str) -> bytes:
+    raw = value.encode()
+    return struct.pack("!H", len(raw)) + raw
+
+
+def _read_utf8(data: bytes, offset: int) -> tuple[str, int]:
+    size = struct.unpack("!H", data[offset : offset + 2])[0]
+    offset += 2
+    return data[offset : offset + size].decode(), offset + size
+
+
+def _encode_remaining_length(value: int) -> bytes:
+    encoded = bytearray()
+    while True:
+        byte = value % 128
+        value //= 128
+        if value:
+            byte |= 0x80
+        encoded.append(byte)
+        if not value:
+            return bytes(encoded)
+
+
+def _decode_remaining_length(data: bytes, offset: int) -> tuple[int, int]:
+    multiplier = 1
+    value = 0
+    while True:
+        encoded_byte = data[offset]
+        offset += 1
+        value += (encoded_byte & 127) * multiplier
+        if encoded_byte & 128 == 0:
+            return value, offset
+        multiplier *= 128
+
+
+def _recv_exact(sock: socket.socket, size: int) -> bytes:
+    chunks = bytearray()
+    while len(chunks) < size:
+        chunk = sock.recv(size - len(chunks))
+        if not chunk:
+            raise ConnectionError("Socket closed while reading MQTT packet")
+        chunks.extend(chunk)
+    return bytes(chunks)
+
+
+def _zigzag(value: int, bits: int) -> int:
+    return (value << 1) ^ (value >> (bits - 1))
+
+
+def _unzigzag(value: int) -> int:
+    return (value >> 1) ^ -(value & 1)
+
+
+def parse_json_payload(payload: bytes) -> Any:
+    return json.loads(try_decompress_payload(payload).decode())
+
+
+RealtimeHandler = Callable[[Any], None]

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -96,6 +96,10 @@ The `Package` workflow runs pip-audit, Bandit, Ruff, the mypy regression gate, n
 builds. On canonical repository pushes it also runs `tests/live/smoke.py` against the pooled live-account endpoint
 configured in `TEST_ACCOUNTS_URL`.
 
+Realtime MQTT/FBNS live tests also use `TEST_ACCOUNTS_URL` for pooled accounts. Set `IG_REALTIME_PROXY` when the account
+HTTP proxy can log in but cannot open a CONNECT tunnel to Instagram's MQTT hosts; the realtime tests use that proxy only
+for the MQTT socket and keep the account proxy for normal private API calls.
+
 The `Publish to PyPI` workflow runs only for version tags such as `0.9.0`. It verifies the tag matches
 `pyproject.toml`, builds the wheel and sdist, publishes through PyPI trusted publishing, creates the GitHub release, and
 publishes versioned docs with `mike`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,9 +40,38 @@ For any other languages (e.g. C++, C#, F#, D, [Golang](https://github.com/subzer
 6. [Like](https://subzeroid.github.io/aiograpi/latest/usage-guide/media/), [Follow](https://subzeroid.github.io/aiograpi/latest/usage-guide/user/), [Edit account](https://subzeroid.github.io/aiograpi/latest/usage-guide/account/) (Bio) and much more else
 7. [Insights](https://subzeroid.github.io/aiograpi/latest/usage-guide/insight/) by account, posts and stories
 8. [Build stories](https://subzeroid.github.io/aiograpi/latest/usage-guide/story/) with custom background, font animation, link sticker and mention users
-9. Account registration helpers and opt-in captcha handler hooks
+9. [Realtime MQTT](usage-guide/realtime.md) for Direct message sync, lightweight Direct MQTT actions, and FBNS push notifications
+10. Account registration helpers and opt-in captcha handler hooks
 
 ## Example
+
+### Realtime MQTT and Direct
+
+`aiograpi 1.1.0` adds experimental async Realtime MQTT/MQTToT helpers. They can receive Direct message sync payloads,
+publish lightweight Direct actions over MQTT, and subscribe to FBNS push notifications.
+
+```python
+from aiograpi import Client
+
+cl = Client()
+await cl.login(USERNAME, PASSWORD)
+
+
+def handle_message(payload):
+    print(payload)
+
+
+cl.realtime_on("message", handle_message)
+rt = await cl.realtime_connect()
+await rt.direct_subscribe()
+
+await rt.direct_send_text(thread_id, "Hello from MQTT")
+
+while True:
+    await cl.realtime_read_once()
+```
+
+See the [Realtime MQTT guide](usage-guide/realtime.md) for Direct sync, MQTT Direct actions, and FBNS push examples.
 
 ### Basic Usage
 
@@ -119,6 +148,7 @@ To learn more about the various ways `aiograpi` can be used, read the [Usage Gui
   * [`Comment`](usage-guide/comment.md) - Comments to Media
   * [`Highlight`](usage-guide/highlight.md) - Highlights
   * [`Notes`](usage-guide/notes.md) - Notes
+  * [`Realtime MQTT`](usage-guide/realtime.md) - Direct sync, lightweight Direct MQTT actions, and FBNS push callbacks
   * [`Pydroid and ffmpeg`](usage-guide/pydroid.md) - Android/Pydroid video upload setup
   * [`Termux`](usage-guide/termux.md) - Termux install notes and optional video helpers
   * [`Public Transport`](usage-guide/public-transport.md) - Optional curl transport for public web requests

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -7,21 +7,19 @@ ported through.
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.7.17
+instagrapi 2.8.2
 ```
 
-`aiograpi 1.0.5` includes the video dependency split, MoviePy 2 helper migration, Reel Facebook cross-post payload
-follow-up, client TLS verification setting, public A1 API removal, current flow request metadata alignment, and social
-action payload updates from `instagrapi` through 2.7.1, the async Direct/music/signup sync through 2.7.2, and the story
-upload read-back fallback from 2.7.3. It also includes the submit-phone challenge step, refreshed comment action
-metadata, upload read-back/live-test hardening, Reel music live read-back verification, and low-level Bloks two-factor
-helpers from 2.7.4, plus the automatic Bloks two-factor login fallback from 2.7.5.
+`aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback
+updates, backup-code 2FA, email and phone helper work, password reset helpers, album per-slide usertags, comment
+pin/unpin endpoint fixes, username normalization, private GraphQL followers helpers, Story music upload helpers,
+scheduled feed uploads, professional account conversion helpers, and the private media-info lookup fix for video
+downloads.
 
-Subsequent 1.0.x releases continue that baseline through `instagrapi 2.7.17`, including Bloks login fallback updates,
-backup-code 2FA, email confirmation helpers, password reset helpers, album per-slide usertags, the comment
-pin/unpin endpoint path fix, username normalization for lookup helpers, private GraphQL followers helpers, Story music
-upload helpers, scheduled feed uploads, professional account conversion helpers, and the private media-info lookup fix
-for video downloads.
+`aiograpi 1.1.0` continues the mirror through `instagrapi 2.8.2`. It adds experimental async Realtime MQTT/MQTToT,
+Direct message sync and lightweight Direct MQTT actions, async FBNS push MQTT with token registration and persisted
+device-auth state, phone confirmation-code support, followed hashtag helpers, feed-media share-to-story, opaque Bloks
+challenge context handling, and clearer Reel/clip upload failure details.
 
 ## Release policy
 
@@ -32,7 +30,8 @@ for video downloads.
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
 `aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent
 `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance
-ports. `aiograpi 1.0.x` records the current SemVer baseline synced through `instagrapi 2.7.17`.
+ports. `aiograpi 1.0.x` recorded the SemVer baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the
+MQTT/FBNS baseline through `instagrapi 2.8.2`.
 
 ## Porting rules
 

--- a/docs/usage-guide/account.md
+++ b/docs/usage-guide/account.md
@@ -15,6 +15,7 @@ Viewing and managing your profile
 | send_confirm_email(email: str)               | dict      | Send confirmation code to new email address
 | confirm_email(email: str, code: str)         | dict      | Confirm a new email address with the received code
 | send_confirm_phone_number(phone_number: str) | dict      | Send confirmation code to new phone number
+| confirm_phone_number(phone_number: str, code: str, has_sms_consent: bool = False) | dict | Confirm a new phone number with the received SMS code
 
 Example:
 
@@ -76,6 +77,9 @@ Account(pk=1903424587, username='example', ..., account_type=3)
     'robocall_after_max_sms': True},
     'status': 'ok'
 }
+
+>>> await cl.confirm_phone_number("+5599999999", "123456", has_sms_consent=True)
+{'status': 'ok'}
 ```
 
 Professional conversion uses Instagram's mobile conversion flow and may still be blocked by account-specific eligibility,

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -52,6 +52,7 @@ Notes:
 * `direct_message()` scans the latest `amount` messages in a thread and raises `DirectMessageNotFound` if the id is not present in that window.
 * Shared XMA items such as `xma_clip`, `xma_media_share`, `xma_story_share`, and `xma_profile` keep their original payload in `message.raw_xma`. When Instagram includes `target_url`, the normalized link is also available through `message.xma_share`.
 * Disappearing direct photos and videos with `item_type == "raven_media"` are exposed through `message.visual_media`.
+* For live Direct message sync callbacks and lightweight MQTT Direct actions, see the [Realtime MQTT guide](realtime.md).
 
 Example of basic actions:
 

--- a/docs/usage-guide/examples.md
+++ b/docs/usage-guide/examples.md
@@ -22,6 +22,7 @@ Common scripts:
 | [`upload_media.py`](https://github.com/subzeroid/aiograpi/blob/main/examples/upload_media.py) | Upload a feed photo, feed video, Reel, or Trial Reel. |
 | [`upload_story.py`](https://github.com/subzeroid/aiograpi/blob/main/examples/upload_story.py) | Upload a photo or video story, optionally with a link sticker. |
 | [`direct_message.py`](https://github.com/subzeroid/aiograpi/blob/main/examples/direct_message.py) | Send a Direct text message to user IDs or thread IDs. |
+| [`realtime_direct.py`](https://github.com/subzeroid/aiograpi/blob/main/examples/realtime_direct.py) | Receive Direct message sync payloads over Realtime MQTT. |
 
 Examples:
 
@@ -32,6 +33,7 @@ python examples/download_user_media.py instagram --amount 5 --folder ./downloads
 python examples/upload_media.py reel ./reel.mp4 --thumbnail ./thumb.jpg --caption "Reel"
 python examples/upload_story.py photo ./story.jpg --caption "Story"
 python examples/direct_message.py --user-ids 123456789 --text "Hello"
+python examples/realtime_direct.py --limit 1
 ```
 
 Video uploads in Android environments should pass `--thumbnail` or install the optional video dependencies, MoviePy `2.2.1`, and executable `ffmpeg`. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).

--- a/docs/usage-guide/hashtag.md
+++ b/docs/usage-guide/hashtag.md
@@ -9,6 +9,7 @@ Pass hashtag names without the leading `#`, for example `pizza`. If a leading `#
 | hashtag_info(name: str)                            | Hashtag             | Return Hashtag info (id, name, picture)
 | hashtag_medias_top(name: str, amount: int = 9)     | List[Media]         | Return Top posts by Hashtag
 | hashtag_medias_recent(name: str, amount: int = 27) | List[Media]         | Return Most recent posts by Hashtag
+| hashtag_following(amount: int = 0)                 | List[Hashtag]       | Return hashtags followed by the authenticated account
 
 
 Example:
@@ -110,6 +111,10 @@ Example:
    'video_url': None,
    'thumbnail_url': HttpUrl('https://instagram.fhel3-1.fna.fbcdn.net/v/t51.2885-15/e35/185727252_524026898594344_9165723485744355754_n.jpg?tp=1&_nc_ht=instagram.fhel3-1.fna.fbcdn.net&_nc_cat=104&_nc_ohc=45NguRpEtZQAX83VSGE&edm=AP_V10EBAAAA&ccb=7-4&oh=c8c087ecfba444d9d85f7bd059f42a2a&oe=60C5C3C2&_nc_sid=4f375e', scheme='https', host='instagram.fhel3-1.fna.fbcdn.net', tld='net', host_type='domain', path='/v/t51.2885-15/e35/185727252_524026898594344_9165723485744355754_n.jpg', query='tp=1&_nc_ht=instagram.fhel3-1.fna.fbcdn.net&_nc_cat=104&_nc_ohc=45NguRpEtZQAX83VSGE&edm=AP_V10EBAAAA&ccb=7-4&oh=c8c087ecfba444d9d85f7bd059f42a2a&oe=60C5C3C2&_nc_sid=4f375e'),
    'media_type': 1}]}
+
+>>> hashtags = await cl.hashtag_following(amount=10)
+>>> [tag.name for tag in hashtags]
+['python', 'instagramapi']
 ```
 
 Low level methods:

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -41,6 +41,7 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_unlike(media_id: str)                                     | bool               | Unlike media
 | media_note_create(media_id: str, text: str = "", audience: int = 7, note_style: int = 13, extra_data: Optional[Dict] = None) | dict | Create a note attached to a media item
 | media_note_delete(note_id: str, extra_data: Optional[Dict] = None) | bool | Delete a note attached to a media item
+| media_share_to_story(media_id: str, background: Path = None, caption: str = "", extra_data: Optional[Dict] = None) | Story | Share an existing feed media as a story sticker
 | media_seen(media_ids: List[str], skipped_media_ids: List[str])  | bool               | Mark a media as seen
 | media_likers(media_id: str)                                     | List\[UserShort]   | Return list of users who liked this post (due to Instagram limitations, this may not return a complete list)
 | media_archive(media_id: str)                                    | bool               | Archive a media
@@ -52,6 +53,9 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | clip_unpin(media_pk: str)                                       | bool               | Unpin a Reel from the Reels tab/profile Reels grid
 
 Media notes are separate from Direct inbox Notes. Use `media_note_create()` and `media_note_delete()` for the note surface attached to a post or Reel; use the [Notes guide](notes.md) for Direct inbox Notes.
+
+`media_share_to_story()` uploads a story background and attaches the feed media as a story sticker. Pass a 9:16
+background image, or omit `background` to generate a temporary black 720x1280 image.
 
 Low level methods:
 

--- a/docs/usage-guide/realtime.md
+++ b/docs/usage-guide/realtime.md
@@ -1,0 +1,162 @@
+# Realtime MQTT
+
+!!! warning
+    Realtime MQTT support is experimental. Instagram can change this private transport without notice.
+
+The realtime client opens Instagram's MQTToT connection for live events after login.
+It is useful when you need callbacks for realtime payloads instead of polling HTTP endpoints.
+It can also publish lightweight Direct actions over MQTT. Use the regular Direct methods for media sends
+and complete thread management.
+
+FBNS push notifications use a separate `mqtt-mini.facebook.com` device-auth connection. Use FBNS when you need
+Instagram push payloads, for example Direct message notification callbacks.
+
+| Method | Return | Description |
+| --- | --- | --- |
+| `await realtime_connect(transport=None)` | `RealtimeClient` | Create and connect the stateful realtime client |
+| `await realtime_disconnect()` | `None` | Disconnect the active realtime client |
+| `realtime_on(event, handler)` | `None` | Register an event handler on the active realtime client |
+| `await realtime_ping()` | `bool` | Send a keepalive ping and wait for `PINGRESP` |
+| `await realtime_read_once()` | `Any` | Read one packet from the active realtime client |
+| `await fbns_connect(transport=None, auth=None, register=True)` | `FbnsClient` | Create, connect, and register the stateful FBNS client |
+| `await fbns_disconnect()` | `None` | Disconnect the active FBNS client |
+| `fbns_on(event, handler)` | `None` | Register an event handler on the active FBNS client |
+| `await fbns_ping()` | `bool` | Send an FBNS keepalive ping and wait for `PINGRESP` |
+| `await fbns_read_once()` | `Any` | Read one packet from the active FBNS client |
+
+`RealtimeClient` also exposes lower-level async helpers:
+
+| Method | Description |
+| --- | --- |
+| `on(event, handler)` | Register a handler for `receive`, `message`, or `realtime_sub` |
+| `await graph_ql_subscribe(subscriptions)` | Publish raw GraphQL realtime subscriptions |
+| `await skywalker_subscribe(subscriptions)` | Publish raw Skywalker subscriptions |
+| `await iris_subscribe(seq_id, snapshot_at_ms)` | Publish Direct inbox sync state for message-sync events |
+| `await direct_subscribe(amount=1)` | Fetch Direct inbox sync state and subscribe to message-sync events |
+| `await direct_send_text(thread_id, text, client_context=None)` | Publish a Direct text message over MQTT |
+| `await direct_send_reaction(thread_id, item_id, emoji="", ...)` | Publish a Direct reaction over MQTT |
+| `await direct_mark_seen(thread_id, item_id)` | Publish Direct seen state over MQTT |
+| `await direct_indicate_activity(thread_id, is_active=True, client_context=None)` | Publish Direct typing/activity state over MQTT |
+| `await send_foreground_state(...)` | Publish foreground state and optional topic changes |
+| `await publish_json(topic, data)` | Publish a JSON payload to a raw MQTToT topic |
+| `await ping()` | Send a keepalive ping and wait for `PINGRESP` |
+| `await read_once()` | Read and dispatch one packet |
+
+Basic receive loop:
+
+```python
+from aiograpi import Client
+
+cl = Client()
+await cl.login(USERNAME, PASSWORD)
+
+
+def handle_receive(event):
+    print(event["topic"], event["payload"])
+
+
+cl.realtime_on("receive", handle_receive)
+rt = await cl.realtime_connect()
+
+try:
+    while True:
+        await cl.realtime_read_once()
+finally:
+    await cl.realtime_disconnect()
+```
+
+Receive Direct message sync payloads:
+
+```python
+import json
+
+from aiograpi import Client
+
+cl = Client()
+await cl.login(USERNAME, PASSWORD)
+
+
+def handle_direct_message(payload):
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+cl.realtime_on("message", handle_direct_message)
+
+rt = await cl.realtime_connect()
+await rt.direct_subscribe()
+
+try:
+    # Optional keepalive check for smoke tests or long-running workers.
+    await rt.ping()
+
+    while True:
+        await cl.realtime_read_once()
+finally:
+    await cl.realtime_disconnect()
+```
+
+Send lightweight Direct actions over MQTT:
+
+```python
+await rt.direct_send_text(thread_id, "Hello from MQTT")
+await rt.direct_send_reaction(thread_id, item_id, emoji="*")
+await rt.direct_indicate_activity(thread_id, is_active=True)
+await rt.direct_mark_seen(thread_id, item_id)
+```
+
+For photos, videos, voice, thread creation, request approval, and other full Direct operations, use the normal
+`direct_*` HTTP methods. The MQTT payload shape is private and can change server-side, so inspect received
+dictionaries before depending on nested keys.
+
+Receive FBNS push notifications:
+
+```python
+import json
+
+from aiograpi import Client
+
+cl = Client()
+await cl.login(USERNAME, PASSWORD)
+
+
+def handle_push(payload):
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+cl.fbns_on("push", handle_push)
+fbns = await cl.fbns_connect()
+
+try:
+    await fbns.ping()
+    while True:
+        await cl.fbns_read_once()
+finally:
+    await cl.fbns_disconnect()
+```
+
+`fbns_connect()` registers the FBNS token with Instagram's private push register endpoint. The device-auth state
+returned by the broker is stored in `settings["fbns_auth"]`, so `dump_settings()` can persist it with the normal
+session data.
+
+Subscribe to raw realtime topics:
+
+```python
+await rt.graph_ql_subscribe(["<graphql-subscription>"])
+await rt.skywalker_subscribe(["<skywalker-subscription>"])
+```
+
+Raw GraphQL and Skywalker subscription strings are advanced and unstable. Message sync is subscribed by the default
+connection topics, so the Direct message example above does not need an extra raw subscription.
+
+Events:
+
+* `receive` is emitted for every decoded publish packet as `{"topic": topic, "payload": payload}`.
+* `message` is emitted for message-sync payloads.
+* `direct` is emitted for parsed Direct realtime payloads from message-sync or realtime-sub streams.
+* `typing`, `seen`, and `presence` are emitted for Direct realtime payloads that can be classified.
+* `send_response` is emitted for MQTT Direct command responses.
+* `iris_sub_response` is emitted for Iris subscription responses.
+* `realtime_sub` is emitted for realtime subscription payloads.
+* `push` is emitted for parsed FBNS `fbpushnotif` payloads.
+* FBNS also emits the notification `collapse_key` as an event name when present, for example `direct_v2_message`.
+* FBNS emits `reg_response`, `registered`, `logging`, and `pp` for registration and lower-level broker payloads.

--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -58,6 +58,7 @@ Common arguments:
 | photo_upload_to_story_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, duration: float = 15.0, extra_data: Dict = {}) | Story | Upload photo to story as a short video with the selected music track muxed into it
 | video_upload_to_story_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, extra_data: Dict = {}) | Story | Upload video to story with the selected music track muxed into it
 | story_music_extra_data(track: Track or dict, extra_data: Dict = {}) | dict | Build Story music configure fields for manual story upload `extra_data`
+| media_share_to_story(media_id: str, background: Path = None, caption: str = "") | Story | Share an existing feed media as a story sticker |
 
 In `extra_data`, you can pass additional story settings, for example:
 
@@ -91,6 +92,15 @@ await cl.video_upload_to_story(
     links=[StoryLink(webUri='https://github.com/subzeroid/aiograpi')],
     hashtags=[StoryHashtag(hashtag=hashtag, x=0.23, y=0.32, width=0.5, height=0.22)],
     medias=[StoryMedia(media_pk=media_pk, x=0.5, y=0.5, width=0.6, height=0.8)],
+)
+```
+
+Share a feed media to story:
+
+```python
+await cl.media_share_to_story(
+    "3613500067578544892_25025320",
+    caption="Shared from feed",
 )
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,6 +36,7 @@ export IG_PUBLIC_TRANSPORT_IMPERSONATE="chrome136"
 | [`upload_media.py`](upload_media.py) | Upload a feed photo, feed video, Reel, or Trial Reel. |
 | [`upload_story.py`](upload_story.py) | Upload a photo or video story, optionally with a link sticker. |
 | [`direct_message.py`](direct_message.py) | Send a Direct text message to user IDs or thread IDs. |
+| [`realtime_direct.py`](realtime_direct.py) | Receive Direct message sync payloads over Realtime MQTT. |
 
 ## Public lookup
 
@@ -78,3 +79,12 @@ python examples/direct_message.py --thread-ids 340282366841710301949128122292511
 ```
 
 Use exactly one target type: `--user-ids` or `--thread-ids`.
+
+## Realtime Direct MQTT
+
+```bash
+python examples/realtime_direct.py --limit 1
+IG_REALTIME_DIRECT_LIMIT=0 python examples/realtime_direct.py
+```
+
+The script logs in, subscribes to Direct message sync over Realtime MQTT, and prints received payloads as JSON.

--- a/examples/realtime_direct.py
+++ b/examples/realtime_direct.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+from _common import env_int, make_client
+
+
+async def receive_direct_messages(limit: int = 1):
+    cl = await make_client()
+    received = []
+
+    def handle_message(payload):
+        received.append(payload)
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+    cl.realtime_on("message", handle_message)
+    rt = await cl.realtime_connect()
+    await rt.direct_subscribe()
+
+    try:
+        while limit <= 0 or len(received) < limit:
+            await cl.realtime_read_once()
+    finally:
+        await cl.realtime_disconnect()
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Receive Direct message sync payloads over Realtime MQTT.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=env_int("IG_REALTIME_DIRECT_LIMIT", 1),
+        help="Number of message payloads to print. Use 0 to run until interrupted.",
+    )
+    args = parser.parse_args()
+
+    await receive_direct_messages(limit=args.limit)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
     - User: usage-guide/user.md
     - Account: usage-guide/account.md
     - Private GraphQL & doc_id: usage-guide/private-graphql.md
+    - Realtime MQTT: usage-guide/realtime.md
     - Best Practices: usage-guide/best-practices.md
     - Troubleshooting: usage-guide/troubleshooting.md
   - Development Guide: development-guide.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.0.11"
+version = "1.1.0"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]
@@ -57,6 +57,7 @@ keywords = [
 dependencies = [
     "httpx==0.28.1",
     "orjson==3.11.8",
+    "PySocks==1.7.1",
     "pydantic==2.12.5; sys_platform == 'android'",
     "pydantic>=2.12.5,<2.14; sys_platform != 'android'",
     "pycryptodomex==3.23.0",

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -15,6 +15,7 @@ from unittest import mock
 from unittest.mock import AsyncMock, Mock
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
+import httpx
 from pydantic import ValidationError
 
 from aiograpi import Client
@@ -158,12 +159,12 @@ class ClientPrivateTestCase(BaseClientMixin, unittest.IsolatedAsyncioTestCase):
     cl = None
     _username_cache = {}
 
-    def test_accounts_url(self):
+    def test_accounts_url(self, count=5):
         if not TEST_ACCOUNTS_URL:
             self.skipTest("TEST_ACCOUNTS_URL not configured")
         parts = urlsplit(TEST_ACCOUNTS_URL)
         query = dict(parse_qsl(parts.query, keep_blank_values=True))
-        query["count"] = "5"
+        query["count"] = str(count)
         return urlunsplit(
             (
                 parts.scheme,
@@ -173,6 +174,37 @@ class ClientPrivateTestCase(BaseClientMixin, unittest.IsolatedAsyncioTestCase):
                 parts.fragment,
             )
         )
+
+    async def fetch_test_accounts(self, count=5):
+        try:
+            async with httpx.AsyncClient(trust_env=False, verify=False, timeout=30) as client:
+                response = await client.get(
+                    self.test_accounts_url(count=count),
+                    headers={"User-Agent": "Mozilla/5.0 aiograpi-tests"},
+                )
+        except httpx.HTTPError as exc:
+            raise RuntimeError(f"Could not fetch TEST_ACCOUNTS_URL: {exc.__class__.__name__}") from None
+        if not 200 <= response.status_code < 300:
+            raise RuntimeError(f"TEST_ACCOUNTS_URL returned HTTP {response.status_code}")
+        return response.json()
+
+    async def client_from_test_account(self, acc):
+        settings = dict(acc["client_settings"])
+        totp_seed = settings.pop("totp_seed", None)
+        cl = Client(settings=settings, proxy=os.getenv("IG_PROXY") or acc["proxy"])
+        login_kwargs = {
+            "username": acc["username"],
+            "password": acc["password"],
+            "relogin": True,
+        }
+        if totp_seed:
+            totp_code = cl.totp_generate_code(totp_seed)
+            cl.totp_seed = totp_seed
+            cl.totp_code = totp_code
+            login_kwargs["verification_code"] = totp_code
+        await cl.login(**login_kwargs)
+        cl._user_id = acc.get("user_id")
+        return cl
 
     async def user_info_by_username(self, username):
         return await self.cl.user_info_by_username_v1(username)
@@ -185,40 +217,16 @@ class ClientPrivateTestCase(BaseClientMixin, unittest.IsolatedAsyncioTestCase):
         return str(info.pk)
 
     async def fresh_account(self):
-        import ssl
-        import urllib.request
-
-        ctx = ssl._create_unverified_context()
-        req = urllib.request.Request(
-            self.test_accounts_url(),
-            headers={"User-Agent": "Mozilla/5.0 aiograpi-tests"},
-        )
-        with urllib.request.urlopen(req, context=ctx) as resp:
-            data = json.loads(resp.read())
+        data = await self.fetch_test_accounts()
         last_exc = None
         for attempt, acc in enumerate(data[:5], start=1):
             print(f"Fresh account attempt {attempt}: %(username)r" % acc)
-            settings = dict(acc["client_settings"])
-            totp_seed = settings.pop("totp_seed", None)
-            cl = Client(settings=settings, proxy=acc["proxy"])
-            login_kwargs = {
-                "username": acc["username"],
-                "password": acc["password"],
-                "relogin": True,
-            }
-            if totp_seed:
-                totp_code = cl.totp_generate_code(totp_seed)
-                cl.totp_seed = totp_seed
-                cl.totp_code = totp_code
-                login_kwargs["verification_code"] = totp_code
             try:
-                await cl.login(**login_kwargs)
+                return await self.client_from_test_account(acc)
             except Exception as exc:
                 last_exc = exc
                 print(f"Fresh account attempt {attempt} failed for {acc['username']}: {exc.__class__.__name__} {exc}")
                 continue
-            cl._user_id = acc.get("user_id")
-            return cl
         raise last_exc or RuntimeError("No usable fresh account returned")
 
     async def asyncSetUp(self):

--- a/tests/live/test_fbns.py
+++ b/tests/live/test_fbns.py
@@ -1,0 +1,95 @@
+import os
+import time
+
+from aiograpi.realtime.fbns import FBNS_HOST
+from aiograpi.realtime.mqttot import SocketMQTToTTransport
+from aiograpi.types import DirectMessage
+from tests import legacy as _legacy
+from tests.live.test_realtime import RealtimeLiveHelpers
+
+
+class ClientFbnsLiveTestCase(RealtimeLiveHelpers, _legacy.ClientPrivateTestCase):
+    def payload_contains_push(self, payload, text, sender_id):
+        return self.payload_contains(payload, text) and self.payload_contains(payload, sender_id)
+
+    async def test_fbns_connect_register_and_ping_live(self):
+        registered = []
+        auth_events = []
+        transport = SocketMQTToTTransport(FBNS_HOST, timeout=30, proxy=self.realtime_proxy(self.cl))
+
+        self.cl.set_push_disabled(False)
+        self.cl.fbns_on("auth", auth_events.append)
+        self.cl.fbns_on("registered", registered.append)
+
+        try:
+            fbns = await self.cl.fbns_connect(transport=transport)
+
+            self.assertTrue(fbns.connected)
+            self.assertTrue(auth_events)
+            self.assertTrue(fbns.auth.password)
+            self.assertTrue(fbns.auth.device_id)
+            self.assertTrue(registered)
+            self.assertTrue(registered[0]["token"])
+            self.assertTrue(await self.cl.fbns_ping())
+        finally:
+            await self.cl.fbns_disconnect()
+
+    async def test_fbns_receives_direct_push_live(self):
+        if os.getenv("IG_RUN_FBNS_PUSH_LIVE") != "1":
+            self.skipTest("IG_RUN_FBNS_PUSH_LIVE=1 is required for the nondeterministic FBNS Direct push test")
+        receiver = self.cl
+        try:
+            sender = await self.fresh_account_excluding({receiver.user_id})
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+        registered = []
+        pushes = []
+        received = []
+        message = None
+        transport = SocketMQTToTTransport(FBNS_HOST, timeout=30, proxy=self.realtime_proxy(receiver))
+        text = f"aiograpi fbns push live {int(time.time())}"
+
+        receiver.set_push_disabled(False)
+        receiver.fbns_on("registered", registered.append)
+        receiver.fbns_on("push", pushes.append)
+        receiver.fbns_on("receive", received.append)
+
+        try:
+            fbns = await receiver.fbns_connect(transport=transport)
+            self.assertTrue(fbns.connected)
+            self.assertTrue(registered)
+            self.assertTrue(await receiver.fbns_ping())
+
+            message = await sender.direct_send(text, user_ids=[receiver.user_id])
+            self.assertIsInstance(message, DirectMessage)
+
+            deadline = time.time() + 60
+            while time.time() < deadline:
+                try:
+                    await receiver.fbns_read_once()
+                except TimeoutError:
+                    continue
+                for payload in pushes:
+                    if self.payload_contains_push(payload, text, sender.user_id):
+                        return
+
+            self.fail(
+                "FBNS did not deliver a Direct push payload for the live Direct message "
+                f"(received={len(received)}, pushes={len(pushes)})"
+            )
+        finally:
+            await receiver.fbns_disconnect()
+            if message:
+                try:
+                    await sender.direct_message_unsend(message.thread_id, message.id)
+                except Exception:
+                    pass
+                try:
+                    await sender.direct_thread_hide(message.thread_id)
+                except Exception:
+                    pass
+                try:
+                    await receiver.direct_thread_hide(message.thread_id)
+                except Exception:
+                    pass

--- a/tests/live/test_realtime.py
+++ b/tests/live/test_realtime.py
@@ -1,0 +1,197 @@
+import asyncio
+import os
+import time
+
+from aiograpi.realtime.client import REALTIME_HOST
+from aiograpi.realtime.mqttot import SocketMQTToTTransport
+from aiograpi.types import DirectMessage
+from tests import legacy as _legacy
+
+
+class RealtimeLiveHelpers:
+    def realtime_proxy(self, client):
+        return os.getenv("IG_REALTIME_PROXY") or client.proxy
+
+    async def fresh_account_excluding(self, exclude_user_ids):
+        data = await self.fetch_test_accounts(count=5 + len(exclude_user_ids))
+        last_exc = None
+        for acc in data[:5]:
+            if str(acc.get("user_id")) in {str(user_id) for user_id in exclude_user_ids}:
+                continue
+            try:
+                return await self.client_from_test_account(acc)
+            except Exception as exc:
+                last_exc = exc
+                continue
+        raise last_exc or RuntimeError("No usable second fresh account returned")
+
+    def payload_contains(self, payload, expected):
+        if isinstance(payload, dict):
+            return any(self.payload_contains(value, expected) for value in payload.values())
+        if isinstance(payload, (list, tuple)):
+            return any(self.payload_contains(value, expected) for value in payload)
+        return str(expected) in str(payload)
+
+    def payload_contains_message(self, payload, text, sender_id):
+        return self.payload_contains(payload, text) and self.payload_contains(payload, sender_id)
+
+    def payload_is_new_direct_message_sync(self, payload):
+        if isinstance(payload, dict):
+            message = payload.get("message")
+            if isinstance(message, dict) and message.get("delta_type") == "deltaNewMessage":
+                return True
+            if payload.get("delta_type") == "deltaNewMessage":
+                return True
+            return any(self.payload_is_new_direct_message_sync(value) for value in payload.values())
+        if isinstance(payload, (list, tuple)):
+            return any(self.payload_is_new_direct_message_sync(value) for value in payload)
+        return False
+
+    async def direct_message_visible(self, client, thread_id, text, sender_id):
+        try:
+            messages = await client.direct_messages(thread_id, amount=10)
+        except Exception:
+            messages = []
+        for message in messages:
+            if message.text == text and str(message.user_id) == str(sender_id):
+                return message
+        try:
+            request_threads = await client.direct_requests(amount=10)
+        except Exception:
+            request_threads = []
+        for thread in request_threads:
+            if str(thread.id) != str(thread_id):
+                continue
+            for message in thread.messages:
+                if message.text == text and str(message.user_id) == str(sender_id):
+                    return message
+        return None
+
+
+class ClientRealtimeLiveTestCase(RealtimeLiveHelpers, _legacy.ClientPrivateTestCase):
+    async def test_realtime_connect_and_ping_live(self):
+        transport = SocketMQTToTTransport(REALTIME_HOST, timeout=30, proxy=self.realtime_proxy(self.cl))
+
+        try:
+            realtime = await self.cl.realtime_connect(transport=transport)
+
+            self.assertTrue(realtime.connected)
+            self.assertTrue(await self.cl.realtime_ping())
+        finally:
+            await self.cl.realtime_disconnect()
+
+    async def test_realtime_receives_direct_message_sync_live(self):
+        receiver = self.cl
+        try:
+            sender = await self.fresh_account_excluding({receiver.user_id})
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+        received_payloads = []
+        message = None
+        transport = SocketMQTToTTransport(REALTIME_HOST, timeout=30, proxy=self.realtime_proxy(receiver))
+        text = f"aiograpi realtime live {int(time.time())}"
+
+        receiver.realtime_on("message", received_payloads.append)
+        try:
+            realtime = await receiver.realtime_connect(transport=transport)
+            self.assertTrue(await receiver.realtime_ping())
+            try:
+                await realtime.direct_subscribe()
+            except RuntimeError as exc:
+                self.skipTest(str(exc))
+
+            message = await sender.direct_send(text, user_ids=[receiver.user_id])
+            self.assertIsInstance(message, DirectMessage)
+
+            deadline = time.time() + 45
+            sync_seen = False
+            while time.time() < deadline:
+                try:
+                    await receiver.realtime_read_once()
+                except TimeoutError:
+                    continue
+                for payload in received_payloads:
+                    sync_seen = sync_seen or self.payload_is_new_direct_message_sync(payload)
+                    if self.payload_contains_message(payload, text, sender.user_id):
+                        return
+                if sync_seen:
+                    visible = await self.direct_message_visible(receiver, message.thread_id, text, sender.user_id)
+                    if visible:
+                        self.assertEqual(visible.text, text)
+                        return
+
+            self.fail("Realtime MQTT did not deliver a Direct message sync payload for the visible Direct message")
+        finally:
+            await receiver.realtime_disconnect()
+            if message:
+                try:
+                    await sender.direct_message_unsend(message.thread_id, message.id)
+                except Exception:
+                    pass
+                try:
+                    await sender.direct_thread_hide(message.thread_id)
+                except Exception:
+                    pass
+                try:
+                    await receiver.direct_thread_hide(message.thread_id)
+                except Exception:
+                    pass
+
+    async def test_realtime_direct_send_text_live(self):
+        sender = self.cl
+        try:
+            receiver = await self.fresh_account_excluding({sender.user_id})
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+        setup_message = None
+        mqtt_message = None
+        thread_id = None
+        transport = SocketMQTToTTransport(REALTIME_HOST, timeout=30, proxy=self.realtime_proxy(sender))
+        setup_text = f"aiograpi realtime setup {int(time.time())}"
+        text = f"aiograpi mqtt send live {int(time.time())}"
+
+        try:
+            setup_message = await sender.direct_send(setup_text, user_ids=[receiver.user_id])
+            self.assertIsInstance(setup_message, DirectMessage)
+            thread_id = setup_message.thread_id
+
+            realtime = await sender.realtime_connect(transport=transport)
+            self.assertTrue(realtime.connected)
+            self.assertTrue(await sender.realtime_ping())
+
+            command = await realtime.direct_send_text(thread_id, text)
+
+            deadline = time.time() + 45
+            while time.time() < deadline:
+                try:
+                    await sender.realtime_read_once()
+                except TimeoutError:
+                    pass
+                mqtt_message = await self.direct_message_visible(receiver, thread_id, text, sender.user_id)
+                if mqtt_message:
+                    self.assertEqual(command["thread_id"], str(thread_id))
+                    self.assertEqual(mqtt_message.text, text)
+                    return
+                await asyncio.sleep(2)
+
+            self.fail("Realtime MQTT direct_send_text did not create a visible Direct message")
+        finally:
+            await sender.realtime_disconnect()
+            for message in (mqtt_message, setup_message):
+                if not message or not thread_id:
+                    continue
+                try:
+                    await sender.direct_message_unsend(thread_id, message.id)
+                except Exception:
+                    pass
+            if thread_id:
+                try:
+                    await sender.direct_thread_hide(thread_id)
+                except Exception:
+                    pass
+                try:
+                    await receiver.direct_thread_hide(thread_id)
+                except Exception:
+                    pass

--- a/tests/regression/test_account.py
+++ b/tests/regression/test_account.py
@@ -133,3 +133,28 @@ class AccountRegressionTestCase(unittest.IsolatedAsyncioTestCase):
                 "code": "123456",
             },
         )
+
+    async def test_confirm_phone_number_posts_verify_sms_code_payload(self):
+        client = Client()
+        client.phone_id = "phone-id"
+        client.authorization_data = {"ds_user_id": "123"}
+        client.uuid = "uuid"
+        client.android_device_id = "android-id"
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        result = await client.confirm_phone_number("+15555550100", "123456", has_sms_consent=True)
+
+        self.assertEqual(result, {"status": "ok"})
+        client.private_request.assert_awaited_once_with(
+            "accounts/verify_sms_code/",
+            {
+                "_uuid": "uuid",
+                "device_id": "android-id",
+                "phone_id": "phone-id",
+                "_uid": "123",
+                "guid": "uuid",
+                "phone_number": "+15555550100",
+                "verification_code": "123456",
+                "has_sms_consent": "true",
+            },
+        )

--- a/tests/regression/test_bloks.py
+++ b/tests/regression/test_bloks.py
@@ -53,6 +53,56 @@ class BloksRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             with_signature=False,
         )
 
+    async def test_bloks_challenge_take_challenge_posts_unsigned_direct_payload(self):
+        client = self.build_client()
+        challenge_context = "Af4sGj7RsOARkOpaqueContext"
+        expected = {"status": "ok"}
+        client.private_request = AsyncMock(return_value=expected)
+
+        result = await client.bloks_challenge_take_challenge(
+            challenge_context=challenge_context,
+            choice=0,
+            extra_data={"is_bloks_web": False},
+        )
+
+        self.assertEqual(result, expected)
+        client.private_request.assert_awaited_once_with(
+            "bloks/apps/com.instagram.challenge.navigation.take_challenge/",
+            data={
+                "_uuid": "uuid-1",
+                "has_follow_up_screens": "0",
+                "bk_client_context": dumps({"bloks_version": "bloks-version", "styles_id": "instagram"}),
+                "bloks_versioning_id": "bloks-version",
+                "challenge_context": challenge_context,
+                "choice": "0",
+                "is_bloks_web": False,
+            },
+            with_signature=False,
+        )
+
+    async def test_bloks_change_password_preserves_opaque_challenge_context(self):
+        client = self.build_client()
+        challenge_context = "Af4sGj7RsOARkOpaqueContext"
+        client.password_encrypt = AsyncMock(return_value="#PWD_INSTAGRAM:4:1:encrypted")
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        result = await client.bloks_change_password("new-password", challenge_context)
+
+        self.assertTrue(result)
+        client.private_request.assert_awaited_once_with(
+            "bloks/apps/com.instagram.challenge.navigation.take_challenge/",
+            data={
+                "_uuid": "uuid-1",
+                "has_follow_up_screens": "0",
+                "bk_client_context": dumps({"bloks_version": "bloks-version", "styles_id": "instagram"}),
+                "bloks_versioning_id": "bloks-version",
+                "challenge_context": challenge_context,
+                "enc_new_password1": "#PWD_INSTAGRAM:4:1:encrypted",
+                "enc_new_password2": "#PWD_INSTAGRAM:4:1:encrypted",
+            },
+            with_signature=False,
+        )
+
     async def test_bloks_fxcal_link_reels_share_uses_current_flow_payload(self):
         client = self.build_client()
         expected = {"status": "ok"}

--- a/tests/regression/test_clip.py
+++ b/tests/regression/test_clip.py
@@ -5,7 +5,7 @@ from unittest import mock
 from unittest.mock import AsyncMock, Mock
 
 from aiograpi import Client
-from aiograpi.exceptions import ClientError
+from aiograpi.exceptions import ClientError, ClipNotUpload
 
 
 def _build_client():
@@ -97,6 +97,24 @@ class ClipPinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
 
 class ClipUploadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_clip_upload_error_includes_stage_status_and_body(self):
+        client = _build_client()
+        response = Mock(status_code=500, text='{"message":"upload failed","status":"fail"}')
+        response.json.return_value = {"message": "upload failed", "status": "fail"}
+
+        with self.assertRaises(ClipNotUpload) as ctx:
+            client._raise_clip_upload_error(response, "upload_settings")
+
+        error = ctx.exception
+        self.assertIs(error.response, response)
+        self.assertEqual(error.stage, "upload_settings")
+        self.assertEqual(error.status_code, 500)
+        self.assertEqual(error.error_response, {"message": "upload failed", "status": "fail"})
+        self.assertEqual(error.response_text, '{"message":"upload failed","status":"fail"}')
+        self.assertIn("Clip upload failed during upload_settings", str(error))
+        self.assertEqual(client.last_response, response)
+        self.assertEqual(client.last_json, {"message": "upload failed", "status": "fail"})
+
     async def test_clip_share_to_fb_config_requests_reel_facebook_config(self):
         client = _build_client()
         expected = {"status": "ok", "eligible": True}

--- a/tests/regression/test_fbns.py
+++ b/tests/regression/test_fbns.py
@@ -1,0 +1,247 @@
+import json
+import unittest
+import zlib
+from unittest import mock
+from unittest.mock import AsyncMock
+
+from aiograpi import Client
+from aiograpi.realtime import FbnsClient, FbnsDeviceAuth
+from aiograpi.realtime.fbns import FBNS_HOST, FBNS_SUBSCRIBE_TOPICS, FBNSTopics
+from aiograpi.realtime.mqttot import MQTToTConnection, decode_packet, read_thrift_object, write_publish_packet
+
+
+def _build_logged_in_client():
+    client = Client()
+    client.authorization_data = {"ds_user_id": "12345", "sessionid": "12345:session"}
+    client.phone_id = "phone-id-12345678901234567890"
+    client.uuid = "uuid-1"
+    client.user_agent = "Instagram 428.0.0.47.67 Android"
+    client.app_version = "428.0.0.47.67"
+    client.capabilities = "3brTvw=="
+    client.locale = "en_US"
+    return client
+
+
+def _packet(packet_type: int, body: bytes) -> bytes:
+    remaining = bytearray()
+    value = len(body)
+    while True:
+        byte = value % 128
+        value //= 128
+        if value:
+            byte |= 0x80
+        remaining.append(byte)
+        if not value:
+            break
+    return bytes([packet_type << 4]) + bytes(remaining) + body
+
+
+def _connack(payload: dict) -> bytes:
+    return _packet(2, b"\x00\x00" + json.dumps(payload, separators=(",", ":")).encode())
+
+
+def _publish(topic: str, payload: dict, packet_id: int = 7) -> bytes:
+    return write_publish_packet(topic, json.dumps(payload, separators=(",", ":")).encode(), packet_id=packet_id)
+
+
+def _suback(packet_id: int = 2) -> bytes:
+    return _packet(9, packet_id.to_bytes(2, "big") + b"\x01")
+
+
+class FbnsClientRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    def test_fbns_device_auth_reads_connack_payload_and_updates_settings(self):
+        client = _build_logged_in_client()
+        auth = FbnsDeviceAuth.from_client(client)
+
+        auth.read(
+            {
+                "ck": 123456,
+                "cs": "connection-secret",
+                "di": "fbns-device-id",
+                "ds": "fbns-device-secret",
+                "sr": "odn",
+                "rc": "ATN",
+            }
+        )
+        auth.save(client)
+
+        self.assertEqual(auth.user_id, 123456)
+        self.assertEqual(auth.password, "connection-secret")
+        self.assertEqual(auth.device_id, "fbns-device-id")
+        self.assertEqual(auth.device_secret, "fbns-device-secret")
+        self.assertEqual(client.settings["fbns_auth"]["device_id"], "fbns-device-id")
+        self.assertEqual(client.settings["fbns_auth"]["user_id"], 123456)
+
+    def test_fbns_device_auth_reads_length_prefixed_connack_payload(self):
+        auth = FbnsDeviceAuth()
+        payload = json.dumps({"ck": 123456, "cs": "secret"}, separators=(",", ":")).encode()
+
+        auth.read(len(payload).to_bytes(2, "big") + payload)
+
+        self.assertEqual(auth.user_id, 123456)
+        self.assertEqual(auth.password, "secret")
+
+    def test_fbns_initial_device_auth_connection_uses_zero_fbns_user_id(self):
+        client = _build_logged_in_client()
+        fbns = FbnsClient(client)
+
+        connection = fbns.build_connection()
+
+        self.assertEqual(connection.client_info["userId"], 0)
+
+    def test_fbns_client_builds_device_auth_connection(self):
+        client = _build_logged_in_client()
+        auth = FbnsDeviceAuth(
+            client_id="phone-id-12345678901",
+            user_id=12345,
+            password="connection-secret",
+            device_id="fbns-device-id",
+            device_secret="fbns-device-secret",
+        )
+        fbns = FbnsClient(client, auth=auth)
+
+        connection = fbns.build_connection()
+
+        self.assertEqual(connection.client_identifier, "phone-id-12345678901")
+        self.assertEqual(connection.password, "connection-secret")
+        self.assertEqual(connection.client_info["userId"], 12345)
+        self.assertEqual(connection.client_info["clientType"], "device_auth")
+        self.assertEqual(connection.client_info["endpointCapabilities"], 128)
+        self.assertEqual(connection.client_info["subscribeTopics"], FBNS_SUBSCRIBE_TOPICS)
+        self.assertEqual(connection.client_info["deviceId"], "fbns-device-id")
+        self.assertEqual(connection.client_info["deviceSecret"], "fbns-device-secret")
+        self.assertEqual(connection.client_info["fbnsDeviceId"], "fbns-device-id")
+
+        decoded = decode_packet(fbns.connect_packet())
+        self.assertEqual(decoded.keep_alive, 60)
+        thrift = read_thrift_object(zlib.decompress(decoded.payload), MQTToTConnection.thrift_descriptors())
+        self.assertEqual(thrift["clientInfo"]["clientType"], "device_auth")
+        self.assertEqual(thrift["clientInfo"]["subscribeTopics"], FBNS_SUBSCRIBE_TOPICS)
+
+    async def test_fbns_register_token_publishes_registration_request_and_reads_token(self):
+        client = _build_logged_in_client()
+        transport = mock.Mock()
+        transport.recv_packet.return_value = _publish(FBNSTopics.REG_RESPONSE, {"token": "fbns-token-1"})
+        fbns = FbnsClient(client, transport=transport)
+
+        token = await fbns.register_token()
+
+        sent = decode_packet(transport.send.call_args_list[0].args[0])
+        self.assertEqual(token, "fbns-token-1")
+        self.assertEqual(sent.topic, FBNSTopics.REG_REQUEST)
+        self.assertEqual(
+            json.loads(zlib.decompress(sent.payload)),
+            {
+                "pkg_name": "com.instagram.android",
+                "appid": 567310203415052,
+            },
+        )
+
+    async def test_fbns_connect_reads_device_auth_and_registers_push_token(self):
+        client = _build_logged_in_client()
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+        transport = mock.Mock()
+        transport.recv_packet.side_effect = [
+            _connack(
+                {
+                    "ck": 123456,
+                    "cs": "connection-secret",
+                    "di": "fbns-device-id",
+                    "ds": "fbns-device-secret",
+                }
+            ),
+            _suback(),
+            _publish(FBNSTopics.REG_RESPONSE, {"token": "fbns-token-1"}),
+        ]
+        registered = []
+        fbns = FbnsClient(client, transport=transport)
+        fbns.on("registered", registered.append)
+
+        await fbns.connect()
+
+        self.assertTrue(fbns.connected)
+        self.assertEqual(fbns.auth.password, "connection-secret")
+        self.assertEqual(client.settings["fbns_auth"]["device_secret"], "fbns-device-secret")
+        client.private_request.assert_awaited_once()
+        endpoint, data = client.private_request.call_args.args[:2]
+        self.assertEqual(endpoint, "push/register/")
+        self.assertEqual(data["device_type"], "android_mqtt")
+        self.assertIs(data["is_main_push_channel"], True)
+        self.assertEqual(data["device_sub_type"], 2)
+        self.assertEqual(data["device_token"], "fbns-token-1")
+        self.assertEqual(data["users"], "12345")
+        self.assertEqual(client.private_request.call_args.kwargs, {"with_signature": False})
+        self.assertEqual(registered, [{"token": "fbns-token-1", "response": {"status": "ok"}}])
+
+    async def test_fbns_connect_subscribes_to_message_topic_before_waiting_for_registration_response(self):
+        client = _build_logged_in_client()
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+        transport = mock.Mock()
+        transport.recv_packet.side_effect = [_connack({}), _suback(), _publish(FBNSTopics.REG_RESPONSE, {"token": "x"})]
+        fbns = FbnsClient(client, transport=transport)
+
+        await fbns.connect()
+
+        subscribe_packet = transport.send.call_args_list[1].args[0]
+        self.assertEqual(subscribe_packet[0], 0x82)
+        self.assertIn(b"\x00\x0276", subscribe_packet)
+
+    def test_fbns_dispatches_push_notification_payloads(self):
+        client = _build_logged_in_client()
+        fbns = FbnsClient(client, transport=mock.Mock())
+        push_events = []
+        direct_push_events = []
+        received_events = []
+        fbns.on("push", push_events.append)
+        fbns.on("direct_v2_message", direct_push_events.append)
+        fbns.on("receive", received_events.append)
+
+        payload = fbns.dispatch_packet(
+            FBNSTopics.MESSAGE,
+            json.dumps(
+                {
+                    "fbpushnotif": json.dumps(
+                        {
+                            "collapse_key": "direct_v2_message",
+                            "message": "hello",
+                            "ig": "payload",
+                        },
+                        separators=(",", ":"),
+                    )
+                },
+                separators=(",", ":"),
+            ).encode(),
+        )
+
+        self.assertEqual(payload["collapse_key"], "direct_v2_message")
+        self.assertEqual(push_events, [payload])
+        self.assertEqual(direct_push_events, [payload])
+        self.assertEqual(received_events, [{"topic": FBNSTopics.MESSAGE, "payload": payload}])
+
+    async def test_client_exposes_stateful_fbns_helpers(self):
+        client = _build_logged_in_client()
+        transport = mock.Mock()
+        transport.recv_packet.side_effect = [
+            _connack({}),
+            _suback(),
+            _publish(FBNSTopics.REG_RESPONSE, {"token": "fbns-token-1"}),
+        ]
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        fbns = await client.fbns_connect(transport=transport)
+
+        self.assertIsInstance(fbns, FbnsClient)
+        self.assertIs(fbns.transport, transport)
+        self.assertTrue(fbns.transport.connect.called)
+
+        await client.fbns_disconnect()
+        transport.disconnect.assert_called_once()
+
+    def test_fbns_default_transport_uses_mqtt_mini_and_client_proxy(self):
+        client = _build_logged_in_client()
+        client.proxy = "socks5://127.0.0.1:8888"
+
+        fbns = FbnsClient(client)
+
+        self.assertEqual(fbns.transport.host, FBNS_HOST)
+        self.assertEqual(fbns.transport.proxy, "socks5://127.0.0.1:8888")

--- a/tests/regression/test_hashtag.py
+++ b/tests/regression/test_hashtag.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import AsyncMock
 
 from aiograpi import Client
+from aiograpi.types import Hashtag
 
 
 class HashtagRegressionTestCase(unittest.IsolatedAsyncioTestCase):
@@ -44,3 +45,44 @@ class HashtagRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         with self.assertRaisesRegex(ValueError, "Hashtag name cannot be empty"):
             await client.hashtag_medias_recent("#")
+
+    async def test_hashtag_following_fetches_current_account_hashtags(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "123"}
+        response = {
+            "data": {
+                "1$xdt_api__v1__friendships__following(_request_data:$request_data,user_id:$user_id)": {
+                    "hashtag_count": 2,
+                    "preview_hashtags": [
+                        {
+                            "id": "17843845123043063",
+                            "name": "fotodestages",
+                            "media_count": 716293,
+                            "profile_pic_url": "https://example.com/fotodestages.jpg",
+                        },
+                        {
+                            "id": "17875609661266431",
+                            "name": "coachingbydregold",
+                            "media_count": 1,
+                            "profile_pic_url": "https://example.com/coachingbydregold.jpg",
+                        },
+                    ],
+                }
+            }
+        }
+        client.private_graphql_following_list = AsyncMock(return_value=response)
+
+        hashtags = await client.hashtag_following(amount=1)
+
+        self.assertEqual(len(hashtags), 1)
+        self.assertIsInstance(hashtags[0], Hashtag)
+        self.assertEqual(hashtags[0].id, "17843845123043063")
+        self.assertEqual(hashtags[0].name, "fotodestages")
+        self.assertEqual(hashtags[0].media_count, 716293)
+        client.private_graphql_following_list.assert_awaited_once_with(
+            "123",
+            client.rank_token,
+            priority="u=3, i",
+            skip_preview_hashtags=False,
+            skip_hashtag_count=False,
+        )

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -1,7 +1,9 @@
 import unittest
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 from aiograpi import Client
+from aiograpi.types import StoryMedia
 
 
 class MediaActionPayloadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
@@ -88,3 +90,33 @@ class MediaActionPayloadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             },
             with_signature=False,
         )
+
+    async def test_media_share_to_story_uses_existing_media_as_story_sticker(self):
+        client = self._build_logged_in_client()
+        background = Path("background.jpg")
+        story = object()
+        client.photo_upload_to_story = AsyncMock(return_value=story)
+
+        result = await client.media_share_to_story(
+            "123_456",
+            background=background,
+            caption="caption",
+            x=0.4,
+            y=0.45,
+            width=0.7,
+            height=0.55,
+        )
+
+        self.assertIs(result, story)
+        client.photo_upload_to_story.assert_awaited_once()
+        args, kwargs = client.photo_upload_to_story.call_args
+        self.assertEqual(args[:2], (background, "caption"))
+        self.assertEqual(len(kwargs["medias"]), 1)
+        media_sticker = kwargs["medias"][0]
+        self.assertIsInstance(media_sticker, StoryMedia)
+        self.assertEqual(media_sticker.media_pk, 123)
+        self.assertEqual(media_sticker.user_id, 456)
+        self.assertEqual(media_sticker.x, 0.4)
+        self.assertEqual(media_sticker.y, 0.45)
+        self.assertEqual(media_sticker.width, 0.7)
+        self.assertEqual(media_sticker.height, 0.55)

--- a/tests/regression/test_realtime.py
+++ b/tests/regression/test_realtime.py
@@ -1,0 +1,399 @@
+import json
+import unittest
+import zlib
+from unittest import mock
+from unittest.mock import AsyncMock
+
+from aiograpi import Client
+from aiograpi.realtime import RealtimeClient
+from aiograpi.realtime.mqttot import (
+    MQTToTConnection,
+    MQTToTTopics,
+    SocketMQTToTTransport,
+    decode_packet,
+    read_thrift_object,
+    write_connect_packet,
+    write_pingreq_packet,
+    write_publish_packet,
+)
+
+
+def _build_logged_in_client():
+    client = Client()
+    client.authorization_data = {"ds_user_id": "12345", "sessionid": "12345:session"}
+    client.phone_id = "phone-id-12345678901234567890"
+    client.uuid = "uuid-1"
+    client.user_agent = "Instagram 428.0.0.47.67 Android"
+    client.app_version = "428.0.0.47.67"
+    client.capabilities = "3brTvw=="
+    client.locale = "en_US"
+    return client
+
+
+class MQTToTPacketRegressionTestCase(unittest.TestCase):
+    def test_mqttot_connect_packet_uses_custom_protocol_and_zipped_thrift_payload(self):
+        connection = MQTToTConnection(
+            client_identifier="phone-id-123456789",
+            client_info={
+                "userId": 12345,
+                "userAgent": "Instagram 428",
+                "clientCapabilities": 183,
+                "endpointCapabilities": 0,
+                "publishFormat": 1,
+                "deviceId": "phone-id-12345678901234567890",
+                "isInitiallyForeground": True,
+                "subscribeTopics": [88, 135, 149, 150, 133, 146],
+                "clientType": "cookie_auth",
+                "appId": 567067343352427,
+                "clientStack": 3,
+            },
+            password="sessionid=12345:session",
+            app_specific_info={
+                "app_version": "428.0.0.47.67",
+                "platform": "android",
+                "ig_mqtt_route": "django",
+            },
+        )
+
+        packet = write_connect_packet(connection, keep_alive=20)
+
+        decoded = decode_packet(packet)
+        self.assertEqual(packet[0], 0x10)
+        self.assertEqual(decoded.packet_type, "connect")
+        self.assertEqual(decoded.protocol_name, "MQTToT")
+        self.assertEqual(decoded.protocol_level, 3)
+        self.assertEqual(decoded.connect_flags, 0xC2)
+        self.assertEqual(decoded.keep_alive, 20)
+
+        thrift_payload = zlib.decompress(decoded.payload)
+        thrift = read_thrift_object(thrift_payload, MQTToTConnection.thrift_descriptors())
+        self.assertEqual(thrift["clientIdentifier"], "phone-id-123456789")
+        self.assertEqual(thrift["password"], "sessionid=12345:session")
+        self.assertEqual(thrift["clientInfo"]["clientType"], "cookie_auth")
+        self.assertEqual(thrift["clientInfo"]["subscribeTopics"], [88, 135, 149, 150, 133, 146])
+        self.assertEqual(thrift["appSpecificInfo"]["ig_mqtt_route"], "django")
+
+    def test_publish_packet_round_trips_topic_and_zipped_payload(self):
+        payload = zlib.compress(json.dumps({"sub": ["1/graphqlsubscriptions/test/{}"]}).encode())
+
+        packet = write_publish_packet(MQTToTTopics.REALTIME_SUB, payload, qos=1, packet_id=7)
+
+        decoded = decode_packet(packet)
+        self.assertEqual(decoded.packet_type, "publish")
+        self.assertEqual(decoded.topic, MQTToTTopics.REALTIME_SUB)
+        self.assertEqual(decoded.qos, 1)
+        self.assertEqual(decoded.packet_id, 7)
+        self.assertEqual(json.loads(zlib.decompress(decoded.payload)), {"sub": ["1/graphqlsubscriptions/test/{}"]})
+
+    def test_ping_response_packet_decodes_as_pingresp(self):
+        decoded = decode_packet(b"\xd0\x00")
+
+        self.assertEqual(decoded.packet_type, "pingresp")
+        self.assertEqual(decoded.payload, b"")
+
+
+class RealtimeClientRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    def test_realtime_client_builds_cookie_auth_connection_from_instagram_session(self):
+        client = _build_logged_in_client()
+        realtime = RealtimeClient(client)
+
+        connection = realtime.build_connection()
+
+        self.assertEqual(connection.client_identifier, "phone-id-12345678901")
+        self.assertEqual(connection.password, "sessionid=12345:session")
+        self.assertEqual(connection.client_info["userId"], 12345)
+        self.assertEqual(connection.client_info["clientType"], "cookie_auth")
+        self.assertEqual(connection.client_info["appId"], 567067343352427)
+        self.assertEqual(connection.client_info["subscribeTopics"], [88, 135, 149, 150, 133, 146])
+        self.assertEqual(connection.app_specific_info["app_version"], "428.0.0.47.67")
+        self.assertEqual(connection.app_specific_info["platform"], "android")
+
+    def test_realtime_client_default_transport_uses_client_proxy(self):
+        client = _build_logged_in_client()
+        client.proxy = "socks5://127.0.0.1:8888"
+
+        realtime = RealtimeClient(client)
+
+        self.assertIsInstance(realtime.transport, SocketMQTToTTransport)
+        self.assertEqual(realtime.transport.proxy, "socks5://127.0.0.1:8888")
+
+    async def test_client_exposes_stateful_realtime_helpers(self):
+        client = _build_logged_in_client()
+        transport = mock.Mock()
+        await client.realtime_connect(transport=transport)
+
+        self.assertIsInstance(client.realtime, RealtimeClient)
+        transport.connect.assert_called_once()
+
+        await client.realtime_disconnect()
+        transport.disconnect.assert_called_once()
+
+    async def test_realtime_client_ping_sends_keepalive_and_reads_pingresp(self):
+        client = _build_logged_in_client()
+        transport = mock.Mock()
+        transport.recv_packet.return_value = b"\xd0\x00"
+        realtime = RealtimeClient(client, transport=transport)
+        realtime.connected = True
+
+        self.assertTrue(await realtime.ping())
+
+        transport.send.assert_called_once_with(write_pingreq_packet())
+        transport.recv_packet.assert_called_once()
+
+    async def test_client_exposes_stateful_realtime_ping_helper(self):
+        client = _build_logged_in_client()
+        transport = mock.Mock()
+        transport.recv_packet.return_value = b"\xd0\x00"
+        await client.realtime_connect(transport=transport)
+
+        self.assertTrue(await client.realtime_ping())
+
+    async def test_realtime_client_iris_subscribe_publishes_inbox_sync_state(self):
+        client = _build_logged_in_client()
+        realtime = RealtimeClient(client, transport=mock.Mock())
+
+        with mock.patch.object(realtime, "publish_json", new=AsyncMock()) as publish_json:
+            await realtime.iris_subscribe(seq_id=123, snapshot_at_ms=456)
+
+        publish_json.assert_awaited_once_with(
+            MQTToTTopics.IRIS_SUB,
+            {
+                "seq_id": 123,
+                "snapshot_at_ms": 456,
+                "snapshot_app_version": "428.0.0.47.67",
+            },
+        )
+
+    async def test_realtime_client_direct_subscribe_fetches_inbox_and_subscribes_to_iris(self):
+        client = _build_logged_in_client()
+        client.last_json = {"seq_id": 123, "snapshot_at_ms": 456}
+        client.direct_threads = AsyncMock(return_value=[])
+        realtime = RealtimeClient(client, transport=mock.Mock())
+
+        with mock.patch.object(realtime, "iris_subscribe", new=AsyncMock()) as iris_subscribe:
+            state = await realtime.direct_subscribe()
+
+        client.direct_threads.assert_awaited_once_with(amount=1)
+        iris_subscribe.assert_awaited_once_with(seq_id=123, snapshot_at_ms=456)
+        self.assertEqual(state, {"seq_id": 123, "snapshot_at_ms": 456})
+
+    async def test_realtime_client_direct_send_text_publishes_mqtt_direct_command(self):
+        client = _build_logged_in_client()
+        transport = mock.Mock()
+        realtime = RealtimeClient(client, transport=transport)
+
+        state = await realtime.direct_send_text("thread-1", "hello", client_context="ctx-1")
+
+        packet = decode_packet(transport.send.call_args.args[0])
+        payload = json.loads(zlib.decompress(packet.payload))
+        self.assertEqual(packet.topic, MQTToTTopics.SEND_MESSAGE)
+        self.assertEqual(
+            payload,
+            {
+                "action": "send_item",
+                "thread_id": "thread-1",
+                "client_context": "ctx-1",
+                "item_type": "text",
+                "text": "hello",
+            },
+        )
+        self.assertEqual(state, {"thread_id": "thread-1", "client_context": "ctx-1", "action": "send_item"})
+
+    async def test_realtime_client_direct_send_reaction_publishes_mqtt_direct_command(self):
+        client = _build_logged_in_client()
+        transport = mock.Mock()
+        realtime = RealtimeClient(client, transport=transport)
+
+        await realtime.direct_send_reaction("thread-1", "item-1", emoji="*", client_context="ctx-1")
+
+        packet = decode_packet(transport.send.call_args.args[0])
+        payload = json.loads(zlib.decompress(packet.payload))
+        self.assertEqual(packet.topic, MQTToTTopics.SEND_MESSAGE)
+        self.assertEqual(
+            payload,
+            {
+                "action": "send_item",
+                "thread_id": "thread-1",
+                "client_context": "ctx-1",
+                "item_type": "reaction",
+                "item_id": "item-1",
+                "node_type": "item",
+                "reaction_type": "like",
+                "reaction_status": "created",
+                "target_item_type": "text",
+                "emoji": "*",
+            },
+        )
+
+    async def test_realtime_client_direct_indicate_activity_publishes_typing_command(self):
+        client = _build_logged_in_client()
+        transport = mock.Mock()
+        realtime = RealtimeClient(client, transport=transport)
+
+        await realtime.direct_indicate_activity("thread-1", is_active=False, client_context="ctx-1")
+
+        packet = decode_packet(transport.send.call_args.args[0])
+        payload = json.loads(zlib.decompress(packet.payload))
+        self.assertEqual(packet.topic, MQTToTTopics.SEND_MESSAGE)
+        self.assertEqual(
+            payload,
+            {
+                "action": "indicate_activity",
+                "thread_id": "thread-1",
+                "client_context": "ctx-1",
+                "activity_status": "0",
+            },
+        )
+
+    async def test_realtime_client_direct_mark_seen_publishes_seen_command(self):
+        client = _build_logged_in_client()
+        transport = mock.Mock()
+        realtime = RealtimeClient(client, transport=transport)
+
+        await realtime.direct_mark_seen("thread-1", "item-1")
+
+        packet = decode_packet(transport.send.call_args.args[0])
+        payload = json.loads(zlib.decompress(packet.payload))
+        self.assertEqual(packet.topic, MQTToTTopics.SEND_MESSAGE)
+        self.assertEqual(
+            payload,
+            {
+                "action": "mark_seen",
+                "thread_id": "thread-1",
+                "item_id": "item-1",
+            },
+        )
+
+    def test_message_sync_delta_new_message_without_patch_data_is_still_emitted(self):
+        client = _build_logged_in_client()
+        realtime = RealtimeClient(client, transport=mock.Mock())
+        messages = []
+        realtime.on("message", messages.append)
+
+        realtime.dispatch_message_sync(
+            [
+                {
+                    "event": "patch",
+                    "data": [],
+                    "message_type": 1,
+                    "seq_id": 22,
+                    "mutation_token": "token-1",
+                    "client_context": "ctx-1",
+                    "realtime": True,
+                    "delta_type": "deltaNewMessage",
+                }
+            ]
+        )
+
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0]["message"]["delta_type"], "deltaNewMessage")
+        self.assertEqual(messages[0]["message"]["client_context"], "ctx-1")
+
+    async def test_realtime_client_send_foreground_state_publishes_thrift_state(self):
+        client = _build_logged_in_client()
+        transport = mock.Mock()
+        realtime = RealtimeClient(client, transport=transport)
+
+        await realtime.send_foreground_state(keep_alive_timeout=60, subscribe_topics=["146"], request_id=99)
+
+        packet = decode_packet(transport.send.call_args.args[0])
+        payload = zlib.decompress(packet.payload)
+        self.assertEqual(packet.topic, MQTToTTopics.FOREGROUND_STATE)
+        self.assertEqual(payload[0], 0)
+        state = read_thrift_object(payload[1:], realtime.foreground_state_descriptors())
+        self.assertEqual(state["keepAliveTimeout"], 60)
+        self.assertEqual(state["subscribeTopics"], ["146"])
+        self.assertEqual(state["requestId"], 99)
+
+    def test_realtime_client_dispatches_send_message_response_event(self):
+        client = _build_logged_in_client()
+        realtime = RealtimeClient(client, transport=mock.Mock())
+        handler = mock.Mock()
+        realtime.on("send_response", handler)
+        payload = {"status": "ok", "client_context": "ctx-1"}
+
+        realtime.dispatch_packet(MQTToTTopics.SEND_MESSAGE_RESPONSE, zlib.compress(json.dumps(payload).encode()))
+
+        handler.assert_called_once_with(payload)
+
+    def test_message_sync_dispatch_emits_direct_message_wrapper(self):
+        client = _build_logged_in_client()
+        realtime = RealtimeClient(client, transport=mock.Mock())
+        handler = mock.Mock()
+        realtime.on("message", handler)
+        payload = [
+            {
+                "event": "patch",
+                "seq_id": 123,
+                "data": [
+                    {
+                        "op": "add",
+                        "path": "/direct_v2/threads/987/items/item-1",
+                        "value": json.dumps({"item_id": "item-1", "text": "hello", "user_id": "55"}),
+                    }
+                ],
+            }
+        ]
+
+        realtime.dispatch_packet(MQTToTTopics.MESSAGE_SYNC, zlib.compress(json.dumps(payload).encode()))
+
+        handler.assert_called_once()
+        message = handler.call_args.args[0]["message"]
+        self.assertEqual(message["thread_id"], "987")
+        self.assertEqual(message["path"], "/direct_v2/threads/987/items/item-1")
+        self.assertEqual(message["op"], "add")
+        self.assertEqual(message["text"], "hello")
+        self.assertEqual(message["user_id"], "55")
+
+    def test_realtime_sub_dispatch_emits_direct_typing_seen_and_presence_events(self):
+        client = _build_logged_in_client()
+        realtime = RealtimeClient(client, transport=mock.Mock())
+        direct_handler = mock.Mock()
+        typing_handler = mock.Mock()
+        seen_handler = mock.Mock()
+        presence_handler = mock.Mock()
+        realtime.on("direct", direct_handler)
+        realtime.on("typing", typing_handler)
+        realtime.on("seen", seen_handler)
+        realtime.on("presence", presence_handler)
+        direct_payload = {
+            "message": json.dumps(
+                {
+                    "data": [
+                        {
+                            "path": "/direct_v2/threads/987/activity_indicator_id",
+                            "value": json.dumps({"activity_status": "1", "sender_id": "55"}),
+                        },
+                        {
+                            "path": "/direct_v2/threads/987/seen_state",
+                            "value": json.dumps({"item_id": "item-1", "user_id": "55"}),
+                        },
+                        {
+                            "path": "/direct_v2/threads/987/presence",
+                            "value": json.dumps({"is_active": True, "user_id": "55"}),
+                        },
+                    ]
+                }
+            )
+        }
+
+        realtime.dispatch_packet(MQTToTTopics.REALTIME_SUB, zlib.compress(json.dumps(direct_payload).encode()))
+
+        self.assertEqual(direct_handler.call_count, 3)
+        typing_handler.assert_called_once()
+        seen_handler.assert_called_once()
+        presence_handler.assert_called_once()
+        self.assertEqual(typing_handler.call_args.args[0]["thread_id"], "987")
+        self.assertEqual(seen_handler.call_args.args[0]["thread_id"], "987")
+        self.assertTrue(presence_handler.call_args.args[0]["value"]["is_active"])
+
+    async def test_realtime_connect_preserves_handlers_registered_before_connect(self):
+        client = _build_logged_in_client()
+        transport = mock.Mock()
+        handler = mock.Mock()
+
+        client.realtime_on("receive", handler)
+        await client.realtime_connect(transport=transport)
+        client.realtime.emit("receive", {"topic": "146", "payload": {"ok": True}})
+
+        handler.assert_called_once_with({"topic": "146", "payload": {"ok": True}})

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -2,4 +2,4 @@ import aiograpi
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.7.17"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.8.2"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "aiograpi"
-version = "1.0.11"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -21,6 +21,7 @@ dependencies = [
     { name = "pycryptodomex" },
     { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'android'" },
     { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'android'" },
+    { name = "pysocks" },
     { name = "zstandard" },
 ]
 
@@ -90,6 +91,7 @@ requires-dist = [
     { name = "pycryptodomex", specifier = "==3.23.0" },
     { name = "pydantic", marker = "sys_platform != 'android'", specifier = ">=2.12.5,<2.14" },
     { name = "pydantic", marker = "sys_platform == 'android'", specifier = "==2.12.5" },
+    { name = "pysocks", specifier = "==1.7.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = "==9.0.3" },
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = "==3.8.0" },
     { name = "python-dotenv", marker = "extra == 'test'", specifier = ">=0.10" },
@@ -2036,6 +2038,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- sync aiograpi to the instagrapi 2.8.2 baseline and bump aiograpi to 1.1.0
- add async realtime MQTT and FBNS clients, Client helpers, Direct MQTT example, and docs
- port the upstream account/hashtag/media/bloks/clip/user deltas covered by regression tests

## Test Plan
- [x] python -m pytest -q tests/regression
- [x] ruff check . && ruff format --check .
- [x] mkdocs build --strict
- [x] python -m build && python -m twine check dist/*
- [x] live MQTT/FBNS via CONNECT tunnel: realtime connect/ping, Direct sync receive, Direct send over MQTT, FBNS register/ping