### PR TITLE
Add async Reel mashup info helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [1.3.16] - 2026-06-13
+
+### Added
+
+- Added async `clip_mashup_info(media_pk)` for Instagram's Reel remix/reuse availability metadata endpoint.
+
+### Changed
+
+- Synced the recorded upstream baseline to `instagrapi` 2.9.16.
+
 ## [1.3.1] - 2026-06-11
 
 ### Added

--- a/aiograpi/mixins/clip.py
+++ b/aiograpi/mixins/clip.py
@@ -90,6 +90,30 @@ class ClipMixin(ClientMixin):
             response_text=response_text,
         )
 
+    async def clip_mashup_info(self, media_pk: str) -> Dict:
+        """
+        Fetch Reel remix/reuse availability metadata.
+
+        Parameters
+        ----------
+        media_pk: str
+            PK for the Reel
+
+        Returns
+        -------
+        Dict
+            A dictionary of response from the call
+        """
+        assert self.user_id, "Login required"
+        return await self.private_request(
+            "clips/get_mashup_info_for_media/",
+            data={
+                "media_id": str(media_pk),
+                "_uid": str(self.user_id),
+                "_uuid": self.uuid,
+            },
+        )
+
     async def clip_pin(self, media_pk: str, revert: bool = False) -> bool:
         """
         Pin Reel to the Reels tab/profile Reels grid

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -32,7 +32,7 @@ challenge context handling, and clearer Reel/clip upload failure details.
 - Mention the upstream range in GitHub, PyPI, and Telegram release notes.
 
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
-`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`.
+`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`.
 
 ## Porting rules
 

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -49,6 +49,7 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | archive_medias(amount: int = 0)                                 | List\[Media]       | Get your archived feed posts
 | media_pin(media_id: str)                                        | bool               | Pin a media to user profile
 | media_unpin(media_id: str)                                      | bool               | Unpin a media to user profile
+| clip_mashup_info(media_pk: str)                                 | dict               | Fetch Reel remix/reuse availability metadata
 | clip_pin(media_pk: str)                                         | bool               | Pin a Reel to the Reels tab/profile Reels grid
 | clip_unpin(media_pk: str)                                       | bool               | Unpin a Reel from the Reels tab/profile Reels grid
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.3.15"
+version = "1.3.16"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -70,3 +70,27 @@ class ClientMediaCountAliasLiveTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIn("video_play_count", payload)
         self.assertEqual(media.view_count, payload["video_view_count"])
         self.assertEqual(media.play_count, payload["video_play_count"])
+
+
+class ClientClipMashupInfoLiveTestCase(unittest.IsolatedAsyncioTestCase):
+    async def live_client(self):
+        test_accounts_url = os.getenv("TEST_ACCOUNTS_URL")
+        if not test_accounts_url:
+            self.skipTest("TEST_ACCOUNTS_URL is required for clip mashup info live tests")
+        accounts = await _fetch_accounts(test_accounts_url, count=20)
+        cl = await _login_first_usable(accounts)
+        if cl is None:
+            self.skipTest("Could not login with any test account")
+        return cl
+
+    async def test_clip_mashup_info_live(self):
+        cl = await self.live_client()
+        media_pk = cl.media_pk_from_code("C_BM2yAN4Rm")
+
+        result = await cl.clip_mashup_info(media_pk)
+
+        self.assertEqual(result.get("status"), "ok")
+        mashup_info = result.get("mashup_info")
+        self.assertIsInstance(mashup_info, dict)
+        self.assertIn("is_reuse_allowed", mashup_info)
+        self.assertIn("mashups_allowed", mashup_info)

--- a/tests/regression/test_clip.py
+++ b/tests/regression/test_clip.py
@@ -61,6 +61,31 @@ def _build_media_payload():
 
 
 class ClipPinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_clip_mashup_info_posts_media_id_and_identity(self):
+        client = Client()
+        client._user_id = "29060001803"
+        client.uuid = "uuid"
+        expected = {
+            "mashup_info": {
+                "is_reuse_allowed": True,
+                "mashups_allowed": True,
+            },
+            "status": "ok",
+        }
+        client.private_request = AsyncMock(return_value=expected)
+
+        result = await client.clip_mashup_info("3894040329476845448")
+
+        assert result == expected
+        client.private_request.assert_awaited_once_with(
+            "clips/get_mashup_info_for_media/",
+            data={
+                "media_id": "3894040329476845448",
+                "_uid": "29060001803",
+                "_uuid": "uuid",
+            },
+        )
+
     async def test_clip_pin_uses_reels_grid_payload(self):
         client = Client()
         client.private_request = AsyncMock(return_value={"status": "ok"})


### PR DESCRIPTION
## Summary
- Added async `Client.clip_mashup_info(media_pk)` for Instagram's `clips/get_mashup_info_for_media/` Reel remix/reuse metadata endpoint.
- Mirrored the instagrapi helper, docs, regression coverage, and read-only live coverage.
- Bumped the package to `1.3.16` and updated changelog/upstream sync notes.

Mirrors https://github.com/subzeroid/instagrapi/pull/2636
Refs https://github.com/subzeroid/instagrapi/issues/1759

## Tests
- `.venv/bin/python -m ruff check aiograpi/mixins/clip.py tests/regression/test_clip.py tests/live/test_media.py`
- `.venv/bin/python -m pytest -q tests/regression/test_clip.py::ClipPinRegressionTestCase`
- `.venv/bin/python -m pytest -q tests/live/test_media.py::ClientClipMashupInfoLiveTestCase::test_clip_mashup_info_live`
- `./scripts/check-mypy-baseline.sh`
- `.venv/bin/python -m build`