### PR TITLE
Sync Reel Facebook destination helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ starting with 1.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added `clip_share_to_fb_destination(...)` to normalize confirmed Reel Facebook destination fields without treating Account Center linking ids such as `account_id` as publish destinations.
+
+### Changed
+
+- Synced the recorded upstream baseline to `instagrapi` 2.8.14.
+
 ## [1.2.0] - 2026-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ What you can rely on instead:
 
 ### What's new in 1.0.0 and recent releases
 
-- **1.2.0 upstream sync** — synced with `instagrapi 2.8.13`, adding Direct media share to existing threads, clearer Direct message request privacy errors, private-first high-level user/media/story lookups, sessionid username recovery via private stream, and clearer Bloks redirect challenge handling.
+- **1.2.x upstream sync** — synced through `instagrapi 2.8.14`, adding Direct media share to existing threads, clearer Direct message request privacy errors, private-first high-level user/media/story lookups, sessionid username recovery via private stream, clearer Bloks redirect challenge handling, and `clip_share_to_fb_destination(...)` for confirmed Reel Facebook destinations.
 - **1.1.0 MQTT/FBNS sync** — synced with `instagrapi 2.8.2`, adding experimental async Realtime MQTT/MQTToT,
   Direct message sync, lightweight Direct MQTT actions, FBNS push token registration/callbacks, phone confirmation,
   followed hashtag helpers, feed-media share-to-story, opaque Bloks challenge context handling, and clearer Reel upload

--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -46,7 +46,7 @@ from aiograpi.mixins.video import DownloadVideoMixin, UploadVideoMixin
 # Used as fallback logger if another is not provided.
 DEFAULT_LOGGER = logging.getLogger("aiograpi")
 
-__upstream_instagrapi_version__ = "2.8.13"
+__upstream_instagrapi_version__ = "2.8.14"
 
 
 class Client(

--- a/aiograpi/mixins/clip.py
+++ b/aiograpi/mixins/clip.py
@@ -217,6 +217,103 @@ class UploadClipMixin(ClientMixin):
             params={"device_status": json.dumps(device_status)},
         )
 
