### PR TITLE
Map public challenge redirects to login required

### DIFF
--- a/aiograpi/mixins/public.py
+++ b/aiograpi/mixins/public.py
@@ -11,7 +11,6 @@ from aiograpi import httpx_ext
 from aiograpi.exceptions import (
     AboutUsError,
     AccountSuspended,
-    ChallengeRequired,
     ClientBadRequestError,
     ClientConnectionError,
     ClientError,
@@ -269,7 +268,7 @@ class PublicRequestMixin(ClientMixin):
             if "/login/" in url:
                 raise ClientLoginRequired(e, response=response)
             elif "/challenge/" in url:
-                raise ChallengeRequired(e, response=response)
+                raise ClientLoginRequired(e, response=response)
             elif "/suspended/" in url:
                 raise AccountSuspended(e, response=response)
             elif "/terms/unblock" in url:

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import AsyncMock, Mock
+
+import orjson
+
+from aiograpi import Client
+from aiograpi.exceptions import ClientLoginRequired
+
+
+class PublicRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_public_request_maps_challenge_redirect_html_to_login_required(self):
+        client = Client()
+        client.last_response_ts = 0
+        response = Mock()
+        response.status_code = 200
+        response.url = "https://www.instagram.com/challenge/?next=/graphql/query/"
+        response.text = '<!DOCTYPE html><html lang="en" class="no-js logged-in client-root"></html>'
+        response.raise_for_status.return_value = None
+        response.json.side_effect = orjson.JSONDecodeError("unexpected character", response.text, 0)
+        client.public.get = AsyncMock(return_value=response)
+
+        with self.assertRaises(ClientLoginRequired):
+            await client._send_public_request("https://www.instagram.com/graphql/query/", return_json=True)


### PR DESCRIPTION
Mirrors the public challenge redirect handling fix from instagrapi.

Links verified before publishing this PR:
- Source issue: https://github.com/subzeroid/instagrapi/issues/1093
- instagrapi PR: https://github.com/subzeroid/instagrapi/pull/2616
- instagrapi release: https://github.com/subzeroid/instagrapi/releases/tag/2.9.4

Changes:
- Map public `/challenge/?next=...` HTML JSON parse failures to `ClientLoginRequired`.
- Keep ordinary malformed public JSON responses as `ClientJSONDecodeError`.
- Add async regression coverage for challenge redirect HTML.

Verification:
- .venv/bin/python -m pytest -q tests/regression/test_public.py::PublicRequestRegressionTestCase::test_public_request_maps_challenge_redirect_html_to_login_required
- .venv/bin/python -m pytest -q tests/regression/test_request_logging.py::RequestLoggingRegressionTestCase::test_public_json_decode_error_log_truncates_response_body
- .venv/bin/python -m pytest -q tests/regression
- .venv/bin/python -m ruff check .
- .venv/bin/python -m ruff format --check .
- ./scripts/check-mypy-baseline.sh
- .venv/bin/python -m bandit -c pyproject.toml -r aiograpi
- .venv/bin/python -m pip_audit --strict --progress-spinner off .
- .venv/bin/python -m build