### PR TITLE
Improve address book helper typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [1.3.19] - 2026-06-13
+
+### Changed
+
+- Changed async `address_book_link(...)` to accept typed `AddressBookContact` values and `include` sequences while preserving raw dict/string compatibility.
+- Synced the recorded upstream baseline to `instagrapi` 2.9.19.
+
 ## [1.3.18] - 2026-06-13
 
 ### Added

--- a/aiograpi/mixins/user.py
+++ b/aiograpi/mixins/user.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from orjson import JSONDecodeError
 
@@ -30,6 +30,7 @@ from aiograpi.extractors import (
 from aiograpi.mixins.base import ClientMixin
 from aiograpi.types import (
     About,
+    AddressBookContact,
     Guide,
     Relationship,
     RelationshipShort,
@@ -44,6 +45,7 @@ FOLLOWERS_ORDERS = ("date_followed_latest", "date_followed_earliest")
 USER_WEB_PROFILE_DOC_ID = "26762473490008061"
 USER_INFO_V2_DOC_ID = "25980296051578533"
 USER_INFO_BY_USERNAME_V2_DOC_ID = "26347858941511777"
+ADDRESS_BOOK_DEFAULT_INCLUDE = ("extra_display_name", "thumbnails")
 
 logger = logging.getLogger(__name__)
 
@@ -2453,19 +2455,37 @@ class UserMixin(ClientMixin):
             return chained
         return await self.fetch_suggestion_details(user_id, chained_ids)
 
-    async def address_book_link(self, contacts: List[dict], include: str = "extra_display_name,thumbnails") -> dict:
+    @staticmethod
+    def _serialize_address_book_contacts(contacts: List[Union[AddressBookContact, dict]]) -> List[dict]:
+        return [
+            contact.model_dump(exclude_none=True) if isinstance(contact, AddressBookContact) else contact
+            for contact in contacts
+        ]
+
+    @staticmethod
+    def _serialize_address_book_include(include: Union[str, Sequence[str]]) -> str:
+        if isinstance(include, str):
+            return include
+        return ",".join(str(field) for field in include)
+
+    async def address_book_link(
+        self,
+        contacts: List[Union[AddressBookContact, dict]],
+        include: Union[str, Sequence[str]] = ADDRESS_BOOK_DEFAULT_INCLUDE,
+    ) -> dict:
         """
         Upload/link address book contacts and return Instagram's raw suggestions response.
 
         Parameters
         ----------
-        contacts: List[dict]
-            Address book contacts in Instagram's mobile payload shape, for example
+        contacts: List[AddressBookContact | dict]
+            Address book contacts as typed objects, or raw dictionaries in
+            Instagram's mobile payload shape, for example
             ``{"phone_numbers": [{"phone_number": "+15555550123"}],
             "email_addresses": [], "first_name": "Test", "last_name": "Contact"}``.
-        include: str, optional
+        include: Sequence[str] | str, optional
             Optional response fields requested from Instagram. Defaults to
-            ``"extra_display_name,thumbnails"``.
+            ``("extra_display_name", "thumbnails")``.
 
         Returns
         -------
@@ -2473,8 +2493,9 @@ class UserMixin(ClientMixin):
             Raw ``address_book/link/`` response, usually containing suggested users
             when Instagram matches uploaded contacts.
         """
+        include_value = self._serialize_address_book_include(include)
         data = {
-            "contacts": json.dumps(contacts, separators=(",", ":")),
+            "contacts": json.dumps(self._serialize_address_book_contacts(contacts), separators=(",", ":")),
             "_uuid": self.uuid,
         }
         if self.user_id:
@@ -2482,7 +2503,7 @@ class UserMixin(ClientMixin):
         return await self.private_request(
             "address_book/link/",
             data=data,
-            params={"include": include} if include else None,
+            params={"include": include_value} if include_value else None,
         )
 
     async def address_book_unlink(self) -> dict:

--- a/aiograpi/types.py
+++ b/aiograpi/types.py
@@ -101,6 +101,21 @@ class About(TypesBaseModel):
     former_usernames: Optional[str] = ""
 
 
+class AddressBookPhone(TypesBaseModel):
+    phone_number: str
+
+
+class AddressBookEmail(TypesBaseModel):
+    email_address: str
+
+
+class AddressBookContact(TypesBaseModel):
+    phone_numbers: List[AddressBookPhone] = Field(default_factory=list)
+    email_addresses: List[AddressBookEmail] = Field(default_factory=list)
+    first_name: str = ""
+    last_name: str = ""
+
+
 class Account(TypesBaseModel):
     pk: str
     username: str

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -5,7 +5,7 @@
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.9.18
+instagrapi 2.9.19
 ```
 
 `aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback
@@ -32,7 +32,7 @@ challenge context handling, and clearer Reel/clip upload failure details.
 - Mention the upstream range in GitHub, PyPI, and Telegram release notes.
 
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
-`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`; `aiograpi 1.3.18` records the address book suggestions helper baseline through `instagrapi 2.9.18`.
+`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`; `aiograpi 1.3.18` records the address book suggestions helper baseline through `instagrapi 2.9.18`; `aiograpi 1.3.19` records the typed address book helper baseline through `instagrapi 2.9.19`.
 
 ## Porting rules
 

--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -36,7 +36,7 @@ View a list of a user's medias, following and followers
 | close_friend_add(user_id: str)                | bool                  | Add to Close Friends List                                    |
 | close_friend_remove(user_id: str)             | bool                  | Remove from Close Friends List                               |
 | user_suggested_profiles(user_id: str, expand_suggestion: bool = False) | dict | Suggested profiles ("Suggested for you") for a profile. Wraps `chaining` and, with `expand_suggestion=True`, returns the raw `fetch_suggestion_details` payload (`items` in current app responses) |
-| address_book_link(contacts: List[dict], include: str = "extra_display_name,thumbnails") | dict | Upload/link address book contacts and return Instagram's raw contact-based suggestions response |
+| address_book_link(contacts: List[AddressBookContact \| dict], include: Sequence[str] \| str = ("extra_display_name", "thumbnails")) | dict | Upload/link address book contacts and return Instagram's raw contact-based suggestions response |
 | address_book_unlink()                         | dict                  | Disconnect the uploaded address book from the current account |
 
 Low level methods:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.3.18"
+version = "1.3.19"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import AsyncMock, Mock
 
 from aiograpi import Client
+from aiograpi import types as ig_types
 from aiograpi.exceptions import ClientError, ClientGraphqlError, ClientJSONDecodeError, UserNotFound
 from aiograpi.extractors import extract_user_short, extract_user_v1
 from aiograpi.mixins.user import MAX_USER_COUNT, USER_INFO_BY_USERNAME_V2_DOC_ID, USER_INFO_V2_DOC_ID, UserMixin
@@ -590,6 +591,36 @@ class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             "address_book/link/",
             data={"contacts": "[]", "_uuid": "uuid"},
             params=None,
+        )
+
+    async def test_address_book_link_accepts_typed_contacts_and_include_list(self):
+        client = Client()
+        client.uuid = "uuid"
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+        contact = ig_types.AddressBookContact(
+            phone_numbers=[ig_types.AddressBookPhone(phone_number="+15555550123")],
+            email_addresses=[ig_types.AddressBookEmail(email_address="test@example.com")],
+            first_name="Test",
+            last_name="Contact",
+        )
+        expected_contacts = [
+            {
+                "phone_numbers": [{"phone_number": "+15555550123"}],
+                "email_addresses": [{"email_address": "test@example.com"}],
+                "first_name": "Test",
+                "last_name": "Contact",
+            }
+        ]
+
+        await client.address_book_link([contact], include=["extra_display_name", "thumbnails"])
+
+        client.private_request.assert_awaited_once_with(
+            "address_book/link/",
+            data={
+                "contacts": json.dumps(expected_contacts, separators=(",", ":")),
+                "_uuid": "uuid",
+            },
+            params={"include": "extra_display_name,thumbnails"},
         )
 
     async def test_address_book_unlink_posts_uuid(self):


### PR DESCRIPTION
## Summary
- mirror typed address-book models from instagrapi
- allow async `address_book_link(...)` to accept typed contacts or raw dicts
- allow `include` to be a sequence while preserving comma-separated string compatibility
- bump package version to 1.3.19 and sync baseline docs to instagrapi 2.9.19

Mirror of https://github.com/subzeroid/instagrapi/pull/2640.
Follow-up to https://github.com/subzeroid/instagrapi/issues/1537.

## Verification
- `.venv/bin/python -m pytest -q tests/regression/test_user.py`
- `.venv/bin/python -m ruff check aiograpi/types.py aiograpi/mixins/user.py tests/regression/test_user.py docs/usage-guide/user.md CHANGELOG.md docs/upstream-sync.md`
- `.venv/bin/python -m py_compile tests/live/test_address_book.py`
- `./scripts/check-mypy-baseline.sh`
- `.venv/bin/python -m build`
- clean-clone live verification: `40 passed` including `ClientAddressBookLiveTestCase::test_address_book_link_returns_suggestions_payload_live`