### PR TITLE
Clamp Reel music audio window

### DIFF
--- a/aiograpi/mixins/clip.py
+++ b/aiograpi/mixins/clip.py
@@ -881,11 +881,19 @@ class UploadClipMixin(ClientMixin):
             video = VideoFileClip(str(path))
             audio_clip = AudioFileClip(str(tmpaudio))
             # set the start time of the audio and create the actual media
+            video_duration = float(video.duration)
             start = highlight_start_time / 1000
-            end = highlight_start_time / 1000 + video.duration
+            end = start + video_duration
+            audio_duration = getattr(audio_clip, "duration", None)
+            if audio_duration:
+                audio_duration = float(audio_duration)
+                if end > audio_duration:
+                    start = max(0.0, audio_duration - video_duration)
+                    end = audio_duration
             audio_clip = audio_clip.subclipped(start, end)
             video = video.with_audio(audio_clip)
-            video_duration = video.duration
+            audio_asset_start_time = int(start * 1000)
+            overlap_duration = int((end - start) * 1000)
             # save the media in tmp folder
             tmpvideo = Path(_make_tmp_path(".mp4"))
             video.write_videofile(str(tmpvideo))
@@ -893,8 +901,8 @@ class UploadClipMixin(ClientMixin):
             data = self.clip_music_extra_data(
                 track,
                 extra_data=extra_data,
-                audio_asset_start_time=highlight_start_time,
-                overlap_duration=int(video_duration * 1000),
+                audio_asset_start_time=audio_asset_start_time,
+                overlap_duration=overlap_duration,
                 original_volume=0.0,
             )
             return await self.clip_upload(tmpvideo, caption, extra_data=data)

--- a/tests/regression/test_clip.py
+++ b/tests/regression/test_clip.py
@@ -1,4 +1,6 @@
 import json
+import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -699,3 +701,68 @@ class ClipUploadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         assert upload_extra["music_params"]["audio_asset_start_time_in_ms"] == 1500
         assert upload_extra["music_params"]["overlap_duration_in_ms"] == 2500
         assert "clips_audio_metadata" in upload_extra
+
+    async def test_clip_upload_as_reel_with_music_keeps_audio_window_inside_track(self):
+        client = _build_client()
+        track = Mock(
+            uri="https://example.com/track.m4a",
+            highlight_start_times_in_ms=[173000],
+            display_artist="Artist",
+            id="track-id",
+            audio_cluster_id="cluster-id",
+            title="Track title",
+        )
+        audio_segments = []
+
+        class FakeAudioClip:
+            def __init__(self, path):
+                self.path = path
+                self.duration = 174.0
+
+            def subclipped(self, start, end):
+                if end > self.duration:
+                    raise OSError(f"end {end} exceeds audio duration {self.duration}")
+                audio_segments.append((start, end))
+                return self
+
+            def close(self):
+                return None
+
+        class FakeVideoClip:
+            def __init__(self, path):
+                self.path = path
+                self.duration = 2.5
+
+            def with_audio(self, audio_clip):
+                self.audio_clip = audio_clip
+                return self
+
+            def write_videofile(self, path):
+                Path(path).write_bytes(b"video")
+
+            def close(self):
+                return None
+
+        fake_mp = types.ModuleType("moviepy")
+        fake_mp.VideoFileClip = FakeVideoClip
+        fake_mp.AudioFileClip = FakeAudioClip
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = Path(tmpdir) / "track.m4a"
+            audio_path.write_bytes(b"audio")
+            video_path = Path(tmpdir) / "output.mp4"
+            client.track_download_by_url = AsyncMock(return_value=audio_path)
+            client.clip_upload = AsyncMock(return_value="uploaded")
+            with mock.patch.dict("sys.modules", {"moviepy": fake_mp}):
+                with mock.patch("aiograpi.mixins.clip._make_tmp_path", side_effect=[str(audio_path), str(video_path)]):
+                    result = await client.clip_upload_as_reel_with_music(
+                        Path("input.mp4"),
+                        "caption",
+                        track,
+                    )
+
+        assert result == "uploaded"
+        assert audio_segments == [(171.5, 174.0)]
+        upload_extra = client.clip_upload.call_args.kwargs["extra_data"]
+        assert upload_extra["music_params"]["audio_asset_start_time_in_ms"] == 171500
+        assert upload_extra["music_params"]["overlap_duration_in_ms"] == 2500


### PR DESCRIPTION
## Summary
- mirror subzeroid/instagrapi#2631 for async `clip_upload_as_reel_with_music()`
- keep the MoviePy audio slice inside the downloaded track duration
- shift the slice earlier when the preferred highlight starts too close to the end, preserving the video-duration overlap
- keep `music_params.audio_asset_start_time_in_ms` and `overlap_duration_in_ms` aligned with the burned-in audio

Mirrors https://github.com/subzeroid/instagrapi/pull/2631
Related issue: https://github.com/subzeroid/instagrapi/issues/1613

## Testing
- RED: `pytest -q tests/regression/test_clip.py::ClipUploadRegressionTestCase::test_clip_upload_as_reel_with_music_keeps_audio_window_inside_track` failed with `OSError: end 175.5 exceeds audio duration 174.0`
- GREEN: `pytest -q tests/regression/test_clip.py::ClipUploadRegressionTestCase::test_clip_upload_as_reel_with_music_keeps_audio_window_inside_track`
- `pytest -q tests/regression/test_clip.py`
- `pytest -q tests/regression`
- `ruff check .`
- `ruff format --check .`
- `./scripts/check-mypy-baseline.sh`