### PR TITLE
Treat pending follow requests as follow success

### DIFF
--- a/aiograpi/mixins/user.py
+++ b/aiograpi/mixins/user.py
@@ -1420,7 +1420,8 @@ class UserMixin(ClientMixin):
         result = await self.private_request(f"friendships/create/{user_id}/", data)
         if self.user_id in self._users_following:
             self._users_following.pop(self.user_id)  # reset
-        return result["friendship_status"]["following"] is True
+        friendship_status = result["friendship_status"]
+        return friendship_status.get("following") is True or friendship_status.get("outgoing_request") is True
 
     async def user_unfollow(self, user_id: str) -> bool:
         """

--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -12,7 +12,7 @@ View a list of a user's medias, following and followers
 | search_following(user_id: str, query: str)    | List[UserShort]       | Search by following                                          |
 | user_info(user_id: str)                       | User                  | Get user info                                                |
 | user_info_by_username(username: str)          | User                  | Get user info by username                                    |
-| user_follow(user_id: str)                     | bool                  | Follow user                                                  |
+| user_follow(user_id: str)                     | bool                  | Follow user, or request to follow a private user             |
 | user_unfollow(user_id: str)                   | bool                  | Unfollow user                                                |
 | user_follow_requests(amount: int = 0)         | List[UserShort]       | Get pending incoming follow requests                         |
 | user_follow_request_approve(user_id: str)     | bool                  | Approve a pending incoming follow request                    |
@@ -52,6 +52,8 @@ Low level methods:
 | user_follow_requests_chunk(max_amount: int = 0, max_id: str = "")                   | Tuple[List[UserShort], str] | Get pending incoming follow requests by Private Mobile API and max_id      |
 | search_followers_v1(user_id: str, query: str)                                       | List[UserShort]             | Search by followers by Private Mobile API                                  |
 | search_following_v1(user_id: str, query: str)                                       | List[UserShort]             | Search by following by Private Mobile API                                  |
+
+`user_follow()` returns `True` when Instagram reports either an immediate follow or an outgoing follow request for a private account. Use `user_friendship_v1()` when you need to distinguish `following` from `outgoing_request`.
 
 Example:
 

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -502,6 +502,14 @@ class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["include_follow_friction_check"], "1")
         self.assertEqual(data["container_module"], "profile")
 
+    async def test_user_follow_returns_true_for_pending_private_follow_request(self):
+        client = self._build_private_client()
+        client.private_request = AsyncMock(
+            return_value={"friendship_status": {"following": False, "outgoing_request": True}}
+        )
+
+        self.assertTrue(await client.user_follow("42"))
+
     async def test_user_unfollow_posts_current_action_context(self):
         client = self._build_action_client()
         client.private_request = AsyncMock(return_value={"friendship_status": {"following": False}})


### PR DESCRIPTION
## Summary
- mirror instagrapi behavior for private-account follow requests
- return `True` from `user_follow()` when Instagram accepts an outgoing follow request
- document the `following` vs `outgoing_request` distinction and add async regression coverage

Mirror of https://github.com/subzeroid/instagrapi/pull/2630
Related issue: https://github.com/subzeroid/instagrapi/issues/1156

## Verification
- `pytest -q tests/regression/test_user.py::UserMixinRegressionTestCase::test_user_follow_returns_true_for_pending_private_follow_request` failed before the implementation and passes after it
- `pytest -q tests/regression`
- `ruff check .`
- `ruff format --check .`
- `./scripts/check-mypy-baseline.sh`
- `mkdocs build --strict`
- `bandit -c pyproject.toml -r aiograpi`
- `python -m build`