+    async def clip_share_to_fb_destination(
+        self,
+        config: Optional[Dict[str, object]] = None,
+        destination_id: Optional[str] = None,
+        destination_type: Optional[str] = None,
+        destination_audience_type: Optional[str] = None,
+        validation_check_bypass: Optional[bool] = None,
+    ) -> Dict[str, object]:
+        """
+        Resolve the Facebook Reel sharing destination from confirmed fields.
+
+        This helper reads only destination-shaped fields that are known to map
+        to Reel configure payload fields. It intentionally does not treat
+        generic Account Center/linking identifiers such as ``account_id`` as
+        ``share_to_fb_destination_id``.
+
+        Parameters
+        ----------
+        config: Dict[str, object], optional
+            Facebook cross-posting config. When omitted, this calls
+            :meth:`clip_share_to_fb_config`.
+        destination_id: str, optional
+            Explicit Facebook destination id. Overrides config values.
+        destination_type: str, optional
+            Explicit Facebook destination type, ``USER`` or ``PAGE``.
+            Overrides config values.
+        destination_audience_type: str, optional
+            Explicit Facebook Reels audience type, e.g. ``PUBLIC``.
+        validation_check_bypass: bool, optional
+            Explicit validation bypass flag. Overrides config values.
+
+        Returns
+        -------
+        Dict[str, object]
+            Normalized destination fields.
+        """
+        fb_config = (config if config is not None else await self.clip_share_to_fb_config()) or {}
+        if fb_config.get("enabled") is False or fb_config.get("is_account_linked") is False:
+            raise ClientError("Facebook Reel sharing is not enabled or no Facebook account is linked")
+
+        destination_id = (
+            destination_id
+            or fb_config.get("share_to_fb_destination_id")
+            or fb_config.get("reels_destination_id")
+            or fb_config.get("destination_id")
+        )
+        destination_type = (
+            destination_type
+            or fb_config.get("share_to_fb_destination_type")
+            or fb_config.get("destination_type")
+            or fb_config.get("posting_type")
+        )
+        destination_audience_type = (
+            destination_audience_type
+            or fb_config.get("share_to_fb_destination_audience_type")
+            or fb_config.get("reels_destination_audience_type")
+            or fb_config.get("audience_type")
+        )
+        if validation_check_bypass is None:
+            validation_check_bypass = fb_config.get(
+                "reels_cross_app_share_fb_validation_check_bypass",
+                fb_config.get("cross_app_share_fb_validation_check_bypass"),
+            )
+
+        has_destination = bool(destination_id and destination_type)
+        if fb_config.get("share_to_fb_unavailable") and not has_destination:
+            raise ClientError(
+                "Facebook Reel sharing is unavailable from the Reel preflight response. "
+                "If the Instagram app can still cross-post manually, pass destination_id "
+                "and destination_type explicitly."
+            )
+        if not destination_id:
+            raise ClientError(
+                "Facebook Reel sharing configuration has no destination. "
+                "Link a Facebook account/page in the Instagram app or pass destination_id."
+            )
+        if not destination_type:
+            raise ClientError(
+                "Facebook Reel sharing configuration has no destination type. Pass destination_type as USER or PAGE."
+            )
+        destination_type = str(destination_type).upper()
+        if destination_type not in {"USER", "PAGE"}:
+            raise ClientError(
+                "Facebook Reel sharing destination type must be USER or PAGE. "
+                "Do not pass reels_cross_app_share_type here."
+            )
+
+        destination = {
+            "destination_id": str(destination_id),
+            "destination_type": destination_type,
+        }
+        if destination_audience_type:
+            destination["destination_audience_type"] = str(destination_audience_type)
+        if validation_check_bypass is not None:
+            destination["validation_check_bypass"] = bool(validation_check_bypass)
+        return destination
+
     async def clip_share_to_fb_extra_data(
         self,
         config: Optional[Dict[str, object]] = None,
@@ -259,81 +356,29 @@ class UploadClipMixin(ClientMixin):
         Dict
             Extra configure data for ``clip_upload(..., extra_data=...)``.
         """
-        fb_config = (config if config is not None else await self.clip_share_to_fb_config()) or {}
-        if fb_config.get("enabled") is False or fb_config.get("is_account_linked") is False:
-            raise ClientError("Facebook Reel sharing is not enabled or no Facebook account is linked")
-
-        destination_id_value = (
-            destination_id
-            or fb_config.get("share_to_fb_destination_id")
-            or fb_config.get("reels_destination_id")
-            or fb_config.get("destination_id")
-            or fb_config.get("account_id")
+        destination = await self.clip_share_to_fb_destination(
+            config=config,
+            destination_id=destination_id,
+            destination_type=destination_type,
+            destination_audience_type=destination_audience_type,
+            validation_check_bypass=validation_check_bypass,
         )
-        destination_id = str(destination_id_value) if destination_id_value is not None else None
-        destination_type_value = (
-            destination_type
-            or fb_config.get("share_to_fb_destination_type")
-            or fb_config.get("destination_type")
-            or fb_config.get("posting_type")
-        )
-        destination_type = str(destination_type_value) if destination_type_value is not None else None
-        destination_audience_type_value = (
-            destination_audience_type
-            or fb_config.get("share_to_fb_destination_audience_type")
-            or fb_config.get("reels_destination_audience_type")
-            or fb_config.get("audience_type")
-        )
-        destination_audience_type = (
-            str(destination_audience_type_value) if destination_audience_type_value is not None else None
-        )
-        if validation_check_bypass is None:
-            validation_check_bypass_value = fb_config.get(
-                "reels_cross_app_share_fb_validation_check_bypass",
-                fb_config.get("cross_app_share_fb_validation_check_bypass"),
-            )
-            validation_check_bypass = (
-                bool(validation_check_bypass_value) if validation_check_bypass_value is not None else None
-            )
-
-        has_destination = bool(destination_id and destination_type)
-        if fb_config.get("share_to_fb_unavailable") and not has_destination:
-            raise ClientError(
-                "Facebook Reel sharing is unavailable from the Reel preflight response. "
-                "If the Instagram app can still cross-post manually, pass destination_id "
-                "and destination_type explicitly."
-            )
-        if not destination_id:
-            raise ClientError(
-                "Facebook Reel sharing configuration has no destination. "
-                "Link a Facebook account/page in the Instagram app or pass destination_id."
-            )
-        if not destination_type:
-            raise ClientError(
-                "Facebook Reel sharing configuration has no destination type. Pass destination_type as USER or PAGE."
-            )
-        destination_type = str(destination_type).upper()
-        if destination_type not in {"USER", "PAGE"}:
-            raise ClientError(
-                "Facebook Reel sharing destination type must be USER or PAGE. "
-                "Do not pass reels_cross_app_share_type here."
-            )
         attempt_id = attempt_id or str(uuid4())
 
         data = {
             "share_to_facebook": "1",
             "is_reel_shared_to_fb": True,
             "share_to_facebook_reels": True,
-            "share_to_fb_destination_id": destination_id,
-            "share_to_fb_destination_type": destination_type,
+            "share_to_fb_destination_id": destination["destination_id"],
+            "share_to_fb_destination_type": destination["destination_type"],
             "xpost_surface": xpost_surface,
             "no_token_crosspost": "1",  # nosec B105
             "attempt_id": attempt_id,
         }
-        if destination_audience_type:
-            data["share_to_fb_destination_audience_type"] = destination_audience_type
-        if validation_check_bypass is not None:
-            data["cross_app_share_fb_validation_check_bypass"] = bool(validation_check_bypass)
+        if destination.get("destination_audience_type"):
+            data["share_to_fb_destination_audience_type"] = destination["destination_audience_type"]
+        if destination.get("validation_check_bypass") is not None:
+            data["cross_app_share_fb_validation_check_bypass"] = bool(destination["validation_check_bypass"])
         return data
 
     async def clip_upload(

--- a/aiograpi/mixins/clip.py
+++ b/aiograpi/mixins/clip.py
@@ -257,28 +257,36 @@ class UploadClipMixin(ClientMixin):
         if fb_config.get("enabled") is False or fb_config.get("is_account_linked") is False:
             raise ClientError("Facebook Reel sharing is not enabled or no Facebook account is linked")
 
-        destination_id = (
+        destination_id_value = (
             destination_id
             or fb_config.get("share_to_fb_destination_id")
             or fb_config.get("reels_destination_id")
             or fb_config.get("destination_id")
         )
-        destination_type = (
+        destination_id = str(destination_id_value) if destination_id_value is not None else None
+        destination_type_value = (
             destination_type
             or fb_config.get("share_to_fb_destination_type")
             or fb_config.get("destination_type")
             or fb_config.get("posting_type")
         )
-        destination_audience_type = (
+        destination_type = str(destination_type_value) if destination_type_value is not None else None
+        destination_audience_type_value = (
             destination_audience_type
             or fb_config.get("share_to_fb_destination_audience_type")
             or fb_config.get("reels_destination_audience_type")
             or fb_config.get("audience_type")
         )
+        destination_audience_type = (
+            str(destination_audience_type_value) if destination_audience_type_value is not None else None
+        )
         if validation_check_bypass is None:
-            validation_check_bypass = fb_config.get(
+            validation_check_bypass_value = fb_config.get(
                 "reels_cross_app_share_fb_validation_check_bypass",
                 fb_config.get("cross_app_share_fb_validation_check_bypass"),
+            )
+            validation_check_bypass = (
+                bool(validation_check_bypass_value) if validation_check_bypass_value is not None else None
             )
 
         has_destination = bool(destination_id and destination_type)
@@ -304,7 +312,7 @@ class UploadClipMixin(ClientMixin):
                 "Do not pass reels_cross_app_share_type here."
             )
 
-        destination = {
+        destination: Dict[str, object] = {
             "destination_id": str(destination_id),
             "destination_type": destination_type,
         }

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ For any other languages (e.g. C++, C#, F#, D, [Golang](https://github.com/subzer
 
 ### Realtime MQTT and Direct
 
-`aiograpi 1.2.0` includes the MQTT/FBNS helpers from 1.1.0 and syncs high-level Direct/user/media/story behavior through `instagrapi 2.8.13`. Realtime helpers can receive Direct message sync payloads,
+`aiograpi 1.2.x` includes the MQTT/FBNS helpers from 1.1.0 and syncs high-level Direct/user/media/story behavior plus Reel Facebook destination helpers through `instagrapi 2.8.14`. Realtime helpers can receive Direct message sync payloads,
 publish lightweight Direct actions over MQTT, and subscribe to FBNS push notifications.
 
 ```python

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -5,7 +5,7 @@
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.8.13
+instagrapi 2.8.14
 ```
 
 `aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback
@@ -19,7 +19,7 @@ Direct message sync and lightweight Direct MQTT actions, async FBNS push MQTT wi
 device-auth state, phone confirmation-code support, followed hashtag helpers, feed-media share-to-story, opaque Bloks
 challenge context handling, and clearer Reel/clip upload failure details.
 
-`aiograpi 1.2.0` continues the mirror through `instagrapi 2.8.13`. It adds Direct media share to existing threads, Direct message request privacy exceptions, private-first high-level user/media/story lookups for authenticated clients, sessionid username recovery via private profile stream, and clear manual handling for Bloks redirect checkpoints.
+`aiograpi 1.2.x` continues the mirror through `instagrapi 2.8.14`. It adds Direct media share to existing threads, Direct message request privacy exceptions, private-first high-level user/media/story lookups for authenticated clients, sessionid username recovery via private profile stream, clear manual handling for Bloks redirect checkpoints, and confirmed Reel Facebook destination normalization.
 
 ## Release policy
 
@@ -28,7 +28,7 @@ challenge context handling, and clearer Reel/clip upload failure details.
 - Mention the upstream range in GitHub, PyPI, and Telegram release notes.
 
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
-`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.0` records the follow-up high-level/private-first baseline through `instagrapi 2.8.13`.
+`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first and Reel Facebook destination baseline through `instagrapi 2.8.14`.
 
 ## Porting rules
 

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -289,6 +289,7 @@ Upload medias to your feed. Common arguments:
 | clip_info_for_creation()                                      | Dict    | Get Reel creation preflight configuration for the current user
 | clip_trial_eligible()                                         | bool    | Check whether Reel creation preflight reports Trial Reels enabled
 | clip_share_to_fb_config()                                      | Dict    | Get Reel Facebook sharing configuration for the current user
+| clip_share_to_fb_destination(config: Dict = None, destination_id: str = None, destination_type: str = None) | dict | Resolve confirmed Reel Facebook destination fields without treating Account Center linking ids as publish destinations
 | clip_share_to_fb_extra_data(config: Dict = None, destination_id: str = None, destination_type: str = None) | Dict | Build modern Reel Facebook cross-post configure fields for manual `extra_data`
 
 For video uploads in Android environments, pass `thumbnail=...` to avoid automatic thumbnail generation, or install the optional video dependencies, MoviePy `2.2.1`, and executable ffmpeg. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).
@@ -308,17 +309,9 @@ media = await cl.clip_upload(
 )
 ```
 
-Facebook Reel sharing requires a Facebook account/page linked in the Instagram app. Modern Android app builds no longer
-use only `{"share_to_facebook": 1}` for Reels; they also send destination and cross-posting fields such as
-`share_to_fb_destination_id`, `share_to_fb_destination_type`, `no_token_crosspost`, and `attempt_id`.
+Facebook Reel sharing requires a Facebook account/page linked in the Instagram app. Modern Android app builds no longer use only `{"share_to_facebook": 1}` for Reels; they also send destination and cross-posting fields such as `share_to_fb_destination_id`, `share_to_fb_destination_type`, `no_token_crosspost`, and `attempt_id`.
 
-`clip_share_to_fb_config()` calls the lightweight Reel sharing preflight endpoint. On recent app versions this response
-contains availability flags, not the full Account Center destination state, and some linked accounts can still return
-`share_to_fb_unavailable=True` even when the Instagram app can cross-post manually. For those accounts, pass
-`fb_destination_id` and `fb_destination_type="USER"` or `"PAGE"` to `clip_upload(...)`, or build `extra_data` manually
-with `clip_share_to_fb_extra_data(...)`. If neither the preflight/config data nor the caller provides a destination,
-aiograpi raises `ClientError` before uploading video bytes. The Reel cross-post `attempt_id` is generated automatically;
-only pass it to `clip_share_to_fb_extra_data(...)` when replaying or testing a specific low-level payload.
+`clip_share_to_fb_config()` calls the lightweight Reel sharing preflight endpoint. On recent app versions this response contains availability flags, not the full Account Center destination state, and some linked accounts can still return `share_to_fb_unavailable=True` even when the Instagram app can cross-post manually. Use `clip_share_to_fb_destination()` when a config or captured app response already contains confirmed destination fields; it normalizes `destination_id`, `destination_type`, optional audience, and validation bypass values. For accounts where the app can cross-post manually but the preflight response has no destination, pass `fb_destination_id` and `fb_destination_type="USER"` or `"PAGE"` to `clip_upload(...)`, or build `extra_data` manually with `clip_share_to_fb_extra_data(...)`. If neither the preflight/config data nor the caller provides a destination, aiograpi raises `ClientError` before uploading video bytes. The Reel cross-post `attempt_id` is generated automatically; only pass it to `clip_share_to_fb_extra_data(...)` when replaying or testing a specific low-level payload.
 `bloks_fxcal_link_reels_share()` exposes the raw Account Center Bloks link action seen on the Reel composer surface, but it starts an app linking flow and does not replace the interactive Facebook linking step in Instagram. Treat Account Center Bloks `fbid`, auth, and linking values as linking context, not as `fb_destination_id`; only use them as a Reel publish destination after verifying that the final Reel configure request sends the same value as `share_to_fb_destination_id`. See [subzeroid/instagrapi#2556](https://github.com/subzeroid/instagrapi/issues/2556) for tracking automatic destination discovery.
 
 ``` python

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -28,6 +28,7 @@ from aiograpi.exceptions import (
     ChallengeRequired,
     ChallengeUnknownStep,
     ClientConnectionError,
+    ClientError,
     ClientGraphqlError,
     ClientIncompleteReadError,
     ClientThrottledError,
@@ -2855,6 +2856,19 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, ClientPrivateTestCa
         finally:
             cleanup(path)
             self.assertTrue(await self.cl.media_delete(media.id))
+
+    async def test_clip_share_to_fb_destination_live(self):
+        config = await self.cl.clip_share_to_fb_config()
+        self.assertEqual(config.get("status"), "ok")
+        try:
+            destination = await self.cl.clip_share_to_fb_destination(config=config)
+        except ClientError as exc:
+            self.skipTest(f"No confirmed Facebook Reel destination available: {exc}")
+
+        self.assertTrue(destination["destination_id"])
+        self.assertIn(destination["destination_type"], {"USER", "PAGE"})
+        if destination.get("destination_audience_type"):
+            self.assertIsInstance(destination["destination_audience_type"], str)
 
     async def test_reel_upload_with_music(self):
         # media_type: 2 (video, not IGTV)

--- a/tests/regression/test_clip.py
+++ b/tests/regression/test_clip.py
@@ -131,6 +131,57 @@ class ClipUploadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         assert device_status["hw_av1_dec"] is False
         assert result == expected
 
+    async def test_clip_share_to_fb_destination_normalizes_current_reel_destination_fields(self):
+        client = _build_client()
+
+        result = await client.clip_share_to_fb_destination(
+            config={
+                "enabled": True,
+                "is_account_linked": True,
+                "share_to_fb_destination_id": "fb-destination-id",
+                "share_to_fb_destination_type": "page",
+                "share_to_fb_destination_audience_type": "PUBLIC",
+                "reels_cross_app_share_fb_validation_check_bypass": True,
+                "status": "ok",
+            }
+        )
+
+        assert result == {
+            "destination_id": "fb-destination-id",
+            "destination_type": "PAGE",
+            "destination_audience_type": "PUBLIC",
+            "validation_check_bypass": True,
+        }
+
+    async def test_clip_share_to_fb_destination_rejects_unavailable_config_without_destination(self):
+        client = _build_client()
+
+        with self.assertRaises(ClientError) as ctx:
+            await client.clip_share_to_fb_destination(
+                config={
+                    "share_to_fb_unavailable": True,
+                    "status": "ok",
+                }
+            )
+
+        assert "unavailable" in str(ctx.exception)
+
+    async def test_clip_share_to_fb_destination_does_not_use_account_id_as_destination(self):
+        client = _build_client()
+
+        with self.assertRaises(ClientError) as ctx:
+            await client.clip_share_to_fb_destination(
+                config={
+                    "enabled": True,
+                    "is_account_linked": True,
+                    "account_id": "account-center-or-linking-id",
+                    "posting_type": "USER",
+                    "status": "ok",
+                }
+            )
+
+        assert "no destination" in str(ctx.exception)
+
     async def test_clip_share_to_fb_extra_data_builds_current_reel_crosspost_payload(self):
         client = _build_client()
         config = {

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -2,4 +2,4 @@ import aiograpi
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.8.13"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.8.14"


### PR DESCRIPTION
## Summary
- Port `clip_share_to_fb_destination(...)` from `instagrapi` 2.8.14 as an async helper.
- Refactor `clip_share_to_fb_extra_data(...)` to use the normalized destination helper and stop treating generic Account Center `account_id` values as publish destinations.
- Update docs, changelog, upstream sync metadata, regression coverage, and a live discovery test.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_clip.py -q -k "clip_share_to_fb_destination"` (RED before implementation: missing helper)
- `.venv/bin/python -m pytest tests/regression/test_clip.py -q -k "clip_share_to_fb"`
- `.venv/bin/python -m pytest tests/regression/test_clip.py::ClipUploadRegressionTestCase::test_clip_upload_share_to_facebook_adds_crosspost_params_before_upload -q`
- `.venv/bin/python -m pytest tests/regression/test_clip.py -q`
- `.venv/bin/python -m pytest tests/legacy.py::ClienUploadTestCase::test_clip_share_to_fb_destination_live -q -rs` (skipped: current test pool has no confirmed Facebook Reel destination)
- `.venv/bin/python -m pytest tests/regression/test_clip.py tests/regression/test_upstream_sync.py -q`
- `.venv/bin/ruff check aiograpi/mixins/clip.py aiograpi/__init__.py tests/regression/test_clip.py tests/regression/test_upstream_sync.py tests/legacy.py`
- `.venv/bin/ruff format --check aiograpi/mixins/clip.py aiograpi/__init__.py tests/regression/test_clip.py tests/regression/test_upstream_sync.py tests/legacy.py`
- `.venv/bin/mkdocs build --strict`
- `.venv/bin/python -m build`
