### PR TITLE
Read hashtag section layout items

### DIFF
--- a/aiograpi/mixins/hashtag.py
+++ b/aiograpi/mixins/hashtag.py
@@ -22,6 +22,18 @@ class HashtagMixin(ClientMixin):
     Helpers for managing Hashtag
     """
 
+    def _hashtag_section_media_nodes(self, section):
+        layout_content = section.get("layout_content") or {}
+        one_by_two_item = layout_content.get("one_by_two_item") or {}
+        if isinstance(one_by_two_item, dict):
+            clips = one_by_two_item.get("clips") or {}
+            if isinstance(clips, dict):
+                for node in clips.get("items") or []:
+                    yield node
+        for key in ("fill_items", "medias"):
+            for node in layout_content.get(key) or []:
+                yield node
+
     def _normalize_hashtag_name(self, name: str) -> str:
         normalized = name.strip()
         if normalized.startswith("#"):
@@ -165,9 +177,7 @@ class HashtagMixin(ClientMixin):
             ids = result.get("next_media_ids")
             next_max_id = base64.b64encode(json.dumps([np, ids]).encode()).decode()
         for section in result["sections"]:
-            layout_content = section.get("layout_content") or {}
-            nodes = layout_content.get("medias") or []
-            for node in nodes:
+            for node in self._hashtag_section_media_nodes(section):
                 if max_amount and len(medias) >= max_amount:
                     break
                 try:

--- a/tests/regression/test_hashtag.py
+++ b/tests/regression/test_hashtag.py
@@ -56,6 +56,73 @@ class HashtagRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request_data["tab"], "recent")
         self.assertEqual(request_data["media_recency_filter"], "top_recent_posts")
 
+    async def test_hashtag_medias_v1_chunk_reads_top_level_section_layout_items(self):
+        client = Client()
+
+        def media(pk):
+            return {
+                "pk": pk,
+                "id": f"{pk}_2",
+                "code": f"code-{pk}",
+                "taken_at": 1710000000,
+                "media_type": 1,
+                "user": {
+                    "pk": "2",
+                    "username": "example",
+                    "profile_pic_url": "https://example.com/profile.jpg",
+                },
+                "image_versions2": {
+                    "candidates": [
+                        {
+                            "url": f"https://example.com/{pk}.jpg",
+                            "width": 100,
+                            "height": 100,
+                        }
+                    ]
+                },
+            }
+
+        client.private_request = AsyncMock(
+            return_value={
+                "sections": [
+                    {
+                        "layout_type": "one_by_two_left",
+                        "feed_type": "clips",
+                        "layout_content": {
+                            "one_by_two_item": {
+                                "clips": {
+                                    "items": [
+                                        {"media": media("1")},
+                                        {"media": media("2")},
+                                    ]
+                                }
+                            },
+                            "fill_items": [
+                                {"media": media("3")},
+                                {"media": media("4")},
+                            ],
+                        },
+                    },
+                    {
+                        "layout_type": "media_grid",
+                        "feed_type": "media",
+                        "layout_content": {
+                            "medias": [
+                                {"media": media("5")},
+                            ]
+                        },
+                    },
+                ],
+                "more_available": False,
+                "next_max_id": None,
+            }
+        )
+
+        medias, next_max_id = await client.hashtag_medias_v1_chunk("example", 0, "top")
+
+        self.assertEqual([media.pk for media in medias], ["1", "2", "3", "4", "5"])
+        self.assertIsNone(next_max_id)
+
     async def test_hashtag_following_fetches_current_account_hashtags(self):
         client = Client()
         client.authorization_data = {"ds_user_id": "123"}


### PR DESCRIPTION
## Summary
- mirror the instagrapi hashtag section parser fix from https://github.com/subzeroid/instagrapi/pull/2622
- read hashtag media nodes from `one_by_two_item.clips.items`, `fill_items`, and `medias`
- add regression coverage for mixed hashtag section layouts

Fixes the aiograpi side of https://github.com/subzeroid/instagrapi/issues/2621.

instagrapi release: https://github.com/subzeroid/instagrapi/releases/tag/2.9.7
PyPI: https://pypi.org/project/instagrapi/2.9.7/
Codeberg: https://codeberg.org/subzeroid/instagrapi/src/tag/2.9.7

## Verification
- `.venv/bin/python -m pytest -q tests/regression/test_hashtag.py::HashtagRegressionTestCase::test_hashtag_medias_v1_chunk_reads_top_level_section_layout_items tests/regression/test_hashtag.py::HashtagRegressionTestCase::test_hashtag_medias_v1_chunk_sends_tab_key`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`
- `./scripts/check-mypy-baseline.sh`
- `.venv/bin/bandit -c pyproject.toml -r aiograpi`
- `.venv/bin/python -m build`
