### PR TITLE
Add story likers

### DIFF
--- a/aiograpi/mixins/story.py
+++ b/aiograpi/mixins/story.py
@@ -549,6 +549,52 @@ class StoryMixin(ClientMixin):
             viewers = viewers[:amount]
         return viewers
 
+    async def story_likers_chunk(
+        self, story_pk: str, max_amount: int = 0, max_id: str = ""
+    ) -> tuple[List[UserShort], str]:
+        unique_set: set = set()
+        likers: List[UserShort] = []
+        story_pk = self.media_pk(story_pk)
+        params = {"supported_capabilities_new": json.dumps(config.SUPPORTED_CAPABILITIES)}
+
+        while True:
+            if max_id:
+                params["max_id"] = max_id
+            result = await self.private_request(f"media/{story_pk}/list_reel_media_viewer/", params=params)
+            for item in result.get("viewers") or []:
+                if not item.get("has_liked"):
+                    continue
+                liker = extract_user_short(item["user"])
+                if liker.pk in unique_set:
+                    continue
+                unique_set.add(liker.pk)
+                likers.append(liker)
+
+            max_id = result.get("next_max_id")
+            if not max_id or (max_amount and len(likers) >= max_amount):
+                break
+        return likers, max_id
+
+    async def story_likers(self, story_pk: str, amount: int = 0) -> List[UserShort]:
+        """
+        List of story likers (Private API)
+
+        Parameters
+        ----------
+        story_pk: str
+        amount: int, optional
+            Maximum number of story likers
+
+        Returns
+        -------
+        List[UserShort]
+            A list of objects of UserShort
+        """
+        likers, _ = await self.story_likers_chunk(story_pk, amount)
+        if amount:
+            likers = likers[:amount]
+        return likers
+
     async def story_like(self, story_id: str, revert: bool = False) -> bool:
         """
         Like a story

--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -10,6 +10,7 @@
 | story_download(story_pk: int, filename: str = "", folder: Path = "")   | Path            | Download story media by media_type
 | story_download_by_url(url: str, filename: str = "", folder: Path = "") | Path            | Download story media using URL to file (mp4 or jpg)
 | story_viewers(story_pk: int, amount: int = 20)                         | List[UserShort] | List of story viewers (via Private API)
+| story_likers(story_pk: int, amount: int = 0)                           | List[UserShort] | List of story likers (via Private API)
 | story_like(story_id: str, revert: bool = False)                        | bool            | Like a story
 | story_unlike(story_id: str)                                            | bool            | Unlike a story
 | story_poll_vote(story_id: str, poll_id: str, vote: int)                | bool            | Vote in a story poll sticker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.6.0"
+version = "1.7.0"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/live/test_story.py
+++ b/tests/live/test_story.py
@@ -109,3 +109,48 @@ class ClientStoryPollVoteLiveTestCase(unittest.IsolatedAsyncioTestCase):
         finally:
             if story:
                 self.assertTrue(await author.story_delete(story.id))
+
+
+async def _story_likers_until_contains(client, story_pk, expected_user_id, attempts=12, delay=5):
+    last_liker_ids = []
+    for attempt in range(attempts):
+        if attempt:
+            await asyncio.sleep(delay)
+        likers = await client.story_likers(story_pk, amount=20)
+        last_liker_ids = [str(liker.pk) for liker in likers]
+        if str(expected_user_id) in last_liker_ids:
+            return likers
+    raise RuntimeError(f"Story likers did not include {expected_user_id} after {attempts} attempts: {last_liker_ids}")
+
+
+class ClientStoryLikersLiveTestCase(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.test_accounts_url = os.getenv("TEST_ACCOUNTS_URL")
+        if not self.test_accounts_url:
+            self.skipTest("TEST_ACCOUNTS_URL is required for story likers live tests")
+
+    async def test_story_likers_live(self):
+        timeout = int(os.getenv("AIOGRAPI_STORY_LIKERS_LIVE_TIMEOUT", "240"))
+        await asyncio.wait_for(self._test_story_likers_live(), timeout=timeout)
+
+    async def _test_story_likers_live(self):
+        clients = await _fresh_reusable_story_clients(self.test_accounts_url)
+        if len(clients) < 2:
+            self.skipTest("At least two reusable TEST_ACCOUNTS_URL sessions are required")
+
+        author, liker = clients[:2]
+        story = None
+        try:
+            story = await author.photo_upload_to_story(Path("examples/background.png"), "Story likers live test")
+            await _story_payload_for_viewer(liker, author.user_id, story)
+            seen = await liker.story_seen([story.pk])
+            liked = await liker.story_like(story.id)
+            likers = await _story_likers_until_contains(author, story.pk, liker.user_id)
+
+            self.assertTrue(story.id)
+            self.assertTrue(seen)
+            self.assertTrue(liked)
+            self.assertIn(str(liker.user_id), [str(user.pk) for user in likers])
+        finally:
+            if story:
+                self.assertTrue(await author.story_delete(story.id))

--- a/tests/regression/test_story.py
+++ b/tests/regression/test_story.py
@@ -131,3 +131,97 @@ class StoryMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["_uid"], "1")
         self.assertEqual(data["vote"], "1")
         self.assertEqual(data["radio_type"], "wifi-none")
+
+    async def test_story_likers_chunk_filters_liked_viewers_and_deduplicates_users(self):
+        client = Client()
+        client.private_request = AsyncMock(
+            side_effect=[
+                {
+                    "viewers": [
+                        {
+                            "has_liked": True,
+                            "user": {
+                                "pk": "10",
+                                "username": "liked_1",
+                                "profile_pic_url": "https://example.com/liked_1.jpg",
+                            },
+                        },
+                        {
+                            "has_liked": False,
+                            "user": {
+                                "pk": "20",
+                                "username": "viewer_only",
+                                "profile_pic_url": "https://example.com/viewer_only.jpg",
+                            },
+                        },
+                    ],
+                    "next_max_id": "page-2",
+                },
+                {
+                    "viewers": [
+                        {
+                            "has_liked": True,
+                            "user": {
+                                "pk": "10",
+                                "username": "liked_1_duplicate",
+                                "profile_pic_url": "https://example.com/liked_1_duplicate.jpg",
+                            },
+                        },
+                        {
+                            "has_liked": True,
+                            "user": {
+                                "pk": "30",
+                                "username": "liked_2",
+                                "profile_pic_url": "https://example.com/liked_2.jpg",
+                            },
+                        },
+                    ],
+                },
+            ]
+        )
+
+        likers, max_id = await client.story_likers_chunk("1234567890_1")
+
+        self.assertEqual([liker.pk for liker in likers], ["10", "30"])
+        self.assertEqual([liker.username for liker in likers], ["liked_1", "liked_2"])
+        self.assertIsNone(max_id)
+        self.assertEqual(client.private_request.call_args_list[0].args[0], "media/1234567890/list_reel_media_viewer/")
+        self.assertIn("supported_capabilities_new", client.private_request.call_args_list[0].kwargs["params"])
+        self.assertEqual(client.private_request.call_args_list[1].kwargs["params"]["max_id"], "page-2")
+
+    async def test_story_likers_limits_amount(self):
+        client = Client()
+        client.private_request = AsyncMock(
+            return_value={
+                "viewers": [
+                    {
+                        "has_liked": True,
+                        "user": {
+                            "pk": "10",
+                            "username": "liked_1",
+                            "profile_pic_url": "https://example.com/liked_1.jpg",
+                        },
+                    },
+                    {
+                        "has_liked": True,
+                        "user": {
+                            "pk": "20",
+                            "username": "liked_2",
+                            "profile_pic_url": "https://example.com/liked_2.jpg",
+                        },
+                    },
+                ],
+            }
+        )
+
+        likers = await client.story_likers("1234567890_1", amount=1)
+
+        self.assertEqual([liker.pk for liker in likers], ["10"])
+
+    async def test_story_likers_handles_viewer_payload_without_viewers(self):
+        client = Client()
+        client.private_request = AsyncMock(return_value={"status": "ok", "user_count": 0, "total_viewer_count": 0})
+
+        likers = await client.story_likers("1234567890_1")
+
+        self.assertEqual(likers, [])


### PR DESCRIPTION
Mirrors instagrapi story liker support with async `Client.story_likers(...)` and `Client.story_likers_chunk(...)`, using `list_reel_media_viewer` rows where `has_liked` is set.

Mirror of https://github.com/subzeroid/instagrapi/pull/2665

Related issue: https://github.com/subzeroid/instagrapi/issues/833

Verification:
- `.venv/bin/python -m pytest -q tests/regression/test_story.py`
- `.venv/bin/python -m ruff check aiograpi/mixins/story.py tests/regression/test_story.py tests/live/test_story.py`
- `.venv/bin/python -m build`
- Remote fresh-clone live verification: `.venv/bin/python -m pytest -q -s tests/live/test_story.py::ClientStoryLikersLiveTestCase::test_story_likers_live` -> `1 passed`