### PR TITLE
Map account edit failures to typed exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [1.4.3] - 2026-06-13
+
+### Fixed
+
+- Raised `AccountEditError` for `accounts/edit_profile/` failures, with the more specific `AccountContactPointRequired` when Instagram requires an email or confirmed phone number, instead of surfacing these profile-edit responses as generic unknown/status-fail errors.
+
+### Changed
+
+- Synced the recorded upstream baseline to `instagrapi` 2.10.3.
+
 ## [1.4.2] - 2026-06-13
 
 ### Fixed

--- a/aiograpi/exceptions.py
+++ b/aiograpi/exceptions.py
@@ -186,6 +186,14 @@ class UnknownError(PrivateError):
     pass
 
 
+class AccountEditError(PrivateError):
+    pass
+
+
+class AccountContactPointRequired(AccountEditError):
+    pass
+
+
 class TrackNotFound(NotFoundError):
     pass
 

--- a/aiograpi/mixins/private.py
+++ b/aiograpi/mixins/private.py
@@ -8,6 +8,8 @@ import orjson
 
 from aiograpi import config, httpx_ext
 from aiograpi.exceptions import (
+    AccountContactPointRequired,
+    AccountEditError,
     AuthRequiredProxyError,
     BadPassword,
     ChallengeRequired,
@@ -59,6 +61,30 @@ _DIRECT_MESSAGE_REQUESTS_DISABLED_MARKERS = (
     "don't allow new message requests",
     "does not allow new message requests",
 )
+
+_ACCOUNT_CONTACT_POINT_REQUIRED_MARKERS = ("need an email or confirmed phone number",)
+
+
+def _private_message_text(message) -> str:
+    if isinstance(message, dict):
+        errors = message.get("errors")
+        if isinstance(errors, (list, tuple)):
+            return " ".join(str(error) for error in errors)
+        return " ".join(str(value) for value in message.values())
+    if isinstance(message, (list, tuple)):
+        return " ".join(str(item) for item in message)
+    return str(message or "")
+
+
+def _is_account_contact_point_required(endpoint: str, message) -> bool:
+    if not endpoint or "accounts/edit_profile" not in endpoint:
+        return False
+    normalized = _private_message_text(message).casefold()
+    return any(marker in normalized for marker in _ACCOUNT_CONTACT_POINT_REQUIRED_MARKERS)
+
+
+def _is_account_edit_error(endpoint: str) -> bool:
+    return bool(endpoint and "accounts/edit_profile" in endpoint)
 
 
 def _is_direct_message_requests_disabled(endpoint: str, message: str) -> bool:
@@ -576,6 +602,10 @@ class PrivateRequestMixin(ClientMixin):
                     if not last_json.get("message"):
                         last_json["message"] = "Two-factor authentication required"
                     raise TwoFactorRequired(**last_json)
+                elif _is_account_contact_point_required(endpoint, message):
+                    raise AccountContactPointRequired(e, response=response, **last_json)
+                elif _is_account_edit_error(endpoint):
+                    raise AccountEditError(e, response=response, **last_json)
                 elif _is_direct_message_requests_disabled(endpoint, message):
                     raise DirectMessageRequestsDisabled(e, response=response, **last_json)
                 elif "Please wait a few minutes before you try again" in message:
@@ -648,6 +678,10 @@ class PrivateRequestMixin(ClientMixin):
             self.last_response_ts = time.time()
         if last_json.get("status") == "fail":
             message = last_json.get("message", "")
+            if _is_account_contact_point_required(endpoint, message):
+                raise AccountContactPointRequired(response=response, **last_json)
+            if _is_account_edit_error(endpoint):
+                raise AccountEditError(response=response, **last_json)
             if _is_direct_message_requests_disabled(endpoint, message):
                 raise DirectMessageRequestsDisabled(response=response, **last_json)
             raise ClientStatusFail(response=response, **last_json)

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -53,6 +53,8 @@
 | BadPassword              | PrivateError | Raises when get message=bad_password
 | TwoFactorRequired        | PrivateError | Raises when get message=two_factor_required
 | UnknownError             | PrivateError | Raises when get unknown message (new message from instagram)
+| AccountEditError         | PrivateError | Raises when `accounts/edit_profile/` returns an account edit failure
+| AccountContactPointRequired | AccountEditError | Raises when profile editing requires an email or confirmed phone number
 | BadCredentials           | PrivateError | The login and password pair for your account have not been passed
 | IsRegulatedC18Error      | ClientBadRequestError | The user is limited to 18+
 

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -5,7 +5,7 @@
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.10.2
+instagrapi 2.10.3
 ```
 
 `aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback
@@ -32,7 +32,7 @@ challenge context handling, and clearer Reel/clip upload failure details.
 - Mention the upstream range in GitHub, PyPI, and Telegram release notes.
 
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
-`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`; `aiograpi 1.3.18` records the address book suggestions helper baseline through `instagrapi 2.9.18`; `aiograpi 1.3.19` records the typed address book helper baseline through `instagrapi 2.9.19`; `aiograpi 1.4.0` records the challenge api-path normalization baseline through `instagrapi 2.10.0`; `aiograpi 1.4.1` records the canonical track not-found baseline through `instagrapi 2.10.1`; `aiograpi 1.4.2` records the XDT sidecar media-info baseline through `instagrapi 2.10.2`.
+`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`; `aiograpi 1.3.18` records the address book suggestions helper baseline through `instagrapi 2.9.18`; `aiograpi 1.3.19` records the typed address book helper baseline through `instagrapi 2.9.19`; `aiograpi 1.4.0` records the challenge api-path normalization baseline through `instagrapi 2.10.0`; `aiograpi 1.4.1` records the canonical track not-found baseline through `instagrapi 2.10.1`; `aiograpi 1.4.2` records the XDT sidecar media-info baseline through `instagrapi 2.10.2`; `aiograpi 1.4.3` records the account-edit exception mapping baseline through `instagrapi 2.10.3`.
 
 ## Porting rules
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.4.2"
+version = "1.4.3"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/regression/test_private.py
+++ b/tests/regression/test_private.py
@@ -3,7 +3,12 @@ import unittest
 from unittest.mock import AsyncMock, Mock
 
 from aiograpi import Client, httpx_ext
-from aiograpi.exceptions import ClientNotFoundError, DirectMessageRequestsDisabled
+from aiograpi.exceptions import (
+    AccountContactPointRequired,
+    AccountEditError,
+    ClientNotFoundError,
+    DirectMessageRequestsDisabled,
+)
 
 
 class PrivateRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
@@ -44,6 +49,60 @@ class PrivateRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             await client._send_private_request(
                 "direct_v2/threads/broadcast/text/",
                 data={"text": "hi"},
+                with_signature=False,
+            )
+
+        self.assertEqual(cm.exception.message, payload["message"])
+        self.assertEqual(cm.exception.status, "fail")
+
+    async def test_send_private_request_promotes_account_edit_contact_point_required_http_error(self):
+        client = self._build_client()
+        payload = {
+            "message": {"errors": ["You need an email or confirmed phone number."]},
+            "status": "fail",
+        }
+        client.private.post = AsyncMock(return_value=self._response(payload, status_code=400))
+
+        with self.assertRaises(AccountContactPointRequired) as cm:
+            await client._send_private_request(
+                "accounts/edit_profile/",
+                data={"external_url": ""},
+                with_signature=False,
+            )
+
+        self.assertEqual(cm.exception.message, payload["message"])
+        self.assertEqual(cm.exception.status, "fail")
+
+    async def test_send_private_request_promotes_account_edit_contact_point_required_status_fail(self):
+        client = self._build_client()
+        payload = {
+            "message": {"errors": ["You need an email or confirmed phone number."]},
+            "status": "fail",
+        }
+        client.private.post = AsyncMock(return_value=self._response(payload))
+
+        with self.assertRaises(AccountContactPointRequired) as cm:
+            await client._send_private_request(
+                "accounts/edit_profile/",
+                data={"external_url": ""},
+                with_signature=False,
+            )
+
+        self.assertEqual(cm.exception.message, payload["message"])
+        self.assertEqual(cm.exception.status, "fail")
+
+    async def test_send_private_request_promotes_account_edit_unknown_server_error(self):
+        client = self._build_client()
+        payload = {
+            "message": "Unknown Server Error.",
+            "status": "fail",
+        }
+        client.private.post = AsyncMock(return_value=self._response(payload, status_code=400))
+
+        with self.assertRaises(AccountEditError) as cm:
+            await client._send_private_request(
+                "accounts/edit_profile/",
+                data={"external_url": ""},
                 with_signature=False,
             )
 


### PR DESCRIPTION
## Summary

- mirror the instagrapi account-edit exception mapping in async private requests
- add `AccountEditError` and `AccountContactPointRequired`
- document the new exceptions, update the sync baseline, and bump the package to 1.4.3

Mirrors https://github.com/subzeroid/instagrapi/pull/2645
Related to https://github.com/subzeroid/instagrapi/issues/1358

## Verification

- `python -m ruff check aiograpi/exceptions.py aiograpi/mixins/private.py tests/regression/test_private.py`
- `python -m pytest -q tests/regression/test_private.py`
- `python -m pytest -q tests/regression`
- `./scripts/check-mypy-baseline.sh`
- `python -m build`
- sk.test targeted regression: account-edit typed exception tests passed
