### PR TITLE
Normalize XDT sidecar media resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [1.4.2] - 2026-06-13
+
+### Fixed
+
+- Normalized XDT GraphQL media typenames for `media_info_gql(...)` sidecar children so doc_id fallback responses with `XDTGraphImage`/`XDTGraphVideo` resources no longer raise `KeyError`.
+
+### Changed
+
+- Synced the recorded upstream baseline to `instagrapi` 2.10.2.
+
 ## [1.4.1] - 2026-06-13
 
 ### Fixed

--- a/aiograpi/extractors.py
+++ b/aiograpi/extractors.py
@@ -45,6 +45,15 @@ from .utils import InstagramIdCodec, json_value
 logger = logging.getLogger(__name__)
 
 MEDIA_TYPES_GQL = {"GraphImage": 1, "GraphVideo": 2, "GraphSidecar": 8, "StoryVideo": 2}
+XDT_MEDIA_TYPES_GQL = {
+    "XDTGraphImage": "GraphImage",
+    "XDTGraphVideo": "GraphVideo",
+    "XDTGraphSidecar": "GraphSidecar",
+}
+
+
+def _normalize_media_gql_typename(data):
+    data["__typename"] = XDT_MEDIA_TYPES_GQL.get(data.get("__typename"), data.get("__typename"))
 
 
 def extract_media_v1(data):
@@ -114,6 +123,7 @@ def extract_media_v1_xma(data):
 def extract_media_gql(data):
     """Extract media from GraphQL"""
     media = deepcopy(data)
+    _normalize_media_gql_typename(media)
     user = extract_user_short(media["owner"])
     # if "full_name" in user:
     #     user = extract_user_short(user)
@@ -193,6 +203,8 @@ def extract_resource_v1(data):
 
 
 def extract_resource_gql(data):
+    data = deepcopy(data)
+    _normalize_media_gql_typename(data)
     data["media_type"] = MEDIA_TYPES_GQL[data["__typename"]]
     return Resource(pk=data["id"], thumbnail_url=data["display_url"], **data)
 

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -5,7 +5,7 @@
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.10.1
+instagrapi 2.10.2
 ```
 
 `aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback
@@ -32,7 +32,7 @@ challenge context handling, and clearer Reel/clip upload failure details.
 - Mention the upstream range in GitHub, PyPI, and Telegram release notes.
 
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
-`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`; `aiograpi 1.3.18` records the address book suggestions helper baseline through `instagrapi 2.9.18`; `aiograpi 1.3.19` records the typed address book helper baseline through `instagrapi 2.9.19`; `aiograpi 1.4.0` records the challenge api-path normalization baseline through `instagrapi 2.10.0`; `aiograpi 1.4.1` records the canonical track not-found baseline through `instagrapi 2.10.1`.
+`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`; `aiograpi 1.3.18` records the address book suggestions helper baseline through `instagrapi 2.9.18`; `aiograpi 1.3.19` records the typed address book helper baseline through `instagrapi 2.9.19`; `aiograpi 1.4.0` records the challenge api-path normalization baseline through `instagrapi 2.10.0`; `aiograpi 1.4.1` records the canonical track not-found baseline through `instagrapi 2.10.1`; `aiograpi 1.4.2` records the XDT sidecar media-info baseline through `instagrapi 2.10.2`.
 
 ## Porting rules
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.4.1"
+version = "1.4.2"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -71,6 +71,15 @@ class ClientMediaCountAliasLiveTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(media.view_count, payload["video_view_count"])
         self.assertEqual(media.play_count, payload["video_play_count"])
 
+    async def test_media_info_gql_normalizes_live_xdt_sidecar_children(self):
+        code = "Cu59OMFPQde"
+        media, payload = await self.live_media(code)
+
+        self.assertIn(payload.get("__typename"), {"GraphSidecar", "XDTGraphSidecar"})
+        self.assertEqual(media.media_type, 8)
+        self.assertGreaterEqual(len(media.resources), 1)
+        self.assertTrue(all(resource.media_type in {1, 2} for resource in media.resources))
+
 
 class ClientClipMashupInfoLiveTestCase(unittest.IsolatedAsyncioTestCase):
     async def live_client(self):

