### PR TITLE
Mirror user_suggested_profiles helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [Unreleased]
+
+### Added
+
+- Added async `user_suggested_profiles(user_id, expand_suggestion=False)` as a convenience wrapper over `chaining(...)` and `fetch_suggestion_details(...)`.
+
+### Changed
+
+- Synced the recorded upstream baseline to `instagrapi` 2.9.1.
+
 ## [1.3.0] - 2026-06-10
 
 ### Added

--- a/aiograpi/mixins/user.py
+++ b/aiograpi/mixins/user.py
@@ -2400,6 +2400,46 @@ class UserMixin(ClientMixin):
             params=params,
         )
 
+    async def user_suggested_profiles(self, user_id: str, expand_suggestion: bool = False) -> dict:
+        """Get suggested profiles ("Suggested for you") for a target user_id.
+
+        Convenience wrapper over :meth:`chaining` and
+        :meth:`fetch_suggestion_details`. By default it returns the raw
+        ``chaining`` payload; with ``expand_suggestion=True`` it feeds the
+        chained pks back into ``fetch_suggestion_details`` and returns the
+        social-context-rich payload instead.
+
+        Parameters
+        ----------
+        user_id: str
+            Target user pk whose suggested profiles to fetch.
+        expand_suggestion: bool, optional
+            When ``True``, return the expanded ``fetch_suggestion_details``
+            payload. Falls back to the ``chaining`` payload when the target
+            has no chained users. Defaults to ``False``.
+
+        Returns
+        -------
+        dict
+            Raw ``discover/chaining/`` response, or the
+            ``discover/fetch_suggestion_details/`` response when
+            ``expand_suggestion`` is ``True`` and chained users exist
+            (currently keyed by ``items`` in app responses).
+
+        Raises
+        ------
+        InvalidTargetUser
+            Instagram refused chaining for this target ("Not eligible
+            for chaining."). Common on locked-down / private accounts.
+        """
+        chained = await self.chaining(user_id)
+        if not expand_suggestion:
+            return chained
+        chained_ids = ",".join(str(user["pk"]) for user in chained.get("users", []) if user.get("pk"))
+        if not chained_ids:
+            return chained
+        return await self.fetch_suggestion_details(user_id, chained_ids)
+
     async def discover_recommended_accounts_for_category_v1(self, user_id: str) -> dict:
         """
         Get business-category-similar accounts for a target user.

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -5,7 +5,7 @@
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.9.0
+instagrapi 2.9.1
 ```
 
 `aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback
@@ -23,6 +23,8 @@ challenge context handling, and clearer Reel/clip upload failure details.
 
 `aiograpi 1.3.0` continues the mirror through `instagrapi 2.9.0`. It adds the experimental modern CAA email signup flow via `signup_caa_email(...)`, the `graphql_www` Bloks app wrapper used by registration, and per-request private headers/domain routing so Bloks friendly names do not leak onto unrelated private requests.
 
+The next mirror continues the baseline through `instagrapi 2.9.1` and adds the async `user_suggested_profiles(...)` convenience helper for composing chaining and expanded suggestion details.
+
 ## Release policy
 
 - Use one `aiograpi` feature release for a large upstream sync.
@@ -30,7 +32,7 @@ challenge context handling, and clearer Reel/clip upload failure details.
 - Mention the upstream range in GitHub, PyPI, and Telegram release notes.
 
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
-`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`.
+`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; the next mirror records the suggested-profiles helper baseline through `instagrapi 2.9.1`.
 
 ## Porting rules
 

--- a/docs/usage-guide/private-graphql.md
+++ b/docs/usage-guide/private-graphql.md
@@ -21,6 +21,7 @@ query) and as **named convenience wrappers** (`user_info_v2_gql`,
 | Flat (merged) profile dict by `user_id` | `Client.user_stream_by_id_flat(user_id)` |
 | Flat (merged) profile dict by `username` | `Client.user_stream_by_username_flat(username)` |
 | Web-scraper-style profile via private host | `Client.user_web_profile_info_v1(username)` |
+| "Suggested for you" convenience wrapper | `Client.user_suggested_profiles(user_id, expand_suggestion=False)` |
 | "Suggested" profiles by user_id (chaining) | `Client.chaining(user_id)` |
 | Suggested-profile expanded details | `Client.fetch_suggestion_details(user_id, chained_ids)` |
 | Similar businesses by user's category | `Client.discover_recommended_accounts_for_category_v1(user_id)` |

--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -35,6 +35,7 @@ View a list of a user's medias, following and followers
 | disable_stories_notifications(user_id: str)   | bool                  | Disable stories notifications of user                        |
 | close_friend_add(user_id: str)                | bool                  | Add to Close Friends List                                    |
 | close_friend_remove(user_id: str)             | bool                  | Remove from Close Friends List                               |
+| user_suggested_profiles(user_id: str, expand_suggestion: bool = False) | dict | Suggested profiles ("Suggested for you") for a profile. Wraps `chaining` and, with `expand_suggestion=True`, returns the raw `fetch_suggestion_details` payload (`items` in current app responses) |
 
 Low level methods:
 
@@ -111,4 +112,23 @@ await cl.login(USERNAME, PASSWORD)
 followers = await cl.user_followers(cl.user_id)
 for follower in followers.values():
     await cl.user_unfollow(follower.pk)
+```
+
+Example: Suggested profiles ("Suggested for you") for a target user:
+
+``` python
+from aiograpi import Client
+from aiograpi.exceptions import InvalidTargetUser
+
+cl = Client()
+await cl.login(USERNAME, PASSWORD)
+
+user_id = await cl.user_id_from_username("example")
+try:
+    suggested = await cl.user_suggested_profiles(user_id)
+    # Expanded social-context fields (current app responses expose them under "items"):
+    detailed = await cl.user_suggested_profiles(user_id, expand_suggestion=True)
+except InvalidTargetUser:
+    # Instagram refuses chaining for locked-down / private targets
+    suggested = {"users": []}
 ```

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -3700,6 +3700,42 @@ class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         params = client.private_request.call_args.kwargs["params"]
         self.assertEqual(params["chained_ids"], "1,2,3")
 
+    async def test_user_suggested_profiles_returns_chaining_payload_by_default(self):
+        client = self.build_private_client()
+        chained = {"users": [{"pk": "9", "username": "a"}, {"pk": "10", "username": "b"}]}
+        client.chaining = AsyncMock(return_value=chained)
+        client.fetch_suggestion_details = AsyncMock()
+
+        result = await client.user_suggested_profiles("123")
+
+        self.assertEqual(result, chained)
+        client.chaining.assert_awaited_once_with("123")
+        client.fetch_suggestion_details.assert_not_awaited()
+
+    async def test_user_suggested_profiles_expands_suggestion_details(self):
+        client = self.build_private_client()
+        chained = {"users": [{"pk": "9"}, {"pk": "10"}]}
+        expanded = {"items": [{"user": {"pk": "9"}, "social_context": "Followed by you"}]}
+        client.chaining = AsyncMock(return_value=chained)
+        client.fetch_suggestion_details = AsyncMock(return_value=expanded)
+
+        result = await client.user_suggested_profiles("123", expand_suggestion=True)
+
+        self.assertEqual(result, expanded)
+        client.chaining.assert_awaited_once_with("123")
+        client.fetch_suggestion_details.assert_awaited_once_with("123", "9,10")
+
+    async def test_user_suggested_profiles_expand_without_users_returns_chaining(self):
+        client = self.build_private_client()
+        chained = {"users": []}
+        client.chaining = AsyncMock(return_value=chained)
+        client.fetch_suggestion_details = AsyncMock()
+
+        result = await client.user_suggested_profiles("123", expand_suggestion=True)
+
+        self.assertEqual(result, chained)
+        client.fetch_suggestion_details.assert_not_awaited()
+
     async def test_user_stream_by_id_v1_posts_info_stream(self):
         client = self.build_private_client()
         client.private_request = AsyncMock(return_value={"stream_rows": []})


### PR DESCRIPTION
## Summary
- mirror instagrapi PR #2613 / release 2.9.1 with async `Client.user_suggested_profiles(user_id, expand_suggestion=False)`
- compose existing `chaining()` and `fetch_suggestion_details()` helpers, returning raw chaining by default and raw expanded `items` payload when requested
- update user/private-graphql docs, changelog, and upstream baseline notes

## Tests
- `ruff check .`
- `ruff format --check .`
- `./scripts/check-mypy-baseline.sh` (253/253)
- `pytest -q tests/regression` (314 passed, 3 skipped, 2 subtests passed)
- targeted `UserMixinRegressionTestCase` suggested-profile tests (7 passed)
- CI-equivalent unit subset from `.github/workflows/python-package.yml` (526 passed, 13 skipped, 2 warnings, 2 subtests passed)
- async live smoke with pooled account against `instagram`: default chaining returned 77 users; expanded details returned 30 items

Upstream: https://github.com/subzeroid/instagrapi/pull/2613
Release baseline: instagrapi 2.9.1