### PR TITLE
Sync Reel Facebook unified config discovery

### DIFF
--- a/aiograpi/mixins/clip.py
+++ b/aiograpi/mixins/clip.py
@@ -28,6 +28,28 @@ def _make_tmp_path(suffix: str) -> str:
     return path
 
 
+CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_CLIENT_DOC_ID = "216179630714134719310007237117"
+CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_FRIENDLY_NAME = "CrosspostingUnifiedConfigsQuery"
+CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_ROOT_FIELD = "xcxp_unified_crossposting_configs_root"
+CLIP_FB_CROSSPOSTING_SURFACES = [
+    {
+        "source_surface": "STORY",
+        "destination_app": "FB",
+        "destination_surface": "STORY",
+    },
+    {
+        "source_surface": "FEED",
+        "destination_app": "FB",
+        "destination_surface": "FEED",
+    },
+    {
+        "source_surface": "REELS",
+        "destination_app": "FB",
+        "destination_surface": "REELS",
+    },
+]
+
+
 class ClipMixin(ClientMixin):
     """
     Helpers for CLIP/Reel actions
@@ -217,6 +239,115 @@ class UploadClipMixin(ClientMixin):
             params={"device_status": json.dumps(device_status)},
         )
 
+    async def clip_share_to_fb_unified_config(
+        self,
+        crosspost_app_surface_list: Optional[List[Dict[str, str]]] = None,
+    ) -> Dict:
+        """
+        Get the Android cross-posting unified config used by the Reel composer.
+
+        Returns
+        -------
+        Dict
+            A dictionary of response from the private GraphQL call
+        """
+        variables = {
+            "configs_request": {
+                "source_app": "IG",
+                "crosspost_app_surface_list": crosspost_app_surface_list or CLIP_FB_CROSSPOSTING_SURFACES,
+            }
+        }
+        return await self.private_graphql_query_request(
+            friendly_name=CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_FRIENDLY_NAME,
+            root_field_name=CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_ROOT_FIELD,
+            variables=variables,
+            client_doc_id=CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_CLIENT_DOC_ID,
+            priority="u=3, i",
+            extra_headers={"X-FB-RMD": "state=URL_ELIGIBLE"},
+        )
+
+    def _clip_share_to_fb_unified_root(self, config: Dict[str, object]) -> object:
+        data = (config or {}).get("data")
+        if isinstance(data, dict):
+            root = data.get(CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_ROOT_FIELD)
+            if root is not None:
+                return root
+            for key, value in data.items():
+                if CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_ROOT_FIELD in str(key):
+                    return value
+        return config or {}
+
+    def _clip_share_to_fb_iter_dicts(self, value):
+        if isinstance(value, dict):
+            yield value
+            for child in value.values():
+                yield from self._clip_share_to_fb_iter_dicts(child)
+        elif isinstance(value, list):
+            for child in value:
+                yield from self._clip_share_to_fb_iter_dicts(child)
+
+    def _clip_share_to_fb_candidate_value(self, config: Dict[str, object], keys) -> object:
+        for key in keys:
+            value = config.get(key)
+            if value not in (None, ""):
+                return value
+        return None
+
+    def _clip_share_to_fb_reels_fb_candidate(self, config: Dict[str, object]) -> bool:
+        source_surface = str(config.get("source_surface") or "").upper()
+        destination_surface = str(config.get("destination_surface") or "").upper()
+        destination_app = str(config.get("destination_app") or "").upper()
+        if source_surface and source_surface not in {"REELS", "CLIPS"}:
+            return False
+        if destination_surface and destination_surface not in {"REELS", "CLIPS"}:
+            return False
+        if destination_app and destination_app not in {"FB", "FACEBOOK"}:
+            return False
+        return bool(source_surface or destination_surface or destination_app)
+
+    def _clip_share_to_fb_unified_destination_candidates(self, config: Dict[str, object]):
+        for candidate in self._clip_share_to_fb_iter_dicts(self._clip_share_to_fb_unified_root(config)):
+            if not self._clip_share_to_fb_reels_fb_candidate(candidate):
+                continue
+            merged = dict(candidate)
+            for key in (
+                "destination",
+                "fb_destination",
+                "reels_destination",
+                "crosspost_destination",
+                "crossposting_destination",
+                "xpost_destination",
+            ):
+                nested = candidate.get(key)
+                if isinstance(nested, dict):
+                    merged.update(nested)
+            yield merged
+
+    async def clip_share_to_fb_unified_destination(
+        self,
+        config: Optional[Dict[str, object]] = None,
+    ) -> Dict[str, object]:
+        """
+        Resolve a confirmed Reel Facebook destination from unified config.
+
+        Parameters
+        ----------
+        config: Dict[str, object], optional
+            Response from :meth:`clip_share_to_fb_unified_config`.
+
+        Returns
+        -------
+        Dict[str, object]
+            Normalized destination fields.
+        """
+        unified_config = config if config is not None else await self.clip_share_to_fb_unified_config()
+        for candidate in self._clip_share_to_fb_unified_destination_candidates(unified_config or {}):
+            try:
+                return await self.clip_share_to_fb_destination(config=candidate, use_unified_config=False)
+            except ClientError:
+                continue
+        raise ClientError("Facebook Reel sharing unified config has no confirmed Reel Facebook destination")
+
     async def clip_share_to_fb_destination(
         self,
         config: Optional[Dict[str, object]] = None,
@@ -224,6 +355,7 @@ class UploadClipMixin(ClientMixin):
         destination_type: Optional[str] = None,
         destination_audience_type: Optional[str] = None,
         validation_check_bypass: Optional[bool] = None,
+        use_unified_config: bool = True,
     ) -> Dict[str, object]:
         """
         Resolve the Facebook Reel sharing destination from confirmed fields.
