### PR TITLE
Mirror UserShort follower metadata

### DIFF
--- a/aiograpi/types.py
+++ b/aiograpi/types.py
@@ -140,7 +140,9 @@ class UserShort(TypesBaseModel):
     profile_pic_url_hd: Optional[HttpUrl] = None
     is_private: Optional[bool] = None
     stories: List = Field(default_factory=list)
-    # is_verified: bool  # not found in hashtag_medias_v1
+    is_verified: Optional[bool] = None
+    latest_reel_media: Optional[int] = None
+    has_anonymous_profile_picture: Optional[bool] = None
 
 
 class Viewer(UserShort):

--- a/tests/live/smoke.py
+++ b/tests/live/smoke.py
@@ -153,6 +153,18 @@ async def main():
                 failures.append((name, e))
                 print(f"REQ {name} FAIL: {type(e).__name__}: {str(e)[:140]}")
 
+        try:
+            followers = await cl.user_followers_v1("25025320", amount=5)
+            assert len(followers) == 5
+            follower = followers[0]
+            assert isinstance(follower.is_verified, bool)
+            assert isinstance(follower.latest_reel_media, int)
+            assert isinstance(follower.has_anonymous_profile_picture, bool)
+            print("REQ user_followers_extended_fields: ok")
+        except Exception as e:
+            failures.append(("user_followers_extended_fields", e))
+            print(f"REQ user_followers_extended_fields FAIL: {type(e).__name__}: {str(e)[:140]}")
+
     # OPTIONAL: chapi-ported endpoints — record but don't fail
     if cl is not None:
         rank_token = str(uuid.uuid4())

--- a/tests/regression/test_live_smoke.py
+++ b/tests/regression/test_live_smoke.py
@@ -78,6 +78,17 @@ class _FakeLiveClient:
     async def user_followers(self, user_id, amount=0, use_cache=True):
         return [types.SimpleNamespace(pk=str(i)) for i in range(amount)]
 
+    async def user_followers_v1(self, user_id, amount=0, use_cache=True):
+        return [
+            types.SimpleNamespace(
+                pk=str(i),
+                is_verified=False,
+                latest_reel_media=1710000000 + i,
+                has_anonymous_profile_picture=False,
+            )
+            for i in range(amount)
+        ]
+
     async def user_following(self, user_id, amount=0, use_cache=True):
         return [types.SimpleNamespace(pk=str(i)) for i in range(amount)]
 
@@ -229,6 +240,7 @@ print(sys.modules["aiograpi"].__file__)
             "username_from_user_id",
             "user_medias",
             "user_medias_paginated",
+            "user_followers_extended_fields",
             "user_following",
             "user_stories",
         ]:

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, Mock
 
 from aiograpi import Client
 from aiograpi.exceptions import ClientError, ClientGraphqlError, ClientJSONDecodeError, UserNotFound
-from aiograpi.extractors import extract_user_v1
+from aiograpi.extractors import extract_user_short, extract_user_v1
 from aiograpi.mixins.user import UserMixin
 
 
@@ -97,6 +97,26 @@ class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(user.username, "instagram")
         client.user_web_profile_info_gql.assert_awaited_once_with("25025320")
         client.public_graphql_request.assert_not_called()
+
+    async def test_extract_user_short_preserves_follower_payload_fields(self):
+        payload = {
+            "pk": 123,
+            "id": "123",
+            "username": "follower",
+            "full_name": "Follower",
+            "is_private": False,
+            "is_verified": True,
+            "latest_reel_media": 1710000123,
+            "has_anonymous_profile_picture": False,
+            "profile_pic_url": "https://example.com/pic.jpg",
+        }
+
+        user = extract_user_short(payload)
+
+        self.assertEqual(user.pk, "123")
+        self.assertTrue(user.is_verified)
+        self.assertEqual(user.latest_reel_media, 1710000123)
+        self.assertFalse(user.has_anonymous_profile_picture)
 
     async def test_user_web_profile_info_gql_uses_public_doc_id_endpoint(self):
         client = Client()


### PR DESCRIPTION
Mirrors instagrapi 2.9.2 follower metadata support.

Links verified before posting:
- Issue: https://github.com/subzeroid/instagrapi/issues/1564
- Upstream PR: https://github.com/subzeroid/instagrapi/pull/2614
- Upstream release: https://github.com/subzeroid/instagrapi/releases/tag/2.9.2

Changes:
- Preserve `is_verified`, `latest_reel_media`, and `has_anonymous_profile_picture` in `UserShort`.
- Add regression coverage for follower payload extraction.
- Add a required live smoke check for `user_followers_v1` extended fields.

Verification:
- `.venv/bin/python -m ruff check aiograpi/types.py tests/regression/test_user.py tests/live/smoke.py`
- `.venv/bin/python -m ruff format --check aiograpi/types.py tests/regression/test_user.py tests/live/smoke.py`
- `.venv/bin/python -m pytest -q tests/regression/test_user.py`
- `.venv/bin/python tests/live/smoke.py`
- `.venv/bin/python -m build`