### PR TITLE
Cap private following page count

### DIFF
--- a/aiograpi/mixins/user.py
+++ b/aiograpi/mixins/user.py
@@ -846,10 +846,13 @@ class UserMixin(ClientMixin):
             Tuple of List of users and max_id
         """
         unique_set = set()
-        users = []
+        users: List[UserShort] = []
         while True:
+            count = MAX_USER_COUNT
+            if max_amount:
+                count = min(max_amount - len(users), MAX_USER_COUNT)
             params = {
-                "count": max_amount or MAX_USER_COUNT,
+                "count": count,
                 "rank_token": self.rank_token,
                 "search_surface": "follow_list_page",
                 "query": "",

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -285,6 +285,16 @@ class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.private_request.assert_awaited_once()
         self.assertEqual(client.private_request.call_args.kwargs["params"]["count"], MAX_USER_COUNT)
 
+    async def test_user_following_v1_chunk_caps_count_to_max_user_count(self):
+        client = Client()
+        client.uuid = "rank-token"
+        client.private_request = AsyncMock(return_value={"users": [], "next_max_id": None})
+
+        await client.user_following_v1_chunk("123", max_amount=MAX_USER_COUNT + 1)
+
+        client.private_request.assert_awaited_once()
+        self.assertEqual(client.private_request.call_args.kwargs["params"]["count"], MAX_USER_COUNT)
+
     async def test_user_followers_falls_back_when_private_list_is_limited(self):
         client = Client()
         client.authorization_data = {"sessionid": "sessionid-value", "ds_user_id": "1"}


### PR DESCRIPTION
Mirrors the private following count cap fix from instagrapi 2.9.6.

Context:
- Issue: https://github.com/subzeroid/instagrapi/issues/1253
- Related older report: https://github.com/subzeroid/instagrapi/issues/1292
- instagrapi PR: https://github.com/subzeroid/instagrapi/pull/2620
- instagrapi release: https://github.com/subzeroid/instagrapi/releases/tag/2.9.6

Changes:
- Caps async private `user_following_v1_chunk` page `count` at `MAX_USER_COUNT`.
- Keeps subsequent pages bounded to the remaining requested amount.
- Adds async regression coverage for the count cap.

Local verification:
- RED: new regression test failed before the fix with `201 != 200`.
- GREEN: new regression test passes after the fix.
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`
- `./scripts/check-mypy-baseline.sh`
- `.venv/bin/python -m bandit -c pyproject.toml -r aiograpi`
- `.venv/bin/python -m pip_audit --strict --progress-spinner off .`
- `.venv/bin/python -m build`
