### PR TITLE
Name user doc_id constants

### DIFF
--- a/aiograpi/mixins/user.py
+++ b/aiograpi/mixins/user.py
@@ -42,6 +42,8 @@ MAX_USER_COUNT = 200
 INFO_FROM_MODULES = ("self_profile", "feed_timeline", "reel_feed_timeline")
 FOLLOWERS_ORDERS = ("date_followed_latest", "date_followed_earliest")
 USER_WEB_PROFILE_DOC_ID = "26762473490008061"
+USER_INFO_V2_DOC_ID = "25980296051578533"
+USER_INFO_BY_USERNAME_V2_DOC_ID = "26347858941511777"
 
 logger = logging.getLogger(__name__)
 
@@ -311,7 +313,7 @@ class UserMixin(ClientMixin):
             "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
         }
         self._inject_sessionid_for_v2_gql()
-        data = await self.public_doc_id_graphql_request("25980296051578533", variables)
+        data = await self.public_doc_id_graphql_request(USER_INFO_V2_DOC_ID, variables)
         user_data = (data or {}).get("user")
         if user_data is None:
             raise UserNotFound("User not found", user_id=user_id)
@@ -339,7 +341,9 @@ class UserMixin(ClientMixin):
         """
         username = self._normalize_username(username)
         self._inject_sessionid_for_v2_gql()
-        data = await self.public_doc_id_graphql_request("26347858941511777", {"hasQuery": True, "query": username})
+        data = await self.public_doc_id_graphql_request(
+            USER_INFO_BY_USERNAME_V2_DOC_ID, {"hasQuery": True, "query": username}
+        )
         # Defend against `{"xdt_api__v1__fbsearch__non_profiled_serp": null}` —
         # `.get(key, {})` returns the default ONLY when key is absent;
         # if the key is present with value `None`, the chained `.get` would

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock
 from aiograpi import Client
 from aiograpi.exceptions import ClientError, ClientGraphqlError, ClientJSONDecodeError, UserNotFound
 from aiograpi.extractors import extract_user_short, extract_user_v1
-from aiograpi.mixins.user import MAX_USER_COUNT, UserMixin
+from aiograpi.mixins.user import MAX_USER_COUNT, USER_INFO_BY_USERNAME_V2_DOC_ID, USER_INFO_V2_DOC_ID, UserMixin
 
 
 class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
@@ -244,8 +244,36 @@ class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result, "user")
         client.public_doc_id_graphql_request.assert_awaited_once_with(
-            "26347858941511777", {"hasQuery": True, "query": "example"}
+            USER_INFO_BY_USERNAME_V2_DOC_ID, {"hasQuery": True, "query": "example"}
         )
+
+    async def test_user_info_v2_gql_uses_profile_doc_id(self):
+        client = Client()
+        client._inject_sessionid_for_v2_gql = Mock()
+        client.public_doc_id_graphql_request = AsyncMock(
+            return_value={
+                "user": {
+                    "id": "25025320",
+                    "username": "instagram",
+                    "full_name": "Instagram",
+                    "is_private": False,
+                    "is_verified": True,
+                    "profile_pic_url": "https://example.com/pic.jpg",
+                    "profile_pic_url_hd": None,
+                    "media_count": 0,
+                    "follower_count": 0,
+                    "following_count": 0,
+                    "is_business": False,
+                }
+            }
+        )
+
+        user = await client.user_info_v2_gql("25025320")
+
+        client.public_doc_id_graphql_request.assert_awaited_once()
+        self.assertEqual(client.public_doc_id_graphql_request.await_args.args[0], USER_INFO_V2_DOC_ID)
+        self.assertEqual(client.public_doc_id_graphql_request.await_args.args[1]["id"], "25025320")
+        self.assertEqual(user.pk, "25025320")
 
     async def test_user_stream_by_username_v1_normalizes_endpoint(self):
         client = Client()


### PR DESCRIPTION
## Summary
- Add named constants for the user v2 profile and username-search doc_ids.
- Replace hardcoded `public_doc_id_graphql_request(...)` doc_id literals in user helpers.
- Update regression expectations to use the same constants.

## Verification
- `ruff check aiograpi/mixins/user.py tests/regression/test_user.py`
- `ruff format --check aiograpi/mixins/user.py tests/regression/test_user.py`
- `pytest -q tests/regression/test_user.py` -> `35 passed`
- Targeted regression run on remote test host -> `35 passed`

## Mirror
- Codeberg branch: https://codeberg.org/subzeroid/aiograpi/compare/main...chore/user-doc-id-constants
