### PR TITLE
test: add fbsearch suggested profiles live coverage

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,6 +17,7 @@ on:
         options:
           - smoke
           - comment
+          - fbsearch
           - realtime
           - signup
           - all
@@ -193,6 +194,14 @@ jobs:
             exit 0
           fi
           PYTHONPATH=. pytest -sv tests/legacy.py::ClientCommentExtendTestCase::test_media_comment
+      - name: Run fbsearch live test
+        if: github.event_name == 'workflow_dispatch' && (github.event.inputs.test_target == 'fbsearch' || github.event.inputs.test_target == 'all')
+        run: |
+          if [ -z "${TEST_ACCOUNTS_URL}" ]; then
+            echo "SKIP: TEST_ACCOUNTS_URL secret is not configured"
+            exit 0
+          fi
+          PYTHONPATH=. pytest -sv tests/live/test_fbsearch.py::ClientFbSearchLiveTestCase
       - name: Run realtime MQTT live tests
         if: github.event_name == 'workflow_dispatch' && (github.event.inputs.test_target == 'realtime' || github.event.inputs.test_target == 'all')
         run: PYTHONPATH=. pytest -sv tests/live/test_realtime.py::ClientRealtimeLiveTestCase tests/live/test_fbns.py::ClientFbnsLiveTestCase

--- a/tests/live/smoke.py
+++ b/tests/live/smoke.py
@@ -23,6 +23,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from aiograpi import Client
+from aiograpi.types import UserShort
 from tests.live.auth_helpers import login_with_timeout
 
 
@@ -164,6 +165,16 @@ async def main():
         except Exception as e:
             failures.append(("user_followers_extended_fields", e))
             print(f"REQ user_followers_extended_fields FAIL: {type(e).__name__}: {str(e)[:140]}")
+
+        try:
+            suggested = await cl.fbsearch_suggested_profiles("25025320")
+            assert suggested
+            assert isinstance(suggested[0], UserShort)
+            assert isinstance(suggested[0].stories, list)
+            print(f"REQ fbsearch_suggested_profiles: {_summarize(suggested)}")
+        except Exception as e:
+            failures.append(("fbsearch_suggested_profiles", e))
+            print(f"REQ fbsearch_suggested_profiles FAIL: {type(e).__name__}: {str(e)[:140]}")
 
     # OPTIONAL: chapi-ported endpoints — record but don't fail
     if cl is not None:

--- a/tests/live/test_fbsearch.py
+++ b/tests/live/test_fbsearch.py
@@ -1,0 +1,29 @@
+import os
+import unittest
+
+from aiograpi.types import UserShort
+from tests.live.smoke import _fetch_accounts, _login_first_usable
+
+INSTAGRAM_USER_ID = "25025320"
+
+
+class ClientFbSearchLiveTestCase(unittest.IsolatedAsyncioTestCase):
+    async def live_client(self):
+        test_accounts_url = os.getenv("TEST_ACCOUNTS_URL")
+        if not test_accounts_url:
+            self.skipTest("TEST_ACCOUNTS_URL is required for fbsearch live tests")
+        accounts = await _fetch_accounts(test_accounts_url, count=20)
+        cl = await _login_first_usable(accounts)
+        if cl is None:
+            self.skipTest("Could not login with any test account")
+        return cl
+
+    async def test_fbsearch_suggested_profiles_returns_user_short_live(self):
+        cl = await self.live_client()
+
+        users = await cl.fbsearch_suggested_profiles(INSTAGRAM_USER_ID)
+
+        if not users:
+            self.skipTest("Instagram returned no suggested profiles")
+        self.assertIsInstance(users[0], UserShort)
+        self.assertIsInstance(users[0].stories, list)

--- a/tests/regression/test_live_smoke.py
+++ b/tests/regression/test_live_smoke.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 from urllib.parse import parse_qs, urlsplit
 
+from aiograpi.types import UserShort
+
 
 def _load_live_smoke_module():
     smoke_path = Path(__file__).resolve().parents[1] / "live" / "smoke.py"
@@ -88,6 +90,9 @@ class _FakeLiveClient:
             )
             for i in range(amount)
         ]
+
+    async def fbsearch_suggested_profiles(self, user_id):
+        return [UserShort(pk="2", username="suggested", stories=[])]
 
     async def user_following(self, user_id, amount=0, use_cache=True):
         return [types.SimpleNamespace(pk=str(i)) for i in range(amount)]
@@ -241,6 +246,7 @@ print(sys.modules["aiograpi"].__file__)
             "user_medias",
             "user_medias_paginated",
             "user_followers_extended_fields",
+            "fbsearch_suggested_profiles",
             "user_following",
             "user_stories",
         ]:


### PR DESCRIPTION
## Summary
- Add an opt-in async live test for `fbsearch_suggested_profiles(...)`.
- Add a `fbsearch` workflow-dispatch target.
- Promote `fbsearch_suggested_profiles(...)` into the aiograpi live smoke required checks so canonical push live coverage exercises the helper.
- Extend the smoke regression test so the new required check remains covered without live credentials.

No package version bump: test coverage only.

## Verification
- Local deterministic: `env -u TEST_ACCOUNTS_URL .venv/bin/python -m pytest -q -rs tests/live/test_fbsearch.py tests/regression/test_live_smoke.py` -> `5 passed, 1 skipped`
- Local lint/YAML: ruff and YAML hooks passed during commit.
- Live on sk.test: `PYTHONPATH=. .venv/bin/python -m pytest -q -rs tests/live/test_fbsearch.py::ClientFbSearchLiveTestCase::test_fbsearch_suggested_profiles_returns_user_short_live` -> `1 passed`.
- Full aiograpi live smoke was attempted on sk.test but hit unrelated Instagram 429 throttling on existing smoke checks, so the new helper was validated with the targeted live test and smoke plumbing is covered by regression.
