### PR TITLE
v1.3.17 feat: add async bookmarked music helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [1.3.17] - 2026-06-13
+
+### Added
+
+- Added async `music_bookmarked(max_id="")` for retrieving bookmarked music tracks.
+
+### Changed
+
+- Synced the recorded upstream baseline to `instagrapi` 2.9.17.
+
 ## [1.3.16] - 2026-06-13
 
 ### Added

--- a/aiograpi/mixins/track.py
+++ b/aiograpi/mixins/track.py
@@ -253,6 +253,29 @@ class TrackMixin(ClientMixin):
         )
         return bool(result.get("success")) or result.get("status") == "ok"
 
+    async def music_bookmarked(self, max_id: str = "") -> Dict:
+        """
+        Retrieve bookmarked music tracks.
+
+        Parameters
+        ----------
+        max_id: str, optional
+            Pagination cursor.
+
+        Returns
+        -------
+        Dict
+            Raw response from ``music/playlist/bookmarked/``.
+        """
+        data = {"_uuid": self.uuid}
+        if max_id:
+            data["max_id"] = max_id
+        return await self.private_request(
+            "music/playlist/bookmarked/",
+            data=data,
+            with_signature=False,
+        )
+
     async def music_clips_audio_browser(
         self,
         product: str = "story_camera_clips_v2",

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -5,7 +5,7 @@
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.9.1
+instagrapi 2.9.17
 ```
 
 `aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback
@@ -32,7 +32,7 @@ challenge context handling, and clearer Reel/clip upload failure details.
 - Mention the upstream range in GitHub, PyPI, and Telegram release notes.
 
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
-`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`.
+`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`.
 
 ## Porting rules
 

--- a/docs/usage-guide/track.md
+++ b/docs/usage-guide/track.md
@@ -15,6 +15,7 @@ Viewing and downloading tracks
 | music_clips_audio_browser(product: str = "story_camera_clips_v2", browse_session_id: str = None) | Dict | Retrieve music candidates for the Reels/Clips camera
 | music_verify_original_audio_title(original_audio_name: str)             | bool        | Validate an original audio title for Reels publishing
 | music_bookmark(original_audio_id: str, surface_requested_from: str = "audio_aggregation_page") | bool | Bookmark an original audio track
+| music_bookmarked(max_id: str = "")                                      | Dict        | Retrieve bookmarked music tracks
 
 ### Example:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.3.16"
+version = "1.3.17"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/live/smoke.py
+++ b/tests/live/smoke.py
@@ -301,6 +301,7 @@ async def main():
                 {},
             ),
             ("music_trending", "music_trending", (), {}),
+            ("music_bookmarked", "music_bookmarked", (), {}),
             ("music_search_v2", "music_search_v2", ("love",), {}),
             ("music_clips_audio_browser", "music_clips_audio_browser", (), {}),
         ]

--- a/tests/live/test_track.py
+++ b/tests/live/test_track.py
@@ -1,0 +1,24 @@
+import os
+import unittest
+
+from tests.live.smoke import _fetch_accounts, _login_first_usable
+
+
+class ClientTrackLiveTestCase(unittest.IsolatedAsyncioTestCase):
+    async def live_client(self):
+        test_accounts_url = os.getenv("TEST_ACCOUNTS_URL")
+        if not test_accounts_url:
+            self.skipTest("TEST_ACCOUNTS_URL is required for track live tests")
+        accounts = await _fetch_accounts(test_accounts_url, count=20)
+        cl = await _login_first_usable(accounts)
+        if cl is None:
+            self.skipTest("Could not login with any test account")
+        return cl
+
+    async def test_music_bookmarked_live(self):
+        cl = await self.live_client()
+
+        result = await cl.music_bookmarked()
+
+        self.assertEqual(result.get("status"), "ok")
+        self.assertIsInstance(result.get("items"), list)

--- a/tests/regression/test_track.py
+++ b/tests/regression/test_track.py
@@ -94,6 +94,33 @@ class TrackMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             with_signature=False,
         )
 
+    async def test_music_bookmarked_posts_empty_payload_by_default(self):
+        client = Client()
+        client.uuid = "uuid-1"
+        client.private_request = AsyncMock(return_value={"items": [], "status": "ok"})
+
+        result = await client.music_bookmarked()
+
+        self.assertEqual(result, {"items": [], "status": "ok"})
+        client.private_request.assert_awaited_once_with(
+            "music/playlist/bookmarked/",
+            data={"_uuid": "uuid-1"},
+            with_signature=False,
+        )
+
+    async def test_music_bookmarked_forwards_max_id(self):
+        client = Client()
+        client.uuid = "uuid-1"
+        client.private_request = AsyncMock(return_value={"items": [], "status": "ok"})
+
+        await client.music_bookmarked(max_id="cursor-1")
+
+        client.private_request.assert_awaited_once_with(
+            "music/playlist/bookmarked/",
+            data={"_uuid": "uuid-1", "max_id": "cursor-1"},
+            with_signature=False,
+        )
+
     async def test_music_clips_audio_browser_posts_browse_session(self):
         client = Client()
         client.uuid = "uuid-1"


### PR DESCRIPTION
## Summary
- add async `Client.music_bookmarked(max_id="")` for `music/playlist/bookmarked/`
- document the helper and update the async upstream baseline to instagrapi 2.9.17
- add regression coverage, targeted live coverage, and smoke listing
- bump package version to 1.3.17

Mirrors https://github.com/subzeroid/instagrapi/pull/2637
Fixes https://github.com/subzeroid/instagrapi/issues/1561

## Verification
- ruff check targeted files
- pytest tests/regression/test_track.py tests/regression/test_live_smoke.py -> 15 passed
- py_compile tests/live/test_track.py tests/live/smoke.py
- scripts/check-mypy-baseline.sh -> 253/253
- python -m build
- remote targeted regression + live track suite -> 16 passed