@@ -247,6 +379,9 @@ class UploadClipMixin(ClientMixin):
             Explicit Facebook Reels audience type, e.g. ``PUBLIC``.
         validation_check_bypass: bool, optional
             Explicit validation bypass flag. Overrides config values.
+        use_unified_config: bool, optional
+            When config is omitted, fall back to the Android cross-posting
+            unified config if the lightweight Reel preflight has no destination.
 
         Returns
         -------
@@ -257,25 +392,39 @@ class UploadClipMixin(ClientMixin):
         if fb_config.get("enabled") is False or fb_config.get("is_account_linked") is False:
             raise ClientError("Facebook Reel sharing is not enabled or no Facebook account is linked")
 
-        destination_id_value = (
-            destination_id
-            or fb_config.get("share_to_fb_destination_id")
-            or fb_config.get("reels_destination_id")
-            or fb_config.get("destination_id")
+        explicit_destination = bool(destination_id or destination_type)
+        destination_id_value = destination_id or self._clip_share_to_fb_candidate_value(
+            fb_config,
+            (
+                "share_to_fb_destination_id",
+                "reels_destination_id",
+                "crosspost_destination_id",
+                "crossposting_destination_id",
+                "xpost_destination_id",
+                "destination_id",
+            ),
         )
         destination_id = str(destination_id_value) if destination_id_value is not None else None
-        destination_type_value = (
-            destination_type
-            or fb_config.get("share_to_fb_destination_type")
-            or fb_config.get("destination_type")
-            or fb_config.get("posting_type")
+        destination_type_value = destination_type or self._clip_share_to_fb_candidate_value(
+            fb_config,
+            (
+                "share_to_fb_destination_type",
+                "crosspost_destination_type",
+                "crossposting_destination_type",
+                "xpost_destination_type",
+                "destination_type",
+                "posting_type",
+            ),
         )
         destination_type = str(destination_type_value) if destination_type_value is not None else None
-        destination_audience_type_value = (
-            destination_audience_type
-            or fb_config.get("share_to_fb_destination_audience_type")
-            or fb_config.get("reels_destination_audience_type")
-            or fb_config.get("audience_type")
+        destination_audience_type_value = destination_audience_type or self._clip_share_to_fb_candidate_value(
+            fb_config,
+            (
+                "share_to_fb_destination_audience_type",
+                "reels_destination_audience_type",
+                "destination_audience_type",
+                "audience_type",
+            ),
         )
         destination_audience_type = (
             str(destination_audience_type_value) if destination_audience_type_value is not None else None
@@ -290,6 +439,11 @@ class UploadClipMixin(ClientMixin):
             )
 
         has_destination = bool(destination_id and destination_type)
+        if not has_destination and use_unified_config and config is None and not explicit_destination:
+            try:
+                return await self.clip_share_to_fb_unified_destination()
+            except ClientError:
+                pass
         if fb_config.get("share_to_fb_unavailable") and not has_destination:
             raise ClientError(
                 "Facebook Reel sharing is unavailable from the Reel preflight response. "

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -289,6 +289,8 @@ Upload medias to your feed. Common arguments:
 | clip_info_for_creation()                                      | Dict    | Get Reel creation preflight configuration for the current user
 | clip_trial_eligible()                                         | bool    | Check whether Reel creation preflight reports Trial Reels enabled
 | clip_share_to_fb_config()                                      | Dict    | Get Reel Facebook sharing configuration for the current user
+| clip_share_to_fb_unified_config() | Dict | Get the Android cross-posting unified config used by the Reel composer
+| clip_share_to_fb_unified_destination(config: Dict = None) | dict | Resolve confirmed Reel Facebook destination fields from the unified cross-posting config
 | clip_share_to_fb_destination(config: Dict = None, destination_id: str = None, destination_type: str = None) | dict | Resolve confirmed Reel Facebook destination fields without treating Account Center linking ids as publish destinations
 | clip_share_to_fb_extra_data(config: Dict = None, destination_id: str = None, destination_type: str = None) | Dict | Build modern Reel Facebook cross-post configure fields for manual `extra_data`
 
@@ -311,13 +313,20 @@ media = await cl.clip_upload(
 
 Facebook Reel sharing requires a Facebook account/page linked in the Instagram app. Modern Android app builds no longer use only `{"share_to_facebook": 1}` for Reels; they also send destination and cross-posting fields such as `share_to_fb_destination_id`, `share_to_fb_destination_type`, `no_token_crosspost`, and `attempt_id`.
 
-`clip_share_to_fb_config()` calls the lightweight Reel sharing preflight endpoint. On recent app versions this response contains availability flags, not the full Account Center destination state, and some linked accounts can still return `share_to_fb_unavailable=True` even when the Instagram app can cross-post manually. Use `clip_share_to_fb_destination()` when a config or captured app response already contains confirmed destination fields; it normalizes `destination_id`, `destination_type`, optional audience, and validation bypass values. For accounts where the app can cross-post manually but the preflight response has no destination, pass `fb_destination_id` and `fb_destination_type="USER"` or `"PAGE"` to `clip_upload(...)`, or build `extra_data` manually with `clip_share_to_fb_extra_data(...)`. If neither the preflight/config data nor the caller provides a destination, aiograpi raises `ClientError` before uploading video bytes. The Reel cross-post `attempt_id` is generated automatically; only pass it to `clip_share_to_fb_extra_data(...)` when replaying or testing a specific low-level payload.
+`clip_share_to_fb_config()` calls the lightweight Reel sharing preflight endpoint. On recent app versions this response contains availability flags, not the full Account Center destination state, and some linked accounts can still return `share_to_fb_unavailable=True` even when the Instagram app can cross-post manually. When `clip_upload(..., share_to_facebook=True)` has no manual destination override, aiograpi now falls back to Android's `CrosspostingUnifiedConfigsQuery` via `clip_share_to_fb_unified_config()` and uses `clip_share_to_fb_unified_destination()` only if that response contains confirmed Reel-to-Facebook destination fields. Use `clip_share_to_fb_destination()` when a config or captured app response already contains confirmed destination fields; it normalizes `destination_id`, `destination_type`, optional audience, and validation bypass values. For accounts where the app can cross-post manually but automatic discovery still has no destination, pass `fb_destination_id` and `fb_destination_type="USER"` or `"PAGE"` to `clip_upload(...)`, or build `extra_data` manually with `clip_share_to_fb_extra_data(...)`. If neither the preflight/unified config data nor the caller provides a destination, aiograpi raises `ClientError` before uploading video bytes. The Reel cross-post `attempt_id` is generated automatically; only pass it to `clip_share_to_fb_extra_data(...)` when replaying or testing a specific low-level payload.
 `bloks_fxcal_link_reels_share()` exposes the raw Account Center Bloks link action seen on the Reel composer surface, but it starts an app linking flow and does not replace the interactive Facebook linking step in Instagram. Treat Account Center Bloks `fbid`, auth, and linking values as linking context, not as `fb_destination_id`; only use them as a Reel publish destination after verifying that the final Reel configure request sends the same value as `share_to_fb_destination_id`. See [subzeroid/instagrapi#2556](https://github.com/subzeroid/instagrapi/issues/2556) for tracking automatic destination discovery.
 
 ``` python
 media = await cl.clip_upload(
     Path("reel.mp4"),
     "Cross-posting this Reel to Facebook",
+    thumbnail=Path("reel-thumb.jpg"),
+    share_to_facebook=True,
+)
+
+media = await cl.clip_upload(
+    Path("reel.mp4"),
+    "Cross-posting with explicit Facebook destination",
     thumbnail=Path("reel-thumb.jpg"),
     share_to_facebook=True,
     fb_destination_id="FACEBOOK_DESTINATION_ID",

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -2870,6 +2870,34 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, ClientPrivateTestCa
         if destination.get("destination_audience_type"):
             self.assertIsInstance(destination["destination_audience_type"], str)
 
+    async def test_clip_share_to_fb_unified_config_live(self):
+        config = await self.cl.clip_share_to_fb_unified_config()
+
+        self.assertEqual(config.get("status"), "ok")
+        self.assertIsInstance(config.get("data"), dict)
+
+    async def test_clip_upload_share_to_facebook_live(self):
+        try:
+            destination = await self.cl.clip_share_to_fb_destination()
+        except ClientError as exc:
+            self.skipTest(f"No confirmed Facebook Reel destination available: {exc}")
+
+        self.assertTrue(destination["destination_id"])
+        self.assertIn(destination["destination_type"], {"USER", "PAGE"})
+        media_pk = await self.cl.media_pk_from_url("https://www.instagram.com/p/CEjXskWJ1on/")
+        path = await self.cl.clip_download(media_pk)
+        media = None
+        self.assertIsInstance(path, Path)
+        try:
+            caption_text = "Facebook Reel crosspost live test"
+            media = await self.cl.clip_upload(path, caption_text, share_to_facebook=True)
+            self.assertIsInstance(media, Media)
+            await self.assertUploadedMediaAccessible(media, media_type=2, caption_text=caption_text)
+        finally:
+            cleanup(path)
+            if media:
+                self.assertTrue(await self.cl.media_delete(media.id))
+
     async def test_reel_upload_with_music(self):
         # media_type: 2 (video, not IGTV)
         # product_type: reels

--- a/tests/regression/test_clip.py
+++ b/tests/regression/test_clip.py
@@ -131,6 +131,44 @@ class ClipUploadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         assert device_status["hw_av1_dec"] is False
         assert result == expected
 
+    async def test_clip_share_to_fb_unified_config_requests_android_cxp_query(self):
+        client = _build_client()
+        expected = {"status": "ok", "data": {"xcxp_unified_crossposting_configs_root": {}}}
+        client.private_graphql_query_request = AsyncMock(return_value=expected)
+
+        result = await client.clip_share_to_fb_unified_config()
+
+        client.private_graphql_query_request.assert_awaited_once()
+        kwargs = client.private_graphql_query_request.call_args.kwargs
+        assert kwargs["friendly_name"] == "CrosspostingUnifiedConfigsQuery"
+        assert kwargs["root_field_name"] == "xcxp_unified_crossposting_configs_root"
+        assert kwargs["client_doc_id"] == "216179630714134719310007237117"
+        assert kwargs["priority"] == "u=3, i"
+        assert kwargs["extra_headers"] == {"X-FB-RMD": "state=URL_ELIGIBLE"}
+        assert kwargs["variables"] == {
+            "configs_request": {
+                "source_app": "IG",
+                "crosspost_app_surface_list": [
+                    {
+                        "source_surface": "STORY",
+                        "destination_app": "FB",
+                        "destination_surface": "STORY",
+                    },
+                    {
+                        "source_surface": "FEED",
+                        "destination_app": "FB",
+                        "destination_surface": "FEED",
+                    },
+                    {
+                        "source_surface": "REELS",
+                        "destination_app": "FB",
+                        "destination_surface": "REELS",
+                    },
+                ],
+            }
+        }
+        assert result == expected
+
     async def test_clip_share_to_fb_destination_normalizes_current_reel_destination_fields(self):
         client = _build_client()
 
@@ -181,6 +219,77 @@ class ClipUploadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             )
 
         assert "no destination" in str(ctx.exception)
+
+    async def test_clip_share_to_fb_destination_falls_back_to_unified_reels_fb_destination(self):
+        client = _build_client()
+        unified_config = {
+            "data": {
+                "1$xcxp_unified_crossposting_configs_root(configs_request:$configs_request)": {
+                    "configs": [
+                        {
+                            "source_surface": "FEED",
+                            "destination_app": "FB",
+                            "destination_surface": "FEED",
+                            "destination": {
+                                "destination_id": "feed-destination-id",
+                                "destination_type": "USER",
+                            },
+                        },
+                        {
+                            "source_surface": "REELS",
+                            "destination_app": "FB",
+                            "destination_surface": "REELS",
+                            "destination": {
+                                "destination_id": "reels-destination-id",
+                                "destination_type": "page",
+                                "destination_audience_type": "PUBLIC",
+                            },
+                            "cross_app_share_fb_validation_check_bypass": True,
+                        },
+                    ]
+                }
+            },
+            "status": "ok",
+        }
+        client.clip_share_to_fb_config = AsyncMock(return_value={"share_to_fb_unavailable": True, "status": "ok"})
+        client.clip_share_to_fb_unified_config = AsyncMock(return_value=unified_config)
+
+        result = await client.clip_share_to_fb_destination()
+
+        client.clip_share_to_fb_config.assert_awaited_once()
+        client.clip_share_to_fb_unified_config.assert_awaited_once()
+        assert result == {
+            "destination_id": "reels-destination-id",
+            "destination_type": "PAGE",
+            "destination_audience_type": "PUBLIC",
+            "validation_check_bypass": True,
+        }
+
+    async def test_clip_share_to_fb_unified_destination_ignores_generic_account_center_ids(self):
+        client = _build_client()
+
+        with self.assertRaises(ClientError) as ctx:
+            await client.clip_share_to_fb_unified_destination(
+                config={
+                    "data": {
+                        "xcxp_unified_crossposting_configs_root": {
+                            "configs": [
+                                {
+                                    "source_surface": "REELS",
+                                    "destination_app": "FB",
+                                    "destination_surface": "REELS",
+                                    "account_id": "account-center-id",
+                                    "fbid": "facebook-linking-id",
+                                    "posting_type": "USER",
+                                }
+                            ]
+                        }
+                    },
+                    "status": "ok",
+                }
+            )
+
+        assert "no confirmed Reel Facebook destination" in str(ctx.exception)
 
     async def test_clip_share_to_fb_extra_data_builds_current_reel_crosspost_payload(self):
         client = _build_client()


### PR DESCRIPTION
## Summary
- mirror instagrapi Reel Facebook unified config discovery helpers in async form
- add conservative fallback from `clip_share_to_fb_destination()` to Android `CrosspostingUnifiedConfigsQuery` when the lightweight Reel preflight has no confirmed destination
- keep manual `fb_destination_id` / `fb_destination_type` overrides and continue ignoring generic Account Center linking ids as publish destinations
- update async docs and regression/live coverage

## Tests
- `.venv/bin/python -m pytest tests/regression/test_clip.py::ClipUploadRegressionTestCase::test_clip_share_to_fb_unified_config_requests_android_cxp_query tests/regression/test_clip.py::ClipUploadRegressionTestCase::test_clip_share_to_fb_destination_falls_back_to_unified_reels_fb_destination tests/regression/test_clip.py::ClipUploadRegressionTestCase::test_clip_share_to_fb_unified_destination_ignores_generic_account_center_ids -q`
- `.venv/bin/python -m pytest tests/regression/test_clip.py::ClipUploadRegressionTestCase -q`
- `.venv/bin/python -m ruff check aiograpi/mixins/clip.py tests/regression/test_clip.py tests/legacy.py`
- `PATH="$PWD/.venv/bin:$PATH" mkdocs build --strict`
- `.venv/bin/python -m pytest tests/legacy.py::ClienUploadTestCase::test_clip_share_to_fb_unified_config_live tests/legacy.py::ClienUploadTestCase::test_clip_upload_share_to_facebook_live -q -s` (unified config passed; upload cross-post skipped because the current fresh account pool has no confirmed Facebook Reel destination)

Mirror of subzeroid/instagrapi#2599.
Refs subzeroid/instagrapi#2556