### PR TITLE
Mark stories seen before liking

### DIFF
--- a/aiograpi/mixins/story.py
+++ b/aiograpi/mixins/story.py
@@ -595,7 +595,7 @@ class StoryMixin(ClientMixin):
             likers = likers[:amount]
         return likers
 
-    async def story_like(self, story_id: str, revert: bool = False) -> bool:
+    async def story_like(self, story_id: str, revert: bool = False, mark_seen: bool = True) -> bool:
         """
         Like a story
 
@@ -605,6 +605,8 @@ class StoryMixin(ClientMixin):
             Unique identifier of a Story
         revert: bool, optional
             If liked, whether or not to unlike. Default is False
+        mark_seen: bool, optional
+            Mark story as seen before liking. Default is True
 
         Returns
         -------
@@ -614,6 +616,8 @@ class StoryMixin(ClientMixin):
         if not self.user_id:
             raise PreLoginRequired
         media_id = await self.media_id(story_id)
+        if mark_seen and not revert:
+            await self.story_seen([self.media_pk(media_id)])
         data = {
             "media_id": media_id,
             "_uid": str(self.user_id),

--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -11,7 +11,7 @@
 | story_download_by_url(url: str, filename: str = "", folder: Path = "") | Path            | Download story media using URL to file (mp4 or jpg)
 | story_viewers(story_pk: int, amount: int = 20)                         | List[UserShort] | List of story viewers (via Private API)
 | story_likers(story_pk: int, amount: int = 0)                           | List[UserShort] | List of story likers (via Private API)
-| story_like(story_id: str, revert: bool = False)                        | bool            | Like a story
+| story_like(story_id: str, revert: bool = False, mark_seen: bool = True) | bool            | Like a story
 | story_unlike(story_id: str)                                            | bool            | Unlike a story
 | story_poll_vote(story_id: str, poll_id: str, vote: int)                | bool            | Vote in a story poll sticker
 | archive_story_days(amount: int = 0, include_memories: bool = True)      | List[StoryArchiveDay] | Get story archive day shells

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.7.0"
+version = "1.7.1"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/live/test_story.py
+++ b/tests/live/test_story.py
@@ -143,12 +143,10 @@ class ClientStoryLikersLiveTestCase(unittest.IsolatedAsyncioTestCase):
         try:
             story = await author.photo_upload_to_story(Path("examples/background.png"), "Story likers live test")
             await _story_payload_for_viewer(liker, author.user_id, story)
-            seen = await liker.story_seen([story.pk])
             liked = await liker.story_like(story.id)
             likers = await _story_likers_until_contains(author, story.pk, liker.user_id)
 
             self.assertTrue(story.id)
-            self.assertTrue(seen)
             self.assertTrue(liked)
             self.assertIn(str(liker.user_id), [str(user.pk) for user in likers])
         finally:

--- a/tests/regression/test_story.py
+++ b/tests/regression/test_story.py
@@ -225,3 +225,39 @@ class StoryMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         likers = await client.story_likers("1234567890_1")
 
         self.assertEqual(likers, [])
+
+    async def test_story_like_marks_story_seen_before_liking(self):
+        client = Client()
+        client.authorization_data = {"sessionid": "sessionid-value", "ds_user_id": "1"}
+        client.story_seen = AsyncMock(return_value=True)
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        result = await client.story_like("1234567890_1")
+
+        self.assertTrue(result)
+        client.story_seen.assert_awaited_once_with(["1234567890"])
+        client.private_request.assert_awaited_once()
+        self.assertEqual(client.private_request.call_args.args[0], "story_interactions/send_story_like")
+
+    async def test_story_like_can_skip_mark_seen(self):
+        client = Client()
+        client.authorization_data = {"sessionid": "sessionid-value", "ds_user_id": "1"}
+        client.story_seen = AsyncMock(return_value=True)
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        result = await client.story_like("1234567890_1", mark_seen=False)
+
+        self.assertTrue(result)
+        client.story_seen.assert_not_awaited()
+
+    async def test_story_unlike_does_not_mark_story_seen(self):
+        client = Client()
+        client.authorization_data = {"sessionid": "sessionid-value", "ds_user_id": "1"}
+        client.story_seen = AsyncMock(return_value=True)
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        result = await client.story_unlike("1234567890_1")
+
+        self.assertTrue(result)
+        client.story_seen.assert_not_awaited()
+        self.assertEqual(client.private_request.call_args.args[0], "story_interactions/unsend_story_like")


### PR DESCRIPTION
Mirrors instagrapi story like behavior: async `story_like()` now marks the story as seen before sending the like by default, so the author-side viewer row can appear with `has_liked=True`. `story_like(..., mark_seen=False)` keeps the old low-level behavior, and `story_unlike()` does not create a seen event.

Mirror of https://github.com/subzeroid/instagrapi/pull/2666

Related issues: https://github.com/subzeroid/instagrapi/issues/912 and https://github.com/subzeroid/instagrapi/issues/913

Verification:
- `.venv/bin/python -m pytest -q tests/regression/test_story.py`
- `.venv/bin/python -m ruff check aiograpi/mixins/story.py tests/regression/test_story.py tests/live/test_story.py`
- `.venv/bin/python -m build`
- Remote fresh-clone live verification: `.venv/bin/python -m pytest -q -s tests/live/test_story.py::ClientStoryLikersLiveTestCase::test_story_likers_live` -> `1 passed`