### PR TITLE
Handle limited private follower lists

### DIFF
--- a/aiograpi/mixins/user.py
+++ b/aiograpi/mixins/user.py
@@ -1029,10 +1029,13 @@ class UserMixin(ClientMixin):
             Tuple of List of users and max_id
         """
         unique_set = set()
-        users = []
+        users: List[UserShort] = []
         while True:
+            count = MAX_USER_COUNT
+            if max_amount:
+                count = min(max_amount - len(users), MAX_USER_COUNT)
             params = {
-                "count": max_amount or MAX_USER_COUNT,
+                "count": count,
                 "rank_token": self.rank_token,
                 "search_surface": "follow_list_page",
                 "query": "",
@@ -1234,6 +1237,8 @@ class UserMixin(ClientMixin):
             if self._has_private_auth():
                 try:
                     users = await self.user_followers_v1(user_id, amount)
+                    if self.last_json.get("should_limit_list_of_followers") and (not amount or len(users) < amount):
+                        users = await self.user_followers_gql(user_id, amount)
                 except Exception as e:
                     if not isinstance(e, ClientError):
                         self.logger.exception(e)

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock
 from aiograpi import Client
 from aiograpi.exceptions import ClientError, ClientGraphqlError, ClientJSONDecodeError, UserNotFound
 from aiograpi.extractors import extract_user_short, extract_user_v1
-from aiograpi.mixins.user import UserMixin
+from aiograpi.mixins.user import MAX_USER_COUNT, UserMixin
 
 
 class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
@@ -274,6 +274,56 @@ class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         client.private_request.assert_awaited_once()
         self.assertEqual(client.private_request.call_args.kwargs["params"]["order"], "date_followed_latest")
+
+    async def test_user_followers_v1_chunk_caps_count_to_max_user_count(self):
+        client = Client()
+        client.uuid = "rank-token"
+        client.private_request = AsyncMock(return_value={"users": [], "next_max_id": None})
+
+        await client.user_followers_v1_chunk("123", max_amount=MAX_USER_COUNT + 1)
+
+        client.private_request.assert_awaited_once()
+        self.assertEqual(client.private_request.call_args.kwargs["params"]["count"], MAX_USER_COUNT)
+
+    async def test_user_followers_falls_back_when_private_list_is_limited(self):
+        client = Client()
+        client.authorization_data = {"sessionid": "sessionid-value", "ds_user_id": "1"}
+        client._users_followers = {}
+        private_user = Mock(pk="private")
+        public_user = Mock(pk="public")
+
+        async def private_lookup(user_id, amount):
+            client.last_json = {"should_limit_list_of_followers": True}
+            return [private_user]
+
+        client.user_followers_v1 = AsyncMock(side_effect=private_lookup)
+        client.user_followers_gql = AsyncMock(return_value=[public_user])
+
+        result = await client.user_followers("123", amount=2, use_cache=False)
+
+        self.assertEqual(list(result.keys()), ["public"])
+        client.user_followers_v1.assert_awaited_once_with("123", 2)
+        client.user_followers_gql.assert_awaited_once_with("123", 2)
+
+    async def test_user_followers_default_amount_falls_back_when_private_list_is_limited(self):
+        client = Client()
+        client.authorization_data = {"sessionid": "sessionid-value", "ds_user_id": "1"}
+        client._users_followers = {}
+        private_user = Mock(pk="private")
+        public_user = Mock(pk="public")
+
+        async def private_lookup(user_id, amount):
+            client.last_json = {"should_limit_list_of_followers": True}
+            return [private_user]
+
+        client.user_followers_v1 = AsyncMock(side_effect=private_lookup)
+        client.user_followers_gql = AsyncMock(return_value=[public_user])
+
+        result = await client.user_followers("123", use_cache=False)
+
+        self.assertEqual(list(result.keys()), ["public"])
+        client.user_followers_v1.assert_awaited_once_with("123", 0)
+        client.user_followers_gql.assert_awaited_once_with("123", 0)
 
     async def test_user_followers_private_gql_chunk_extracts_followers_payload(self):
         client = Client()


### PR DESCRIPTION
Mirrors the follower pagination fix from instagrapi 2.9.5.

Context:
- Issue: https://github.com/subzeroid/instagrapi/issues/1318
- instagrapi PR: https://github.com/subzeroid/instagrapi/pull/2618
- instagrapi release: https://github.com/subzeroid/instagrapi/releases/tag/2.9.5

Changes:
- Caps private `user_followers_v1_chunk` page `count` at `MAX_USER_COUNT` so large `amount` values are not sent directly to Instagram's private followers endpoint.
- Falls back from the authenticated private followers path to public GraphQL when Instagram returns `should_limit_list_of_followers=True` and the private result does not satisfy the requested amount.
- Adds async regression coverage for both behaviors.

Local verification:
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`
- `./scripts/check-mypy-baseline.sh`
- `.venv/bin/python -m bandit -c pyproject.toml -r aiograpi`
- `.venv/bin/python -m pip_audit --strict --progress-spinner off .`
- `.venv/bin/python -m build`
