### PR TITLE
Fix private video count aliases

### DIFF
--- a/aiograpi/extractors.py
+++ b/aiograpi/extractors.py
@@ -79,7 +79,8 @@ def extract_media_v1(data):
     media["like_count"] = media.get("like_count", 0)
     media["has_liked"] = media.get("has_liked", False)
     media["sponsor_tags"] = [tag["sponsor"] for tag in media.get("sponsor_tags") or []]
-    media["play_count"] = media.get("play_count", 0)
+    media["view_count"] = media.get("view_count", media.get("video_view_count", 0))
+    media["play_count"] = media.get("play_count", media.get("video_play_count", 0))
     media["coauthor_producers"] = media.get("coauthor_producers", [])
     return Media(
         caption_text=(media.get("caption") or {}).get("text", ""),

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -65,6 +65,20 @@ class MediaClipsMetadataRegressionTestCase(unittest.TestCase):
                 self.assertIs(media.clips_metadata.is_shared_to_fb, value)
                 self.assertIs(media.model_dump()["clips_metadata"]["is_shared_to_fb"], value)
 
+    def test_extract_media_v1_normalizes_video_counts(self):
+        payload = self._media_payload()
+        payload.update(
+            {
+                "video_view_count": 1234,
+                "video_play_count": 5678,
+            }
+        )
+
+        media = extract_media_v1(payload)
+
+        self.assertEqual(media.view_count, 1234)
+        self.assertEqual(media.play_count, 5678)
+
 
 class MediaActionPayloadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
     def _build_logged_in_client(self):


### PR DESCRIPTION
## Summary
- Normalize Private API `video_view_count` into `Media.view_count`.
- Normalize Private API `video_play_count` into `Media.play_count`.
- Add regression coverage for private video count aliases.

Mirrors https://github.com/subzeroid/instagrapi/pull/2632
Related to https://github.com/subzeroid/instagrapi/issues/1620

## Tests
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/bandit -c pyproject.toml -r aiograpi`
- `.venv/bin/mkdocs build --strict`
- `./scripts/check-mypy-baseline.sh`