### PR TITLE
Fix media video count aliases in doc_id GraphQL

### DIFF
--- a/aiograpi/extractors.py
+++ b/aiograpi/extractors.py
@@ -149,6 +149,7 @@ def extract_media_gql(data):
         location=extract_location(location) if location else None,
         user=user,
         view_count=media.get("video_view_count", 0),
+        play_count=media.get("play_count", media.get("video_play_count")),
         comment_count=json_value(media, "edge_media_to_comment", "count"),
         like_count=json_value(media, "edge_media_preview_like", "count"),
         caption_text=json_value(media, "edge_media_to_caption", "edges", 0, "node", "text", default=""),

--- a/aiograpi/mixins/public.py
+++ b/aiograpi/mixins/public.py
@@ -439,6 +439,9 @@ class PublicRequestMixin(ClientMixin):
             "doc_id": doc_id,
             "server_timestamps": "true",
         }
+        inject_sessionid = getattr(self, "inject_sessionid_to_public", None)
+        if inject_sessionid:
+            inject_sessionid()
         # IG rejects bare /graphql/query/ POSTs — needs the iPhone web-app
         # signalling headers it sees from m.instagram.com (instaloader does
         # the same: see _default_http_header(empty_session_only=True)).
@@ -451,6 +454,9 @@ class PublicRequestMixin(ClientMixin):
                 "Instagram 273.0.0.16.70 (iPhone15,2; iOS 17_5_1; en_US; en-US; scale=3.00; 1290x2796; 470085518)"
             ),
         }
