### PR TITLE
Mirror legacy signup warning

### DIFF
--- a/aiograpi/mixins/signup.py
+++ b/aiograpi/mixins/signup.py
@@ -3,6 +3,7 @@ import base64
 import random
 import secrets
 import time
+import warnings
 from typing import Optional
 from urllib.parse import urlsplit
 from uuid import uuid4
@@ -25,6 +26,10 @@ from aiograpi.mixins.challenge import ChallengeChoice
 from aiograpi.types import UserShort
 
 CHOICE_EMAIL = 1
+LEGACY_SIGNUP_WARNING = (
+    "signup() uses Instagram's legacy account-create flow and should be treated as experimental. "
+    "Modern Instagram signup often requires additional official-app device trust checks that aiograpi does not currently generate."
+)
 
 
 class SignUpMixin(ClientMixin):
@@ -65,6 +70,7 @@ class SignUpMixin(ClientMixin):
     ) -> UserShort:
         if not (email or phone_number):
             raise ClientError("Use email or phone_number for signup")
+        warnings.warn(LEGACY_SIGNUP_WARNING, RuntimeWarning, stacklevel=2)
         await self.get_signup_config()
         kwargs = {
             "username": username,

--- a/docs/usage-guide/challenge_resolver.md
+++ b/docs/usage-guide/challenge_resolver.md
@@ -46,7 +46,7 @@ Signup SMS challenges use the `phone_number` passed to `signup(...)` and call `c
 
 Phone-only signup is supported with `await cl.signup(username, password, email="", phone_number="+15551234567")`. If both `email` and `phone_number` are provided, aiograpi keeps the email signup flow and uses the phone number only for signup challenges.
 
-`signup(...)` uses Instagram's legacy account-create flow. On modern Instagram app versions this flow is often rejected with `SignupSpamError` / `feedback_required` because the official app uses additional signup checks that aiograpi does not currently generate. Treat this as a platform rejection, not as a malformed SMS/email code.
+`signup(...)` emits a `RuntimeWarning` because it uses Instagram's legacy account-create flow and should be treated as experimental. On modern Instagram app versions this flow is often rejected with `SignupSpamError` / `feedback_required` because the official app uses additional signup checks that aiograpi does not currently generate. Treat this as a platform rejection, not as a malformed SMS/email code.
 
 Bloks redirect checkpoints such as `bloks_action="com.bloks.www.ig.challenge.redirect.async"` or placeholder `step_name="STEP_NAME"` require manual confirmation in the official Instagram app or web flow on a trusted device; aiograpi raises `ChallengeRequired` with the sanitized challenge context instead of treating this as a legacy step.
 

--- a/tests/regression/test_signup.py
+++ b/tests/regression/test_signup.py
@@ -44,16 +44,17 @@ class SignupHelperRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.last_response = Mock(headers={"ig-set-authorization": ""})
 
         with unittest.mock.patch("aiograpi.mixins.signup.extract_user_short", return_value="created-user"):
-            result = await client.signup(
-                username="example",
-                password="password",
-                email="",
-                phone_number="+15551234567",
-                full_name="Example User",
-                year=2000,
-                month=5,
-                day=12,
-            )
+            with self.assertWarnsRegex(RuntimeWarning, "legacy account-create flow"):
+                result = await client.signup(
+                    username="example",
+                    password="password",
+                    email="",
+                    phone_number="+15551234567",
+                    full_name="Example User",
+                    year=2000,
+                    month=5,
+                    day=12,
+                )
 
         self.assertEqual(result, "created-user")
         client.check_email.assert_not_awaited()
@@ -70,6 +71,28 @@ class SignupHelperRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             phone_number="+15551234567",
             phone_code="123456",
         )
+
+    async def test_signup_warns_about_legacy_flow(self):
+        client = Client()
+        client.wait_seconds = 0
+        client.get_signup_config = AsyncMock(return_value={})
+        client.check_phone_number = AsyncMock(return_value={"status": "ok"})
+        client.send_signup_sms_code = AsyncMock(return_value={"status": "ok"})
+        client.challenge_code_handler = AsyncMock(return_value="123456")
+        client.accounts_create = AsyncMock(return_value={"created_user": {"pk": "1", "username": "example"}})
+        client.parse_authorization = Mock(return_value={})
+        client.last_response = Mock(headers={"ig-set-authorization": ""})
+
+        with unittest.mock.patch("aiograpi.mixins.signup.extract_user_short", return_value="created-user"):
+            with self.assertWarnsRegex(RuntimeWarning, "legacy account-create flow"):
+                result = await client.signup(
+                    username="example",
+                    password="password",
+                    email="",
+                    phone_number="+15551234567",
+                )
+
+        self.assertEqual(result, "created-user")
 
     async def test_accounts_create_primary_signup_omits_secondary_account_flag(self):
         client = Client()
@@ -326,12 +349,13 @@ class SignupHelperRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.last_response = Mock(headers={"ig-set-authorization": ""})
 
         with unittest.mock.patch("aiograpi.mixins.signup.extract_user_short", return_value="created-user"):
-            result = await client.signup(
-                "example",
-                "password",
-                "example@example.com",
-                "+15551234567",
-            )
+            with self.assertWarnsRegex(RuntimeWarning, "legacy account-create flow"):
+                result = await client.signup(
+                    "example",
+                    "password",
+                    "example@example.com",
+                    "+15551234567",
+                )
 
         self.assertEqual(result, "created-user")
         client.check_phone_number.assert_not_awaited()


### PR DESCRIPTION
## Summary

- mirror instagrapi 2.8.21 legacy signup warning in async `Client.signup()`
- document that signup/register remains experimental and often rejected by modern Instagram trust checks
- update signup regression coverage to assert the warning on mocked successful flows

## Tests

- `PYTHONPATH=$PWD .venv/bin/python -m pytest -q tests/regression/test_signup.py tests/live/test_signup_live.py -rs`
- `.venv/bin/ruff check aiograpi/mixins/signup.py tests/regression/test_signup.py docs/usage-guide/challenge_resolver.md`

Live signup result: skipped locally because no disposable signup email/SMS environment was configured.
