### PR TITLE
v1.3.18 feat: add async address book suggestions helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [1.3.18] - 2026-06-13
+
+### Added
+
+- Added async `address_book_link(...)` and `address_book_unlink()` helpers for Instagram's contact-based address book suggestions surface.
+
+### Changed
+
+- Synced the recorded upstream baseline to `instagrapi` 2.9.18.
+
 ## [1.3.17] - 2026-06-13
 
 ### Added

--- a/aiograpi/mixins/user.py
+++ b/aiograpi/mixins/user.py
@@ -2453,6 +2453,52 @@ class UserMixin(ClientMixin):
             return chained
         return await self.fetch_suggestion_details(user_id, chained_ids)
 
+    async def address_book_link(self, contacts: List[dict], include: str = "extra_display_name,thumbnails") -> dict:
+        """
+        Upload/link address book contacts and return Instagram's raw suggestions response.
+
+        Parameters
+        ----------
+        contacts: List[dict]
+            Address book contacts in Instagram's mobile payload shape, for example
+            ``{"phone_numbers": [{"phone_number": "+15555550123"}],
+            "email_addresses": [], "first_name": "Test", "last_name": "Contact"}``.
+        include: str, optional
+            Optional response fields requested from Instagram. Defaults to
+            ``"extra_display_name,thumbnails"``.
+
+        Returns
+        -------
+        dict
+            Raw ``address_book/link/`` response, usually containing suggested users
+            when Instagram matches uploaded contacts.
+        """
+        data = {
+            "contacts": json.dumps(contacts, separators=(",", ":")),
+            "_uuid": self.uuid,
+        }
+        if self.user_id:
+            data["_uid"] = str(self.user_id)
+        return await self.private_request(
+            "address_book/link/",
+            data=data,
+            params={"include": include} if include else None,
+        )
+
+    async def address_book_unlink(self) -> dict:
+        """
+        Disconnect the uploaded address book from the current account.
+
+        Returns
+        -------
+        dict
+            Raw ``address_book/unlink/`` response.
+        """
+        return await self.private_request(
+            "address_book/unlink/",
+            data={"_uuid": self.uuid},
+        )
+
     async def discover_recommended_accounts_for_category_v1(self, user_id: str) -> dict:
         """
         Get business-category-similar accounts for a target user.

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -5,7 +5,7 @@
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.9.17
+instagrapi 2.9.18
 ```
 
 `aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback
@@ -32,7 +32,7 @@ challenge context handling, and clearer Reel/clip upload failure details.
 - Mention the upstream range in GitHub, PyPI, and Telegram release notes.
 
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
-`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`.
+`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`; `aiograpi 1.3.18` records the address book suggestions helper baseline through `instagrapi 2.9.18`.
 
 ## Porting rules
 

--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -36,6 +36,8 @@ View a list of a user's medias, following and followers
 | close_friend_add(user_id: str)                | bool                  | Add to Close Friends List                                    |
 | close_friend_remove(user_id: str)             | bool                  | Remove from Close Friends List                               |
 | user_suggested_profiles(user_id: str, expand_suggestion: bool = False) | dict | Suggested profiles ("Suggested for you") for a profile. Wraps `chaining` and, with `expand_suggestion=True`, returns the raw `fetch_suggestion_details` payload (`items` in current app responses) |
+| address_book_link(contacts: List[dict], include: str = "extra_display_name,thumbnails") | dict | Upload/link address book contacts and return Instagram's raw contact-based suggestions response |
+| address_book_unlink()                         | dict                  | Disconnect the uploaded address book from the current account |
 
 Low level methods:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.3.17"
+version = "1.3.18"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/live/test_address_book.py
+++ b/tests/live/test_address_book.py
@@ -1,0 +1,44 @@
+import os
+import unittest
+
+from aiograpi import Client
+from tests.live.smoke import _fetch_accounts
+
+
+class ClientAddressBookLiveTestCase(unittest.IsolatedAsyncioTestCase):
+    async def live_client(self):
+        test_accounts_url = os.getenv("TEST_ACCOUNTS_URL")
+        if not test_accounts_url:
+            self.skipTest("TEST_ACCOUNTS_URL is required for address book live tests")
+        accounts = await _fetch_accounts(test_accounts_url, count=80)
+        last_exc = None
+        for acc in accounts:
+            try:
+                cl = Client()
+                settings = dict(acc.get("client_settings") or acc.get("settings") or {})
+                settings.pop("totp_seed", None)
+                cl.set_settings(settings)
+                if acc.get("proxy"):
+                    cl.set_proxy(acc["proxy"])
+                cl._user_id = acc.get("user_id")
+                await cl.account_info()
+                return cl
+            except Exception as exc:
+                last_exc = exc
+        self.skipTest(f"No usable saved-session account returned: {last_exc}")
+
+    async def test_address_book_link_returns_suggestions_payload_live(self):
+        cl = await self.live_client()
+        self.addAsyncCleanup(cl.address_book_unlink)
+        contacts = [
+            {
+                "phone_numbers": [{"phone_number": "+15555550123"}],
+                "email_addresses": [],
+                "first_name": "Test",
+                "last_name": "Contact",
+            }
+        ]
+
+        result = await cl.address_book_link(contacts)
+
+        self.assertEqual(result.get("status"), "ok")

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -552,6 +552,59 @@ class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["radio_type"], "wifi-none")
         self.assertEqual(data["container_module"], "profile")
 
+    async def test_address_book_link_posts_contacts_payload(self):
+        client = Client()
+        client.uuid = "uuid"
+        client._user_id = "123"
+        client.private_request = AsyncMock(return_value={"users": []})
+        contacts = [
+            {
+                "phone_numbers": [{"phone_number": "+15555550123"}],
+                "email_addresses": [],
+                "first_name": "Test",
+                "last_name": "Contact",
+            }
+        ]
+
+        result = await client.address_book_link(contacts)
+
+        self.assertEqual(result, {"users": []})
+        client.private_request.assert_awaited_once_with(
+            "address_book/link/",
+            data={
+                "contacts": json.dumps(contacts, separators=(",", ":")),
+                "_uuid": "uuid",
+                "_uid": "123",
+            },
+            params={"include": "extra_display_name,thumbnails"},
+        )
+
+    async def test_address_book_link_allows_empty_include(self):
+        client = Client()
+        client.uuid = "uuid"
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        await client.address_book_link([], include="")
+
+        client.private_request.assert_awaited_once_with(
+            "address_book/link/",
+            data={"contacts": "[]", "_uuid": "uuid"},
+            params=None,
+        )
+
+    async def test_address_book_unlink_posts_uuid(self):
+        client = Client()
+        client.uuid = "uuid"
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        result = await client.address_book_unlink()
+
+        self.assertEqual(result, {"status": "ok"})
+        client.private_request.assert_awaited_once_with(
+            "address_book/unlink/",
+            data={"_uuid": "uuid"},
+        )
+
     async def test_user_stream_by_id_v1_parses_first_json_line_from_stream_response(self):
         client = Client()
         client.last_json = {}


### PR DESCRIPTION
Summary
- Mirror instagrapi address book suggestions helpers as async `Client.address_book_link(...)` and `Client.address_book_unlink()`.
- Document the helpers, bump to 1.3.18, and update the recorded upstream baseline to instagrapi 2.9.18.
- Add async regression coverage and targeted live coverage.

Mirror of https://github.com/subzeroid/instagrapi/pull/2639
Refs https://github.com/subzeroid/instagrapi/issues/1537

Verification
- `.venv/bin/python -m ruff check aiograpi/mixins/user.py tests/regression/test_user.py tests/live/test_address_book.py`
- `.venv/bin/python -m pytest -q tests/regression/test_user.py` -> 38 passed
- `.venv/bin/python -m py_compile tests/live/test_address_book.py`
- `./scripts/check-mypy-baseline.sh` -> 253/253
- `.venv/bin/python -m build`
- Targeted remote verification: `tests/regression/test_user.py` + `ClientAddressBookLiveTestCase::test_address_book_link_returns_suggestions_payload_live` -> 39 passed