### PR TITLE
Cover typed address book helper in live test

### DIFF
--- a/tests/live/test_address_book.py
+++ b/tests/live/test_address_book.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 from aiograpi import Client
+from aiograpi import types as ig_types
 from tests.live.smoke import _fetch_accounts
 
 
@@ -31,14 +32,13 @@ class ClientAddressBookLiveTestCase(unittest.IsolatedAsyncioTestCase):
         cl = await self.live_client()
         self.addAsyncCleanup(cl.address_book_unlink)
         contacts = [
-            {
-                "phone_numbers": [{"phone_number": "+15555550123"}],
-                "email_addresses": [],
-                "first_name": "Test",
-                "last_name": "Contact",
-            }
+            ig_types.AddressBookContact(
+                phone_numbers=[ig_types.AddressBookPhone(phone_number="+15555550123")],
+                first_name="Test",
+                last_name="Contact",
+            )
         ]
 
-        result = await cl.address_book_link(contacts)
+        result = await cl.address_book_link(contacts, include=["extra_display_name", "thumbnails"])
 
         self.assertEqual(result.get("status"), "ok")


### PR DESCRIPTION
## Summary
- mirror the address-book live test update from instagrapi
- run the async live test through `AddressBookContact` / `AddressBookPhone`
- pass `include` as a list so live coverage exercises the public typed API added in 1.3.19

Mirror of https://github.com/subzeroid/instagrapi/pull/2641.
Follow-up to https://github.com/subzeroid/instagrapi/issues/1537.

## Verification
- `.venv/bin/python -m ruff check tests/live/test_address_book.py`
- `.venv/bin/python -m py_compile tests/live/test_address_book.py`
- clean-clone live verification: `1 passed` for `ClientAddressBookLiveTestCase::test_address_book_link_returns_suggestions_payload_live`