### PR TITLE
Use media_info_gql in media count alias live test

### DIFF
--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from unittest.mock import AsyncMock, patch
 
 from aiograpi.exceptions import (
     ClientBadRequestError,
@@ -9,8 +10,6 @@ from aiograpi.exceptions import (
     ClientThrottledError,
     ClientUnauthorizedError,
 )
-from aiograpi.extractors import extract_media_gql
-from aiograpi.mixins.media import MEDIA_INFO_DOC_ID
 from tests.live.smoke import _fetch_accounts, _login_first_usable
 
 PUBLIC_MEDIA_FETCH_ERRORS = (
@@ -24,7 +23,7 @@ PUBLIC_MEDIA_FETCH_ERRORS = (
 
 
 class ClientMediaCountAliasLiveTestCase(unittest.IsolatedAsyncioTestCase):
-    async def live_media_payload(self, code):
+    async def live_media(self, code):
         test_accounts_url = os.getenv("TEST_ACCOUNTS_URL")
         if not test_accounts_url:
             self.skipTest("TEST_ACCOUNTS_URL is required for media count alias live tests")
@@ -34,29 +33,40 @@ class ClientMediaCountAliasLiveTestCase(unittest.IsolatedAsyncioTestCase):
             cl = await _login_first_usable([account])
             if cl is None:
                 continue
+            media_pk = cl.media_pk_from_code(code)
+            captured_payload = {}
+            original_doc_id_request = cl.public_doc_id_graphql_request
+
+            async def capture_doc_id_payload(*args, **kwargs):
+                result = await original_doc_id_request(*args, **kwargs)
+                payload = result.get("xdt_shortcode_media") or result.get("shortcode_media")
+                if payload:
+                    captured_payload.update(payload)
+                return result
+
             try:
-                result = await cl.public_doc_id_graphql_request(
-                    MEDIA_INFO_DOC_ID,
-                    {"shortcode": code},
-                    referer=f"https://www.instagram.com/p/{code}/",
-                )
+                with (
+                    patch.object(
+                        cl,
+                        "public_graphql_request",
+                        AsyncMock(side_effect=ClientForbiddenError("force doc_id media fallback")),
+                    ),
+                    patch.object(cl, "public_doc_id_graphql_request", AsyncMock(side_effect=capture_doc_id_payload)),
+                ):
+                    media = await cl.media_info_gql(media_pk)
             except PUBLIC_MEDIA_FETCH_ERRORS as exc:
                 last_error = f"{type(exc).__name__}: {str(exc)[:120]}"
                 continue
-            payload = result.get("xdt_shortcode_media") or result.get("shortcode_media")
-            if payload:
-                return payload
-            last_error = f"public doc_id media payload was empty: {result}"
+            if captured_payload:
+                return media, captured_payload
+            last_error = "public doc_id media payload was empty"
         self.skipTest(f"Could not fetch public doc_id media payload from test accounts: {last_error}")
 
-    async def test_extract_media_gql_normalizes_live_video_count_aliases(self):
+    async def test_media_info_gql_normalizes_live_video_count_aliases(self):
         code = "C_BM2yAN4Rm"
-        payload = await self.live_media_payload(code)
+        media, payload = await self.live_media(code)
         self.assertIn(payload.get("__typename"), {"GraphVideo", "XDTGraphVideo"})
         self.assertIn("video_view_count", payload)
         self.assertIn("video_play_count", payload)
-
-        media = extract_media_gql(payload)
-
         self.assertEqual(media.view_count, payload["video_view_count"])
         self.assertEqual(media.play_count, payload["video_play_count"])


### PR DESCRIPTION
## Summary
- Update the live coverage mirroring https://github.com/subzeroid/instagrapi/issues/1620 to exercise the public `media_info_gql(...)` helper.
- Keep the raw doc_id payload only as test instrumentation, so the test still proves Instagram returns `video_view_count` / `video_play_count` before extraction.
- Avoid presenting `MEDIA_INFO_DOC_ID` / referer wiring as the user-facing path.

## Verification
- `ruff check tests/live/test_media.py`
- `ruff format --check tests/live/test_media.py`
- `TEST_ACCOUNTS_URL= .venv/bin/python -m pytest -q -rs tests/live/test_media.py::ClientMediaCountAliasLiveTestCase::test_media_info_gql_normalizes_live_video_count_aliases` -> `1 skipped`
- Targeted live run with account pool -> `1 passed, 5 warnings in 22.09s`

## Mirror
- Codeberg branch: https://codeberg.org/subzeroid/aiograpi/compare/main...test/media-info-gql-live-helper
