### PR TITLE
Handle non-JSON private HTTP errors

### DIFF
--- a/aiograpi/mixins/private.py
+++ b/aiograpi/mixins/private.py
@@ -511,7 +511,7 @@ class PrivateRequestMixin(ClientMixin):
             response = self.last_response
             try:
                 self.last_json = last_json = response.json()
-            except (orjson.JSONDecodeError, AttributeError):
+            except (ValueError, AttributeError):
                 self.logger.warning(
                     "ClientUnknownError1. response text: %r (%r)",
                     response and response.text,

--- a/tests/regression/test_private.py
+++ b/tests/regression/test_private.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import AsyncMock, Mock
 
 from aiograpi import Client, httpx_ext
-from aiograpi.exceptions import DirectMessageRequestsDisabled
+from aiograpi.exceptions import ClientNotFoundError, DirectMessageRequestsDisabled
 
 
 class PrivateRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
@@ -49,6 +49,19 @@ class PrivateRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(cm.exception.message, payload["message"])
         self.assertEqual(cm.exception.status, "fail")
+
+    async def test_send_private_request_ignores_non_json_body_on_http_error(self):
+        client = self._build_client()
+        response = self._response({}, status_code=404)
+        response.content = b"<html>not found</html>"
+        response.text = response.content.decode("utf-8")
+        response.json.side_effect = ValueError("bad json")
+        client.private.get = AsyncMock(return_value=response)
+
+        with self.assertRaises(ClientNotFoundError):
+            await client._send_private_request("users/999/info/")
+
+        self.assertEqual(client.last_json, {})
 
     async def test_private_request_retries_remote_protocol_error_once(self):
         client = self._build_client()


### PR DESCRIPTION
Mirrors the private request HTTP-error JSON handling fix from instagrapi.

Links verified before publishing this PR:
- Source issue: https://github.com/subzeroid/instagrapi/issues/708
- instagrapi PR: https://github.com/subzeroid/instagrapi/pull/2615
- instagrapi release: https://github.com/subzeroid/instagrapi/releases/tag/2.9.3

Changes:
- Treat ValueError from response.json() in the secondary HTTPStatusError parse as a non-JSON error body.
- Preserve the normal successful-response JSONDecodeError path as ClientJSONDecodeError.
- Add async regression coverage for non-JSON private HTTP error responses.

Verification:
- .venv/bin/python -m pytest -q tests/regression/test_private.py::PrivateRequestRegressionTestCase::test_send_private_request_ignores_non_json_body_on_http_error
- .venv/bin/python -m pytest -q tests/regression
- .venv/bin/python -m ruff check .
- .venv/bin/python -m ruff format --check .
- ./scripts/check-mypy-baseline.sh
- .venv/bin/python -m bandit -c pyproject.toml -r aiograpi
- .venv/bin/python -m pip_audit --strict --progress-spinner off .
- .venv/bin/python -m build