--- a/tests/regression/test_media_pagination.py
+++ b/tests/regression/test_media_pagination.py
@@ -265,6 +265,52 @@ class MediaInfoGraphQLRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         )
         assert media.pk == "1"
 
+    async def test_media_info_gql_normalizes_xdt_sidecar_children(self):
+        client = Client()
+        child_payload = {
+            "__typename": "XDTGraphImage",
+            "id": "3150818668564738953",
+            "shortcode": "Cu59OMFPQde",
+            "display_url": "https://example.com/child.jpg",
+            "edge_media_to_tagged_user": {"edges": []},
+        }
+        media_payload = {
+            "__typename": "XDTGraphSidecar",
+            "id": "3150818670205011806",
+            "shortcode": "Cu59OMFPQde",
+            "taken_at_timestamp": 1690160400,
+            "owner": {
+                "id": "1903424587",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "display_resources": [
+                {
+                    "src": "https://example.com/thumbnail.jpg",
+                    "config_width": 360,
+                    "config_height": 640,
+                }
+            ],
+            "is_video": False,
+            "edge_media_preview_comment": {"count": 3, "edges": []},
+            "edge_media_preview_like": {"count": -1, "edges": []},
+            "edge_media_to_caption": {"edges": [{"node": {"text": "caption"}}]},
+            "edge_media_to_tagged_user": {"edges": []},
+            "edge_media_to_sponsor_user": {"edges": []},
+            "edge_sidecar_to_children": {"edges": [{"node": child_payload}]},
+            "viewer_has_liked": False,
+        }
+        client.public_graphql_request = AsyncMock(side_effect=ClientForbiddenError("blocked"))
+        client.public_doc_id_graphql_request = AsyncMock(return_value={"xdt_shortcode_media": media_payload})
+
+        media = await client.media_info_gql("3150818670205011806")
+
+        assert media.media_type == 8
+        assert media.pk == "3150818670205011806"
+        assert len(media.resources) == 1
+        assert media.resources[0].media_type == 1
+        assert str(media.resources[0].thumbnail_url) == "https://example.com/child.jpg"
+
 
 class MediaLikersGraphQLRegressionTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_media_likers_gql_chunk_posts_doc_id_query(self):


### PR DESCRIPTION
## Summary
- Mirror https://github.com/subzeroid/instagrapi/pull/2644 for the async client.
- Normalize XDT GraphQL media typenames before extracting both top-level media and sidecar resources.
- Fix async `media_info_gql(...)` doc_id fallback responses where `XDTGraphSidecar` contains `XDTGraphImage`/`XDTGraphVideo` children.
- Add async regression/live coverage, update the upstream sync baseline, and bump the package version to 1.4.2.

Related: https://github.com/subzeroid/instagrapi/issues/1481

## Tests
- `.venv/bin/python -m ruff check aiograpi/extractors.py tests/regression/test_media_pagination.py tests/live/test_media.py CHANGELOG.md docs/upstream-sync.md pyproject.toml`
- `.venv/bin/python -m pytest -q tests/regression/test_media_pagination.py::MediaInfoGraphQLRegressionTestCase::test_media_info_gql_normalizes_xdt_sidecar_children tests/regression/test_media_pagination.py::MediaInfoGraphQLRegressionTestCase::test_media_info_gql_falls_back_to_doc_id_endpoint`
- `.venv/bin/python -m pytest -q tests/regression/test_media_pagination.py tests/regression/test_media.py` (27 passed, 2 subtests passed)
- `.venv/bin/python -m pytest -q tests/regression` (346 passed, 3 skipped, 4 subtests passed)
- `./scripts/check-mypy-baseline.sh` (253/253)
- `.venv/bin/python -m build`
- Clean-clone verification: `pytest -q tests/regression/test_media_pagination.py::MediaInfoGraphQLRegressionTestCase::test_media_info_gql_normalizes_xdt_sidecar_children tests/live/test_media.py::ClientMediaCountAliasLiveTestCase::test_media_info_gql_normalizes_live_xdt_sidecar_children -rs` (2 passed)