+        csrftoken = self.public.cookies_dict().get("csrftoken")
+        if csrftoken:
+            merged_headers["X-CSRFToken"] = csrftoken
         if headers:
             merged_headers.update(headers)
         body_json = await self.public_request(

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -1,30 +1,57 @@
 import os
 import unittest
 
+from aiograpi.exceptions import (
+    ClientBadRequestError,
+    ClientForbiddenError,
+    ClientLoginRequired,
+    ClientNotFoundError,
+    ClientThrottledError,
+    ClientUnauthorizedError,
+)
 from aiograpi.extractors import extract_media_gql
 from aiograpi.mixins.media import MEDIA_INFO_DOC_ID
 from tests.live.smoke import _fetch_accounts, _login_first_usable
 
+PUBLIC_MEDIA_FETCH_ERRORS = (
+    ClientBadRequestError,
+    ClientForbiddenError,
+    ClientLoginRequired,
+    ClientNotFoundError,
+    ClientThrottledError,
+    ClientUnauthorizedError,
+)
+
 
 class ClientMediaCountAliasLiveTestCase(unittest.IsolatedAsyncioTestCase):
-    async def asyncSetUp(self):
+    async def live_media_payload(self, code):
         test_accounts_url = os.getenv("TEST_ACCOUNTS_URL")
         if not test_accounts_url:
             self.skipTest("TEST_ACCOUNTS_URL is required for media count alias live tests")
         accounts = await _fetch_accounts(test_accounts_url, count=20)
-        self.cl = await _login_first_usable(accounts)
-        if self.cl is None:
-            self.skipTest("No usable fresh account returned")
+        last_error = None
+        for account in accounts:
+            cl = await _login_first_usable([account])
+            if cl is None:
+                continue
+            try:
+                result = await cl.public_doc_id_graphql_request(
+                    MEDIA_INFO_DOC_ID,
+                    {"shortcode": code},
+                    referer=f"https://www.instagram.com/p/{code}/",
+                )
+            except PUBLIC_MEDIA_FETCH_ERRORS as exc:
+                last_error = f"{type(exc).__name__}: {str(exc)[:120]}"
+                continue
+            payload = result.get("xdt_shortcode_media") or result.get("shortcode_media")
+            if payload:
+                return payload
+            last_error = f"public doc_id media payload was empty: {result}"
+        self.skipTest(f"Could not fetch public doc_id media payload from test accounts: {last_error}")
 
     async def test_extract_media_gql_normalizes_live_video_count_aliases(self):
         code = "C_BM2yAN4Rm"
-        result = await self.cl.public_doc_id_graphql_request(
-            MEDIA_INFO_DOC_ID,
-            {"shortcode": code},
-            referer=f"https://www.instagram.com/p/{code}/",
-        )
-        payload = result.get("xdt_shortcode_media") or result.get("shortcode_media")
-        self.assertTrue(payload, f"public doc_id media payload was empty: {result}")
+        payload = await self.live_media_payload(code)
         self.assertIn(payload.get("__typename"), {"GraphVideo", "XDTGraphVideo"})
         self.assertIn("video_view_count", payload)
         self.assertIn("video_play_count", payload)

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -1,0 +1,35 @@
+import os
+import unittest
+
+from aiograpi.extractors import extract_media_gql
+from aiograpi.mixins.media import MEDIA_INFO_DOC_ID
+from tests.live.smoke import _fetch_accounts, _login_first_usable
+
+
+class ClientMediaCountAliasLiveTestCase(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        test_accounts_url = os.getenv("TEST_ACCOUNTS_URL")
+        if not test_accounts_url:
+            self.skipTest("TEST_ACCOUNTS_URL is required for media count alias live tests")
+        accounts = await _fetch_accounts(test_accounts_url, count=20)
+        self.cl = await _login_first_usable(accounts)
+        if self.cl is None:
+            self.skipTest("No usable fresh account returned")
+
+    async def test_extract_media_gql_normalizes_live_video_count_aliases(self):
+        code = "C_BM2yAN4Rm"
+        result = await self.cl.public_doc_id_graphql_request(
+            MEDIA_INFO_DOC_ID,
+            {"shortcode": code},
+            referer=f"https://www.instagram.com/p/{code}/",
+        )
+        payload = result.get("xdt_shortcode_media") or result.get("shortcode_media")
+        self.assertTrue(payload, f"public doc_id media payload was empty: {result}")
+        self.assertIn(payload.get("__typename"), {"GraphVideo", "XDTGraphVideo"})
+        self.assertIn("video_view_count", payload)
+        self.assertIn("video_play_count", payload)
+
+        media = extract_media_gql(payload)
+
+        self.assertEqual(media.view_count, payload["video_view_count"])
+        self.assertEqual(media.play_count, payload["video_play_count"])

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
 from aiograpi import Client
-from aiograpi.extractors import extract_media_v1
+from aiograpi.extractors import extract_media_gql, extract_media_v1
 from aiograpi.types import StoryMedia
 
 
@@ -75,6 +75,33 @@ class MediaClipsMetadataRegressionTestCase(unittest.TestCase):
         )
 
         media = extract_media_v1(payload)
+
+        self.assertEqual(media.view_count, 1234)
+        self.assertEqual(media.play_count, 5678)
+
+    def test_extract_media_gql_normalizes_video_counts(self):
+        payload = {
+            "__typename": "GraphVideo",
+            "id": "1",
+            "shortcode": "abc",
+            "taken_at_timestamp": 1710000000,
+            "owner": {
+                "id": "2",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "display_resources": [],
+            "edge_media_to_comment": {"count": 0},
+            "edge_media_preview_like": {"count": 0},
+            "edge_media_to_caption": {"edges": []},
+            "edge_media_to_tagged_user": {"edges": []},
+            "edge_sidecar_to_children": {"edges": []},
+            "edge_media_to_sponsor_user": {"edges": []},
+            "video_view_count": 1234,
+            "video_play_count": 5678,
+        }
+
+        media = extract_media_gql(payload)
 
         self.assertEqual(media.view_count, 1234)
         self.assertEqual(media.play_count, 5678)

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -21,3 +21,16 @@ class PublicRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         with self.assertRaises(ClientLoginRequired):
             await client._send_public_request("https://www.instagram.com/graphql/query/", return_json=True)
+
+    async def test_public_doc_id_graphql_request_injects_logged_in_public_cookies(self):
+        client = Client()
+        client.authorization_data = {"sessionid": "123:session", "ds_user_id": "123"}
+        client.public.set_cookies({"csrftoken": "csrf-token"})
+        client.public_request = AsyncMock(return_value={"data": {"ok": True}})
+
+        result = await client.public_doc_id_graphql_request("doc-id", {"shortcode": "abc"})
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(client.public.cookies_dict()["sessionid"], "123:session")
+        headers = client.public_request.await_args.kwargs["headers"]
+        self.assertEqual(headers["X-CSRFToken"], "csrf-token")


### PR DESCRIPTION
## Summary
- Add a live media extractor test mirroring https://github.com/subzeroid/instagrapi/issues/1620 coverage.
- Map GraphQL `video_play_count` to `Media.play_count` in `extract_media_gql`.
- Inject logged-in session cookies before doc_id GraphQL requests, matching instagrapi behavior and avoiding authenticated public GraphQL 401s.

## Verification
- `ruff check aiograpi/mixins/public.py aiograpi/extractors.py tests/regression/test_public.py tests/regression/test_media.py tests/live/test_media.py`
- `ruff format --check aiograpi/mixins/public.py aiograpi/extractors.py tests/regression/test_public.py tests/regression/test_media.py tests/live/test_media.py`
- `pytest -q tests/regression/test_public.py` -> `2 passed`
- `pytest -q tests/regression/test_media.py` -> `13 passed, 2 subtests passed`
- `TEST_ACCOUNTS_URL= .venv/bin/python -m pytest -q -rs tests/live/test_media.py::ClientMediaCountAliasLiveTestCase::test_extract_media_gql_normalizes_live_video_count_aliases` -> `1 skipped`
- Targeted live run with account pool -> `1 passed, 8 warnings in 35.47s`

## Mirror
- Codeberg branch: https://codeberg.org/subzeroid/aiograpi/compare/main...test/live-media-count-aliases
