### PR TITLE
Sync instagrapi 2.8.18 fixes

### DIFF
--- a/aiograpi/extractors.py
+++ b/aiograpi/extractors.py
@@ -241,6 +241,8 @@ def extract_user_v1(data):
     """For Private API"""
     data["broadcast_channel"] = extract_broadcast_channel(data)
     data["external_url"] = data.get("external_url") or None
+    data["public_email"] = data.get("public_email") or data.get("business_email")
+    data["contact_phone_number"] = data.get("contact_phone_number") or data.get("business_phone_number")
     versions = data.get("hd_profile_pic_versions")
     pic_hd = versions[-1] if versions else data.get("hd_profile_pic_url_info", {})
     data["profile_pic_url_hd"] = pic_hd.get("url")

--- a/aiograpi/mixins/hashtag.py
+++ b/aiograpi/mixins/hashtag.py
@@ -138,6 +138,7 @@ class HashtagMixin(ClientMixin):
             "recent": "top_recent_posts",
         }
         data = {
+            "tab": tab_key,
             "media_recency_filter": media_recency_filter.get(tab_key, tab_key),
             # "page": 1,
             "_uuid": self.uuid,

--- a/tests/regression/test_fbsearch.py
+++ b/tests/regression/test_fbsearch.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import AsyncMock
+
+from aiograpi import Client
+
+
+class FbSearchRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    def _build_client(self):
+        client = Client()
+        client.__dict__["timezone_offset"] = 10800
+        return client
+
+    async def test_search_hashtags_accepts_numeric_private_id(self):
+        client = self._build_client()
+        client.private_request = AsyncMock(
+            return_value={
+                "results": [
+                    {
+                        "id": 17843915557058484,
+                        "name": "restaurant",
+                        "media_count": 65043150,
+                        "profile_pic_url": None,
+                    }
+                ]
+            }
+        )
+
+        hashtags = await client.search_hashtags("restaurant")
+
+        self.assertEqual(hashtags[0].id, "17843915557058484")
+        self.assertEqual(hashtags[0].name, "restaurant")
+        self.assertEqual(hashtags[0].media_count, 65043150)

--- a/tests/regression/test_hashtag.py
+++ b/tests/regression/test_hashtag.py
@@ -46,6 +46,16 @@ class HashtagRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         with self.assertRaisesRegex(ValueError, "Hashtag name cannot be empty"):
             await client.hashtag_medias_recent("#")
 
+    async def test_hashtag_medias_v1_chunk_sends_tab_key(self):
+        client = Client()
+        client.private_request = AsyncMock(return_value={"sections": [], "more_available": False, "next_max_id": None})
+
+        await client.hashtag_medias_v1_chunk("pizza", tab_key="recent")
+
+        request_data = client.private_request.call_args.kwargs["data"]
+        self.assertEqual(request_data["tab"], "recent")
+        self.assertEqual(request_data["media_recency_filter"], "top_recent_posts")
+
     async def test_hashtag_following_fetches_current_account_hashtags(self):
         client = Client()
         client.authorization_data = {"ds_user_id": "123"}

--- a/tests/regression/test_story_configure.py
+++ b/tests/regression/test_story_configure.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock
 
 from aiograpi import Client
-from aiograpi.types import Location, StoryLocation
+from aiograpi.types import Hashtag, Location, StoryHashtag, StoryLink, StoryLocation, StoryMention, UserShort
 
 
 def _build_client():
@@ -46,6 +46,32 @@ def _assert_story_location_model(data):
 
 
 class StoryConfigureRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_photo_story_sticker_ids_include_all_stickers(self):
+        client = _build_client()
+        client.private_request = AsyncMock(side_effect=[{"status": "ok"}, {"status": "ok"}])
+
+        await client.photo_configure_to_story(
+            upload_id="1",
+            width=720,
+            height=1280,
+            caption="",
+            links=[StoryLink(webUri="https://example.com")],
+            hashtags=[
+                StoryHashtag(
+                    hashtag=Hashtag(id="1", name="example"),
+                    x=0.2,
+                    y=0.3,
+                    width=0.5,
+                    height=0.2,
+                )
+            ],
+        )
+
+        validate_args, _ = client.private_request.call_args_list[0]
+        assert validate_args[1]["url"] == "https://example.com/"
+        configure_args, _ = client.private_request.call_args_list[1]
+        assert configure_args[1]["story_sticker_ids"] == "hashtag_sticker,link_sticker_default"
+
     async def test_photo_story_location_uses_external_location_id_tap_model(self):
         client = _build_client()
         location = _build_location()
@@ -71,6 +97,32 @@ class StoryConfigureRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         endpoint, data = client.private_request.call_args.args
         assert endpoint == "media/configure_to_story/"
         _assert_story_location_model(data)
+
+    async def test_photo_story_interactive_metadata_builds_tap_models(self):
+        client = _build_client()
+        location = _build_location()
+        user = UserShort(pk="2", username="artist", full_name="Artist", profile_pic_url=None)
+        hashtag = Hashtag(id="1", name="event")
+        client.location_complete = AsyncMock(return_value=location)
+        client.private_request = AsyncMock(side_effect=[{"status": "ok"}, {"status": "ok"}])
+
+        await client.photo_configure_to_story(
+            upload_id="1",
+            width=720,
+            height=1280,
+            caption="",
+            mentions=[StoryMention(user=user, x=0.2, y=0.3, width=0.4, height=0.1)],
+            links=[StoryLink(webUri="https://example.com")],
+            hashtags=[StoryHashtag(hashtag=hashtag, x=0.3, y=0.4, width=0.4, height=0.1)],
+            locations=[StoryLocation(location=location, x=0.4, y=0.5, width=0.4, height=0.1)],
+        )
+
+        configure_args, _ = client.private_request.call_args_list[1]
+        data = configure_args[1]
+        tap_models = json.loads(data["tap_models"])
+        assert [model["type"] for model in tap_models] == ["mention", "hashtag", "location", "story_link"]
+        assert data["story_sticker_ids"] == "hashtag_sticker,location_sticker,link_sticker_default"
+        assert "reel_mentions" in data
 
     async def test_video_story_location_uses_external_location_id_tap_model(self):
         client = _build_client()

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock
 
 from aiograpi import Client
 from aiograpi.exceptions import ClientError, ClientGraphqlError, ClientJSONDecodeError, UserNotFound
+from aiograpi.extractors import extract_user_v1
 from aiograpi.mixins.user import UserMixin
 
 
@@ -188,6 +189,28 @@ class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(user.username, "example")
         client.private_request.assert_awaited_once_with("users/example/usernameinfo/")
+
+    async def test_extract_user_v1_maps_business_contact_fields(self):
+        user = extract_user_v1(
+            {
+                "pk": "123",
+                "username": "business",
+                "full_name": "Business",
+                "is_private": False,
+                "profile_pic_url": "https://example.com/pic.jpg",
+                "is_verified": False,
+                "media_count": 0,
+                "follower_count": 0,
+                "following_count": 0,
+                "is_business": True,
+                "business_email": "public@example.com",
+                "business_phone_number": "+15551234567",
+                "external_url": "",
+            }
+        )
+
+        self.assertEqual(user.public_email, "public@example.com")
+        self.assertEqual(user.contact_phone_number, "+15551234567")
 
     async def test_user_info_by_username_v2_gql_normalizes_search_query(self):
         client = Client()


### PR DESCRIPTION
## Summary
- mirror private business contact field extraction from instagrapi 2.8.18
- send the hashtag sections `tab` key for private hashtag media pagination
- add regression coverage for numeric hashtag IDs and story interactive metadata parity

## Tests
- `.venv/bin/python -m pytest tests/regression -q`
- `.venv/bin/python -m ruff format --check aiograpi/extractors.py aiograpi/mixins/hashtag.py tests/regression/test_hashtag.py tests/regression/test_user.py tests/regression/test_fbsearch.py tests/regression/test_story_configure.py`
- `.venv/bin/python -m ruff check aiograpi/extractors.py aiograpi/mixins/hashtag.py tests/regression/test_hashtag.py tests/regression/test_user.py tests/regression/test_fbsearch.py tests/regression/test_story_configure.py`
- `.venv/bin/python tests/live/smoke.py` (ALL REQUIRED PASS; optional public/web GraphQL checks hit expected IG 429/HTML responses)