### PR TITLE
Normalize challenge API paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [1.4.0] - 2026-06-13
+
+### Fixed
+
+- Normalized challenge `api_path` values that already include `/api/` or `/api/v1/` so login challenge resolution does not request `/api/v1/api/challenge/...`.
+
+### Changed
+
+- Synced the recorded upstream baseline to `instagrapi` 2.10.0.
+
 ## [1.3.19] - 2026-06-13
 
 ### Changed

--- a/aiograpi/mixins/challenge.py
+++ b/aiograpi/mixins/challenge.py
@@ -46,6 +46,14 @@ class ChallengeResolveMixin(ClientMixin):
     Helpers for resolving login challenge
     """
 
+    @staticmethod
+    def _normalize_challenge_api_path(api_path: str) -> str:
+        if api_path.startswith("/api/v1/"):
+            return api_path[len("/api/v1") :]
+        if api_path.startswith("/api/"):
+            return api_path[len("/api") :]
+        return api_path
+
     def __init__(self, with_challenge_flow: bool = False, *args, **kwargs):
         self.with_challenge_flow = with_challenge_flow
         super().__init__(*args, **kwargs)
@@ -91,7 +99,7 @@ class ChallengeResolveMixin(ClientMixin):
             A boolean value
         """
         # START GET REQUEST to challenge_url
-        challenge_url = last_json["challenge"]["api_path"]
+        challenge_url = self._normalize_challenge_api_path(last_json["challenge"]["api_path"])
         if challenge_url.startswith("/auth_platform/"):
             last_json["message"] = (
                 "Manual verification required via Instagram auth platform flow. "
@@ -119,7 +127,7 @@ class ChallengeResolveMixin(ClientMixin):
             # not enough values to unpack (expected 2, got 1)
             params = {}
         try:
-            await self._send_private_request(challenge_url[1:], params=params)
+            await self._send_private_request(challenge_url.lstrip("/"), params=params)
         except ChallengeRequired:
             assert self.last_json["message"] == "challenge_required", self.last_json
             return await self.challenge_resolve_contact_form(challenge_url)

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -5,7 +5,7 @@
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.9.19
+instagrapi 2.10.0
 ```
 
 `aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback
@@ -32,7 +32,7 @@ challenge context handling, and clearer Reel/clip upload failure details.
 - Mention the upstream range in GitHub, PyPI, and Telegram release notes.
 
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
-`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`; `aiograpi 1.3.18` records the address book suggestions helper baseline through `instagrapi 2.9.18`; `aiograpi 1.3.19` records the typed address book helper baseline through `instagrapi 2.9.19`.
+`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`; `aiograpi 1.3.18` records the address book suggestions helper baseline through `instagrapi 2.9.18`; `aiograpi 1.3.19` records the typed address book helper baseline through `instagrapi 2.9.19`; `aiograpi 1.4.0` records the challenge api-path normalization baseline through `instagrapi 2.10.0`.
 
 ## Porting rules
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.3.19"
+version = "1.4.0"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/regression/test_challenge.py
+++ b/tests/regression/test_challenge.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import AsyncMock
+
+from aiograpi import Client
+
+
+class ChallengeRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_challenge_resolve_normalizes_prefixed_api_challenge_path(self):
+        client = Client()
+        client.uuid = "uuid-1"
+        client.android_device_id = "android-1"
+        client._send_private_request = AsyncMock()
+        client.challenge_resolve_simple = AsyncMock(return_value=True)
+        last_json = {
+            "message": "challenge_required",
+            "challenge": {"api_path": "/api/challenge/12345/nonce-code/"},
+            "status": "fail",
+        }
+
+        result = await client.challenge_resolve(last_json)
+
+        self.assertTrue(result)
+        self.assertEqual(client._send_private_request.call_args.args[0], "challenge/12345/nonce-code/")
+        client.challenge_resolve_simple.assert_awaited_once_with("/challenge/12345/nonce-code/")
+
+    async def test_challenge_resolve_normalizes_prefixed_api_v1_challenge_path(self):
+        client = Client()
+        client.uuid = "uuid-1"
+        client.android_device_id = "android-1"
+        client._send_private_request = AsyncMock()
+        client.challenge_resolve_simple = AsyncMock(return_value=True)
+        last_json = {
+            "message": "challenge_required",
+            "challenge": {"api_path": "/api/v1/challenge/12345/nonce-code/"},
+            "status": "fail",
+        }
+
+        result = await client.challenge_resolve(last_json)
+
+        self.assertTrue(result)
+        self.assertEqual(client._send_private_request.call_args.args[0], "challenge/12345/nonce-code/")
+        client.challenge_resolve_simple.assert_awaited_once_with("/challenge/12345/nonce-code/")


### PR DESCRIPTION
## Summary
- mirror challenge `api_path` normalization from instagrapi
- prevent challenge resolution from requesting `/api/v1/api/challenge/...`
- keep the Bloks redirect checkpoint surfaced as clear `ChallengeRequired`
- bump package version to 1.4.0 and sync baseline docs to instagrapi 2.10.0

Mirror of https://github.com/subzeroid/instagrapi/pull/2642.
Fixes https://github.com/subzeroid/instagrapi/issues/2638.

## Verification
- `.venv/bin/python -m pytest -q tests/regression/test_challenge.py`
- `.venv/bin/python -m pytest -q tests/regression/test_challenge.py tests/regression/test_bloks.py tests/regression/test_private.py tests/regression/test_auth.py`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m ruff check aiograpi/mixins/challenge.py tests/regression/test_challenge.py CHANGELOG.md docs/upstream-sync.md pyproject.toml`
- `./scripts/check-mypy-baseline.sh`
- `.venv/bin/python -m build`
- clean-clone regression verification on remote test host: `34 passed` for challenge/private/auth/bloks regression subset