### PR TITLE
Cover UserShort stories field in story lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [1.4.4] - 2026-06-14
+
+### Fixed
+
+- Added regression coverage for bulk public story lookups so `users_stories_gql(...)` continues to populate `UserShort.stories` instead of losing story items for users discovered from comments.
+
+### Changed
+
+- Synced the recorded upstream baseline to `instagrapi` 2.10.4.
+
 ## [1.4.3] - 2026-06-13
 
 ### Fixed

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -5,7 +5,7 @@
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.10.3
+instagrapi 2.10.4
 ```
 
 `aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback
@@ -32,7 +32,7 @@ challenge context handling, and clearer Reel/clip upload failure details.
 - Mention the upstream range in GitHub, PyPI, and Telegram release notes.
 
 For the 2026-05 sync, the public releases are `aiograpi 0.9.0` and newer.
-`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`; `aiograpi 1.3.18` records the address book suggestions helper baseline through `instagrapi 2.9.18`; `aiograpi 1.3.19` records the typed address book helper baseline through `instagrapi 2.9.19`; `aiograpi 1.4.0` records the challenge api-path normalization baseline through `instagrapi 2.10.0`; `aiograpi 1.4.1` records the canonical track not-found baseline through `instagrapi 2.10.1`; `aiograpi 1.4.2` records the XDT sidecar media-info baseline through `instagrapi 2.10.2`; `aiograpi 1.4.3` records the account-edit exception mapping baseline through `instagrapi 2.10.3`.
+`aiograpi 0.9.0` synced through `instagrapi 2.5.18`, and subsequent `aiograpi 0.9.x` patch releases continued that baseline through `instagrapi 2.6.8`, plus targeted maintenance ports. `aiograpi 1.0.x` recorded the SemVer async baseline through `instagrapi 2.7.17`; `aiograpi 1.1.0` records the MQTT/FBNS baseline through `instagrapi 2.8.2`; `aiograpi 1.2.x` records the follow-up high-level/private-first, Reel Facebook destination, hashtag, metadata, and private incomplete-read retry baseline through `instagrapi 2.8.19`; `aiograpi 1.3.0` records the CAA signup baseline through `instagrapi 2.9.0`; `aiograpi 1.3.1` records the suggested-profiles helper baseline through `instagrapi 2.9.1`; `aiograpi 1.3.16` records the Reel mashup-info helper baseline through `instagrapi 2.9.16`; `aiograpi 1.3.17` records the bookmarked music helper baseline through `instagrapi 2.9.17`; `aiograpi 1.3.18` records the address book suggestions helper baseline through `instagrapi 2.9.18`; `aiograpi 1.3.19` records the typed address book helper baseline through `instagrapi 2.9.19`; `aiograpi 1.4.0` records the challenge api-path normalization baseline through `instagrapi 2.10.0`; `aiograpi 1.4.1` records the canonical track not-found baseline through `instagrapi 2.10.1`; `aiograpi 1.4.2` records the XDT sidecar media-info baseline through `instagrapi 2.10.2`; `aiograpi 1.4.3` records the account-edit exception mapping baseline through `instagrapi 2.10.3`; `aiograpi 1.4.4` records the `UserShort.stories` regression baseline through `instagrapi 2.10.4`.
 
 ## Porting rules
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.4.3"
+version = "1.4.4"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/regression/test_story.py
+++ b/tests/regression/test_story.py
@@ -35,3 +35,32 @@ class StoryMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         stories = await client._user_stories_public("123", amount=1)
 
         self.assertEqual(stories, [])
+
+    async def test_users_stories_gql_populates_user_short_stories(self):
+        client = Client()
+        story_payload = {
+            "id": "1234567890",
+            "owner": {
+                "id": "123",
+                "username": "alice",
+                "full_name": "Alice",
+                "profile_pic_url": "https://example.com/alice.jpg",
+                "is_private": False,
+            },
+            "display_url": "https://example.com/story.jpg",
+            "taken_at_timestamp": 1_700_000_000,
+            "is_video": False,
+            "tappable_objects": [],
+            "edge_media_to_sponsor_user": {"edges": []},
+        }
+
+        client.public_graphql_request = AsyncMock(
+            return_value={"reels_media": [{"owner": story_payload["owner"], "items": [story_payload]}]}
+        )
+
+        users = await client.users_stories_gql(["123"])
+
+        self.assertEqual(len(users), 1)
+        self.assertEqual(users[0].pk, "123")
+        self.assertEqual(len(users[0].stories), 1)
+        self.assertEqual(users[0].stories[0].id, "1234567890_123")


### PR DESCRIPTION
Mirrors https://github.com/subzeroid/instagrapi/pull/2646

## Summary
- add async regression coverage for `users_stories_gql(...)` populating `UserShort.stories`
- bump package version to 1.4.4
- record the upstream baseline as `instagrapi` 2.10.4

## Verification
- `.venv/bin/python -m pytest -q tests/regression/test_story.py`
- `.venv/bin/python -m ruff check aiograpi/types.py tests/regression/test_story.py pyproject.toml CHANGELOG.md docs/upstream-sync.md`
- `.venv/bin/python -m pytest -q tests/regression`
- `./scripts/check-mypy-baseline.sh`
- `.venv/bin/python -m build`
