### PR TITLE
Scope saved app profile hydration

### DIFF
--- a/aiograpi/mixins/auth.py
+++ b/aiograpi/mixins/auth.py
@@ -1161,7 +1161,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             if matched and not override_app_version:
                 apply_settings(matched)
             else:
-                if override_app_version or not app_version:
+                has_complete_app_profile = all(self.device_settings.get(key) for key in app_keys)
+                if override_app_version or not app_version or not has_complete_app_profile:
                     apply_settings(default_settings())
 
         if override_app_version:

--- a/aiograpi/mixins/auth.py
+++ b/aiograpi/mixins/auth.py
@@ -638,7 +638,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
 
         self.set_timezone_offset(timezone_offset, timezone_name=timezone_name or None)
         self.set_push_disabled(push_disabled)
-        self.set_device(self.settings.get("device_settings"))
+        self.set_device(self.settings.get("device_settings"), hydrate_app_profile=True)
         self.set_user_agent(self.settings.get("user_agent"))
         self.set_uuids(self.settings.get("uuids") or {})
         self.set_locale(locale)
@@ -1081,7 +1081,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             )
         return True
 
-    def set_device(self, device: Dict = None, reset: bool = False) -> bool:
+    def set_device(self, device: Dict = None, reset: bool = False, hydrate_app_profile: bool = False) -> bool:
         """
         Helper to set a device for login
 
@@ -1089,6 +1089,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         ----------
         device: Dict, optional
             Dict of device settings, default is None
+        hydrate_app_profile: bool, optional
+            Hydrate incomplete app profile fields from the current default app when loading saved settings
 
         Returns
         -------
@@ -1102,12 +1104,12 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         if self.settings:
             uuids = self.settings.get("uuids") or {}
             seed = uuids.get("uuid")
-        self.set_app(seed=seed)
+        self.set_app(seed=seed, hydrate_incomplete_profile=hydrate_app_profile)
         if reset:
             self.set_uuids({})
         return True
 
-    def set_app(self, app: Union[str, Dict] = None, seed: str = None) -> bool:
+    def set_app(self, app: Union[str, Dict] = None, seed: str = None, hydrate_incomplete_profile: bool = False) -> bool:
         """
         Helper to set app version settings
 
@@ -1117,6 +1119,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             App version string or settings dict
         seed: str, optional
             Seed used for stable app selection
+        hydrate_incomplete_profile: bool, optional
+            Hydrate incomplete app profile fields from the current default app
 
         Returns
         -------
@@ -1147,6 +1151,14 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         def default_settings() -> Dict:
             return config.APP_SETTINGS.get(config.DEFAULT_APP_VERSION) or pick_by_seed()
 
+        def is_current_or_newer_app_version(value: Any) -> bool:
+            try:
+                version = tuple(int(part) for part in str(value).split("."))
+                default_version = tuple(int(part) for part in config.DEFAULT_APP_VERSION.split("."))
+            except (TypeError, ValueError):
+                return False
+            return version >= default_version
+
         if app:
             if isinstance(app, str):
                 matched = config.APP_SETTINGS.get(app)
@@ -1162,7 +1174,12 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
                 apply_settings(matched)
             else:
                 has_complete_app_profile = all(self.device_settings.get(key) for key in app_keys)
-                if override_app_version or not app_version or not has_complete_app_profile:
+                should_hydrate_incomplete_profile = (
+                    hydrate_incomplete_profile
+                    and not has_complete_app_profile
+                    and is_current_or_newer_app_version(app_version)
+                )
+                if override_app_version or not app_version or should_hydrate_incomplete_profile:
                     apply_settings(default_settings())
 
         if override_app_version:

--- a/tests/regression/test_current_app_profile.py
+++ b/tests/regression/test_current_app_profile.py
@@ -101,3 +101,31 @@ def test_unknown_saved_app_without_bloks_hash_uses_current_default_profile():
     assert client.device_settings["app_version"] == config.DEFAULT_APP_VERSION
     assert client.device_settings["version_code"] == "961145276"
     assert client.bloks_versioning_id == "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8"
+
+
+def test_legacy_saved_app_without_bloks_hash_is_not_overridden_by_default():
+    client = Client(
+        {
+            "device_settings": {
+                "app_version": "269.0.0.19.301",
+                "version_code": "301484483",
+            },
+        }
+    )
+
+    assert client.device_settings["app_version"] == "269.0.0.19.301"
+    assert client.device_settings["version_code"] == "301484483"
+    assert client.bloks_versioning_id is None
+
+
+def test_explicit_set_device_preserves_unknown_incomplete_app_profile():
+    client = Client()
+    device = {
+        "app_version": "431.0.0.47.82",
+        "version_code": "979332773",
+    }
+
+    client.set_device(device)
+
+    assert client.device_settings["app_version"] == "431.0.0.47.82"
+    assert client.device_settings["version_code"] == "979332773"

--- a/tests/regression/test_current_app_profile.py
+++ b/tests/regression/test_current_app_profile.py
@@ -86,3 +86,18 @@ def test_constructor_override_app_version_replaces_saved_profile_with_current_de
 
     assert client.device_settings["app_version"] == config.DEFAULT_APP_VERSION
     assert client.device_settings["version_code"] == "961145276"
+
+
+def test_unknown_saved_app_without_bloks_hash_uses_current_default_profile():
+    client = Client(
+        {
+            "device_settings": {
+                "app_version": "431.0.0.47.82",
+                "version_code": "979332773",
+            },
+        }
+    )
+
+    assert client.device_settings["app_version"] == config.DEFAULT_APP_VERSION
+    assert client.device_settings["version_code"] == "961145276"
+    assert client.bloks_versioning_id == "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8"


### PR DESCRIPTION
Mirror of https://github.com/subzeroid/instagrapi/pull/2626 for https://github.com/subzeroid/instagrapi/issues/2617.

When saved `device_settings` contain a current-or-newer unknown/incomplete app tuple without `bloks_versioning_id`, the client hydrates the current known Android app profile while loading settings. Explicit `set_device(...)` calls and older saved app profiles remain unchanged.

This mirrors instagrapi 2.9.10:
- release: https://github.com/subzeroid/instagrapi/releases/tag/2.9.10
- PyPI: https://pypi.org/project/instagrapi/2.9.10/
- Codeberg: https://codeberg.org/subzeroid/instagrapi/src/tag/2.9.10

Verification:
- `.venv/bin/python -m pytest -q tests/regression/test_current_app_profile.py tests/legacy.py::ClientTestCase::test_country_locale_timezone` -> 10 passed
- `.venv/bin/python -m pytest -q tests/regression` -> 327 passed, 3 skipped, 4 subtests passed
- `.venv/bin/ruff check .` -> passed
- `.venv/bin/ruff format --check .` -> passed
- `./scripts/check-mypy-baseline.sh` -> 253/253
- `.venv/bin/bandit -c pyproject.toml -r aiograpi` -> no issues
- `.venv/bin/python -m build` -> success