### PR TITLE
Handle missing canonical track info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [1.4.1] - 2026-06-13
+
+### Fixed
+
+- Raised `TrackNotFound` from `track_info_by_canonical_id(...)` when Instagram omits `music_asset_info`, instead of letting `extract_track(None)` raise `AttributeError`.
+
+### Changed
+
+- Synced the recorded upstream baseline to `instagrapi` 2.10.1.
+
 ## [1.4.0] - 2026-06-13
 
 ### Fixed

--- a/aiograpi/mixins/track.py
+++ b/aiograpi/mixins/track.py
@@ -389,6 +389,8 @@ class TrackMixin(ClientMixin):
         }
         result = await self._track_request(data)
         track = json_value(result, "metadata", "music_info", "music_asset_info")
+        if not track:
+            raise TrackNotFound(music_canonical_id=str(music_canonical_id))
         return extract_track(track)
 
     async def track_info_by_id(self, track_id: str, max_id: str = "") -> Dict:

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -5,7 +5,7 @@
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.10.0
+instagrapi 2.10.1
 ```
 
 `aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback
@@ -32,7 +32,7 @@ challenge context handling, and clearer Reel/clip upload failure details.
 - Mention the upstream range in GitHub, PyPI, and Telegram release notes.
 
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
-`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`; `aiograpi 1.3.18` records the address book suggestions helper baseline through `instagrapi 2.9.18`; `aiograpi 1.3.19` records the typed address book helper baseline through `instagrapi 2.9.19`; `aiograpi 1.4.0` records the challenge api-path normalization baseline through `instagrapi 2.10.0`.
+`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`; `aiograpi 1.3.18` records the address book suggestions helper baseline through `instagrapi 2.9.18`; `aiograpi 1.3.19` records the typed address book helper baseline through `instagrapi 2.9.19`; `aiograpi 1.4.0` records the challenge api-path normalization baseline through `instagrapi 2.10.0`; `aiograpi 1.4.1` records the canonical track not-found baseline through `instagrapi 2.10.1`.
 
 ## Porting rules
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.4.0"
+version = "1.4.1"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/live/test_track.py
+++ b/tests/live/test_track.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+from aiograpi.exceptions import TrackNotFound
 from tests.live.smoke import _fetch_accounts, _login_first_usable
 
 
@@ -22,3 +23,11 @@ class ClientTrackLiveTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result.get("status"), "ok")
         self.assertIsInstance(result.get("items"), list)
+
+    async def test_track_info_by_canonical_id_missing_live(self):
+        cl = await self.live_client()
+
+        with self.assertRaises(TrackNotFound) as cm:
+            await cl.track_info_by_canonical_id("0")
+
+        self.assertEqual(cm.exception.music_canonical_id, "0")

--- a/tests/regression/test_track.py
+++ b/tests/regression/test_track.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiograpi import Client
+from aiograpi.exceptions import TrackNotFound
 
 
 class TrackMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
@@ -152,6 +153,26 @@ class TrackMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             "music/verify_original_audio_title/",
             data={"original_audio_name": "Original Audio", "_uuid": "uuid-1"},
             with_signature=False,
+        )
+
+    async def test_track_info_by_canonical_id_raises_track_not_found_when_music_asset_missing(self):
+        client = Client()
+        client.uuid = "uuid-1"
+        client._track_request = AsyncMock(
+            return_value={"metadata": {"music_info": {"music_asset_info": None}}, "status": "ok"}
+        )
+
+        with self.assertRaises(TrackNotFound) as cm:
+            await client.track_info_by_canonical_id("18159860503036324")
+
+        self.assertEqual(cm.exception.music_canonical_id, "18159860503036324")
+        client._track_request.assert_awaited_once_with(
+            {
+                "tab_type": "clips",
+                "referrer_media_id": "",
+                "_uuid": "uuid-1",
+                "music_canonical_id": "18159860503036324",
+            }
         )
 
     async def test_track_download_by_url_uses_httpx_request(self):


### PR DESCRIPTION
## Summary
- Mirror https://github.com/subzeroid/instagrapi/pull/2643 for the async client.
- Raise `TrackNotFound(music_canonical_id=...)` when `track_info_by_canonical_id(...)` receives a successful `clips/music/` response without `metadata.music_info.music_asset_info`.
- Add async regression and live coverage, update the upstream sync baseline, and bump the package version to 1.4.1.

Related: https://github.com/subzeroid/instagrapi/issues/1340

## Tests
- `.venv/bin/python -m ruff check aiograpi/mixins/track.py tests/regression/test_track.py tests/live/test_track.py CHANGELOG.md docs/upstream-sync.md pyproject.toml`
- `.venv/bin/python -m pytest -q tests/regression` (345 passed, 3 skipped, 4 subtests passed)
- `./scripts/check-mypy-baseline.sh` (253/253)
- `.venv/bin/python -m build`
- Clean-clone verification: `pytest -q tests/regression/test_track.py tests/live/test_track.py -rs` (12 passed, 1 skipped)
- Clean-clone targeted live verification: `pytest -q tests/live/test_track.py::ClientTrackLiveTestCase::test_track_info_by_canonical_id_missing_live -rs` (1 passed)