### PR TITLE
Sync instagrapi 2.8.19 incomplete read retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ starting with 1.0.0.
 
 ### Changed
 
-- Synced the recorded upstream baseline to `instagrapi` 2.8.14.
+- Private mobile requests now retry one incomplete-read transport failure once after a short delay.
+- Synced the recorded upstream baseline to `instagrapi` 2.8.19.
 
 ## [1.2.0] - 2026-06-06
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ What you can rely on instead:
 
 ### What's new in 1.0.0 and recent releases
 
-- **1.2.x upstream sync** — synced through `instagrapi 2.8.14`, adding Direct media share to existing threads, clearer Direct message request privacy errors, private-first high-level user/media/story lookups, sessionid username recovery via private stream, clearer Bloks redirect challenge handling, and `clip_share_to_fb_destination(...)` for confirmed Reel Facebook destinations.
+- **1.2.x upstream sync** — synced through `instagrapi 2.8.19`, adding Direct media share to existing threads, clearer Direct message request privacy errors, private-first high-level user/media/story lookups, sessionid username recovery via private stream, clearer Bloks redirect challenge handling, `clip_share_to_fb_destination(...)` for confirmed Reel Facebook destinations, hashtag private section fixes, private business contact field mapping, story metadata extraction, and private incomplete-read retry handling.
 - **1.1.0 MQTT/FBNS sync** — synced with `instagrapi 2.8.2`, adding experimental async Realtime MQTT/MQTToT,
   Direct message sync, lightweight Direct MQTT actions, FBNS push token registration/callbacks, phone confirmation,
   followed hashtag helpers, feed-media share-to-story, opaque Bloks challenge context handling, and clearer Reel upload

--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -46,7 +46,7 @@ from aiograpi.mixins.video import DownloadVideoMixin, UploadVideoMixin
 # Used as fallback logger if another is not provided.
 DEFAULT_LOGGER = logging.getLogger("aiograpi")
 
-__upstream_instagrapi_version__ = "2.8.14"
+__upstream_instagrapi_version__ = "2.8.19"
 
 
 class Client(

--- a/aiograpi/mixins/private.py
+++ b/aiograpi/mixins/private.py
@@ -16,6 +16,7 @@ from aiograpi.exceptions import (
     ClientConnectionError,
     ClientErrorWithTitle,
     ClientForbiddenError,
+    ClientIncompleteReadError,
     ClientJSONDecodeError,
     ClientNotFoundError,
     ClientRequestTimeout,
@@ -498,6 +499,8 @@ class PrivateRequestMixin(ClientMixin):
                 endpoint,
             )
             raise AuthRequiredProxyError(e, response=self.last_response)
+        except httpx_ext.RemoteProtocolError as e:
+            raise ClientIncompleteReadError("{} {}".format(e.__class__.__name__, str(e))) from e
         except (httpx_ext.HTTPStatusError, httpx_ext.HTTPError) as e:
             response = self.last_response
             try:
@@ -715,6 +718,10 @@ class PrivateRequestMixin(ClientMixin):
         except ClientRequestTimeout:
             self.logger.info("Wait 60 seconds and try one more time (ClientRequestTimeout)")
             await asyncio.sleep(60)
+            return await self._send_private_request(endpoint, **kwargs)
+        except ClientIncompleteReadError:
+            self.logger.info("Wait 2 seconds and try one more time (ClientIncompleteReadError)")
+            await asyncio.sleep(2)
             return await self._send_private_request(endpoint, **kwargs)
         # except BadPassword as e:
         #     raise e

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -5,7 +5,7 @@
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.8.14
+instagrapi 2.8.19
 ```
 
 `aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback
@@ -19,7 +19,7 @@ Direct message sync and lightweight Direct MQTT actions, async FBNS push MQTT wi
 device-auth state, phone confirmation-code support, followed hashtag helpers, feed-media share-to-story, opaque Bloks
 challenge context handling, and clearer Reel/clip upload failure details.
 
-`aiograpi 1.2.x` continues the mirror through `instagrapi 2.8.14`. It adds Direct media share to existing threads, Direct message request privacy exceptions, private-first high-level user/media/story lookups for authenticated clients, sessionid username recovery via private profile stream, clear manual handling for Bloks redirect checkpoints, and confirmed Reel Facebook destination normalization.
+`aiograpi 1.2.x` continues the mirror through `instagrapi 2.8.19`. It adds Direct media share to existing threads, Direct message request privacy exceptions, private-first high-level user/media/story lookups for authenticated clients, sessionid username recovery via private profile stream, clear manual handling for Bloks redirect checkpoints, confirmed Reel Facebook destination normalization, hashtag private section fixes, private business contact field mapping, story metadata extraction, and private incomplete-read retry handling.
 
 ## Release policy
 
@@ -28,7 +28,7 @@ challenge context handling, and clearer Reel/clip upload failure details.
 - Mention the upstream range in GitHub, PyPI, and Telegram release notes.
 
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
-`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first and Reel Facebook destination baseline through `instagrapi 2.8.14`.
+`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`.
 
 ## Porting rules
 

--- a/tests/regression/test_private.py
+++ b/tests/regression/test_private.py
@@ -50,6 +50,26 @@ class PrivateRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(cm.exception.message, payload["message"])
         self.assertEqual(cm.exception.status, "fail")
 
+    async def test_private_request_retries_remote_protocol_error_once(self):
+        client = self._build_client()
+        client._user_id = "123"
+        response = self._response({"status": "ok"})
+        client.private.post = AsyncMock(
+            side_effect=[
+                httpx_ext.RemoteProtocolError(
+                    "peer closed connection without sending complete message body (received 207264 bytes, expected 375848)"
+                ),
+                response,
+            ]
+        )
+
+        with unittest.mock.patch("aiograpi.mixins.private.asyncio.sleep", new_callable=AsyncMock) as sleep:
+            result = await client.private_request("test/", data={"_uuid": client.uuid}, with_signature=False)
+
+        self.assertEqual(result, {"status": "ok"})
+        self.assertEqual(client.private.post.await_count, 2)
+        self.assertEqual(sleep.await_args_list.count(unittest.mock.call(2)), 1)
+
     async def test_send_private_request_promotes_direct_message_requests_disabled_status_fail(self):
         client = self._build_client()
         payload = {

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -2,4 +2,4 @@ import aiograpi
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.8.14"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.8.19"


### PR DESCRIPTION
## Summary\n- mirror instagrapi 2.8.19 private incomplete-read retry handling for async private requests\n- update recorded upstream baseline to instagrapi 2.8.19\n- document the 1.2.x sync range in README, changelog, and upstream sync docs\n\n## Tests\n- .venv/bin/python -m pytest tests/regression/test_private.py::PrivateRequestRegressionTestCase::test_private_request_retries_remote_protocol_error_once (RED before fix)\n- .venv/bin/python -m pytest tests/regression/test_private.py tests/regression/test_upstream_sync.py\n- .venv/bin/python -m pytest tests/regression\n- .venv/bin/ruff format --check aiograpi/mixins/private.py tests/regression/test_private.py aiograpi/__init__.py tests/regression/test_upstream_sync.py\n- .venv/bin/ruff check aiograpi/mixins/private.py tests/regression/test_private.py aiograpi/__init__.py tests/regression/test_upstream_sync.py\n- .venv/bin/mkdocs build --strict --site-dir /tmp/aiograpi-site-sync-2.8.19