### PR TITLE
Add story fit resize mode

### DIFF
--- a/aiograpi/image_util.py
+++ b/aiograpi/image_util.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import socket
 import tempfile
+from typing import Union
 from urllib.parse import urlparse
 
 try:
@@ -214,6 +215,41 @@ def prepare_image(
     b = io.BytesIO()
     im.save(b, "JPEG")
     return b.getvalue(), im.size
+
+
+def prepare_story_image_fit(
+    img,
+    max_size=(1080, 1920),
+    background_color: Union[str, tuple] = "black",
+    save_path=None,
+):
+    """
+    Prepare an image for a Story without cropping the source media.
+    """
+    if is_remote(img):
+        res = _safe_remote_get(img)
+        source_image = Image.open(io.BytesIO(res.content), formats=_SAFE_REMOTE_IMAGE_FORMATS)
+    else:
+        source_image = Image.open(img)
+
+    im: Image.Image = source_image
+    try:
+        if im.mode != "RGBA":
+            im = im.convert("RGBA")
+        im.thumbnail(max_size, Image.Resampling.LANCZOS)
+        canvas = Image.new("RGB", max_size, background_color)
+        left = int((max_size[0] - im.size[0]) / 2)
+        top = int((max_size[1] - im.size[1]) / 2)
+        canvas.paste(im, (left, top), im)
+        if save_path:
+            canvas.save(save_path)
+        b = io.BytesIO()
+        canvas.save(b, "JPEG")
+        return b.getvalue(), canvas.size
+    finally:
+        if im is not source_image:
+            im.close()
+        source_image.close()
 
 
 def prepare_video(

--- a/aiograpi/mixins/photo.py
+++ b/aiograpi/mixins/photo.py
@@ -15,7 +15,7 @@ from aiograpi.exceptions import (
     PhotoConfigureStoryError,
     PhotoNotUpload,
 )
-from aiograpi.image_util import prepare_image
+from aiograpi.image_util import prepare_image, prepare_story_image_fit
 from aiograpi.mixins.base import ClientMixin
 from aiograpi.types import (
     Location,
@@ -152,6 +152,7 @@ class UploadPhotoMixin(ClientMixin):
         upload_id: str = "",
         to_album: bool = False,
         for_story: bool = False,
+        resize_mode: str = "fill",
     ) -> tuple:
         """
         Upload photo to Instagram
@@ -165,6 +166,8 @@ class UploadPhotoMixin(ClientMixin):
         to_album: bool, optional
         for_story: bool, optional
             Useful for resize util only
+        resize_mode: str, optional
+            Story resize mode: "fill" crops oversized Story media to fill the canvas, "fit" letterboxes it.
 
         Returns
         -------
@@ -173,6 +176,10 @@ class UploadPhotoMixin(ClientMixin):
         """
         if not isinstance(path, Path):
             raise Exception(f"Path must been Path, now {path} ({type(path)})")
+        if resize_mode not in {"fill", "fit"}:
+            raise ValueError('resize_mode must be "fill" or "fit"')
+        if resize_mode == "fit" and not for_story:
+            raise ValueError('resize_mode="fit" is only supported for story uploads')
         valid_extensions = [".jpg", ".jpeg", ".png", ".webp"]
         if path.suffix.lower() not in valid_extensions:
             raise ValueError("Invalid file format. Only JPG/JPEG/PNG/WEBP files are supported.")
@@ -199,7 +206,9 @@ class UploadPhotoMixin(ClientMixin):
         }
         if to_album:
             rupload_params["is_sidecar"] = "1"
-        if for_story:
+        if for_story and resize_mode == "fit":
+            photo_data, photo_size = prepare_story_image_fit(str(path))
+        elif for_story:
             photo_data, photo_size = prepare_image(
                 str(path),
                 max_side=1080,
@@ -232,8 +241,11 @@ class UploadPhotoMixin(ClientMixin):
             self.logger.error("Photo Upload failed with the following response: %s", response)
             last_json = self.last_json  # local variable for read in sentry
             raise PhotoNotUpload(response.text, response=response, **last_json)
-        with Image.open(path) as im:
-            width, height = im.size
+        if for_story and resize_mode == "fit":
+            width, height = photo_size
+        else:
+            with Image.open(path) as im:
+                width, height = im.size
         return upload_id, width, height
 
     async def photo_upload(
@@ -479,6 +491,7 @@ class UploadPhotoMixin(ClientMixin):
         medias: List[StoryMedia] = [],
         polls: List[StoryPoll] = [],
         extra_data: Dict[str, str] = {},
+        resize_mode: str = "fill",
     ) -> Story:
         """
         Upload photo as a story and configure it
@@ -507,6 +520,8 @@ class UploadPhotoMixin(ClientMixin):
             List of polls to be included on this upload, default is empty list.
         extra_data: Dict[str, str], optional
             Dict of extra data, if you need to add your params, like {"share_to_facebook": 1}.
+        resize_mode: str, optional
+            Story resize mode: "fill" crops oversized media to fill the Story canvas, "fit" letterboxes it.
 
         Returns
         -------
@@ -514,7 +529,7 @@ class UploadPhotoMixin(ClientMixin):
             An object of Media class
         """
         path = Path(path)
-        upload_id, width, height = await self.photo_rupload(path, upload_id, for_story=True)
+        upload_id, width, height = await self.photo_rupload(path, upload_id, for_story=True, resize_mode=resize_mode)
         previous_story_ids = await self._current_story_ids()
         story_kwargs = {
             "links": links,

--- a/aiograpi/mixins/video.py
+++ b/aiograpi/mixins/video.py
@@ -16,6 +16,7 @@ from aiograpi.exceptions import (
     VideoNotUpload,
 )
 from aiograpi.mixins.base import ClientMixin
+from aiograpi.story import StoryBuilder
 from aiograpi.types import (
     DirectMessage,
     Location,
@@ -673,6 +674,7 @@ class UploadVideoMixin(ClientMixin):
         medias: List[StoryMedia] = [],
         polls: List[StoryPoll] = [],
         extra_data: Dict[str, str] = {},
+        resize_mode: str = "fill",
     ) -> Story:
         """
         Upload video as a story and configure it
@@ -701,6 +703,8 @@ class UploadVideoMixin(ClientMixin):
             List of polls to be included on this upload, default is empty list.
         extra_data: Dict[str, str], optional
             Dict of extra data, if you need to add your params, like {"share_to_facebook": 1}.
+        resize_mode: str, optional
+            Story resize mode: "fill" keeps current upload behavior, "fit" renders a Story canvas without cropping.
 
         Returns
         -------
@@ -710,56 +714,75 @@ class UploadVideoMixin(ClientMixin):
         path = Path(path)
         if thumbnail is not None:
             thumbnail = Path(thumbnail)
-        upload_id, width, height, duration, thumbnail = await self.video_rupload(path, thumbnail, to_story=True)
-        previous_story_ids = await self._current_story_ids()
-        story_kwargs = {
-            "links": links,
-            "mentions": mentions,
-            "hashtags": hashtags,
-            "locations": locations,
-            "stickers": stickers,
-            "medias": medias,
-            "polls": polls,
-        }
-        for attempt in range(50):
-            self.logger.debug(f"Attempt #{attempt} to configure Video: {path}")
-            await asyncio.sleep(3)
-            try:
-                configured = await self.video_configure_to_story(
-                    upload_id,
-                    width,
-                    height,
-                    duration,
-                    thumbnail,
-                    caption,
-                    mentions,
-                    locations,
-                    links,
-                    hashtags,
-                    stickers,
-                    medias,
-                    polls,
-                    extra_data=extra_data,
-                )
-            except Exception as e:
-                if "Transcode not finished yet" in str(e):
-                    """
-                    Response 202 status:
-                    {"message": "Transcode not finished yet.", "status": "fail"}
-                    """
-                    await asyncio.sleep(10)
-                    continue
-                raise e
-            if configured:
-                await self.expose()
-                return await self._extract_configured_story_or_recent(
-                    configured,
-                    VideoConfigureStoryError,
-                    "Video story upload",
-                    previous_story_ids,
-                    story_kwargs,
-                )
-        raise VideoConfigureStoryError(response=self.last_response, **self.last_json)
+        if resize_mode not in {"fill", "fit"}:
+            raise ValueError('resize_mode must be "fill" or "fit"')
+        rendered_story = None
+        upload_path = path
+        upload_thumbnail: Any = thumbnail
+        try:
+            if resize_mode == "fit":
+                rendered_story = StoryBuilder(path).video_fit()
+                upload_path = Path(rendered_story.path)
+                upload_thumbnail = None
+            upload_id, width, height, duration, thumbnail = await self.video_rupload(
+                upload_path,
+                upload_thumbnail,
+                to_story=True,
+            )
+            previous_story_ids = await self._current_story_ids()
+            story_kwargs = {
+                "links": links,
+                "mentions": mentions,
+                "hashtags": hashtags,
+                "locations": locations,
+                "stickers": stickers,
+                "medias": medias,
+                "polls": polls,
+            }
+            for attempt in range(50):
+                self.logger.debug(f"Attempt #{attempt} to configure Video: {path}")
+                await asyncio.sleep(3)
+                try:
+                    configured = await self.video_configure_to_story(
+                        upload_id,
+                        width,
+                        height,
+                        duration,
+                        thumbnail,
+                        caption,
+                        mentions,
+                        locations,
+                        links,
+                        hashtags,
+                        stickers,
+                        medias,
+                        polls,
+                        extra_data=extra_data,
+                    )
+                except Exception as e:
+                    if "Transcode not finished yet" in str(e):
+                        """
+                        Response 202 status:
+                        {"message": "Transcode not finished yet.", "status": "fail"}
+                        """
+                        await asyncio.sleep(10)
+                        continue
+                    raise e
+                if configured:
+                    await self.expose()
+                    return await self._extract_configured_story_or_recent(
+                        configured,
+                        VideoConfigureStoryError,
+                        "Video story upload",
+                        previous_story_ids,
+                        story_kwargs,
+                    )
+            raise VideoConfigureStoryError(response=self.last_response, **self.last_json)
+        finally:
+            if rendered_story:
+                for item in [rendered_story.path, *rendered_story.paths, f"{rendered_story.path}.jpg"]:
+                    with contextlib.suppress(OSError):
+                        Path(item).unlink()
 
     async def video_configure_to_story(
         self,

--- a/aiograpi/story.py
+++ b/aiograpi/story.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import tempfile
 from pathlib import Path
@@ -49,6 +50,13 @@ class StoryBuilder:
 
     width = 720
     height = 1280
+
+    @staticmethod
+    def _fit_size(source_size, canvas_size):
+        source_width, source_height = source_size
+        canvas_width, canvas_height = canvas_size
+        scale = min(canvas_width / float(source_width), canvas_height / float(source_height))
+        return int(source_width * scale), int(source_height * scale)
 
     def __init__(
         self,
@@ -245,6 +253,52 @@ class StoryBuilder:
         build = self.build_main(clip, max_duration, font, fontsize, color, link)
         clip.close()
         return build
+
+    def video_fit(
+        self,
+        max_duration: int = 0,
+        background_color=(0, 0, 0),
+    ):
+        """
+        Build a Story video canvas that fits the full source video without cropping.
+        """
+        CompositeVideoClip, _, _, VideoFileClip, _ = _import_moviepy_for_story()
+        source_clip = None
+        work_clip = None
+        resized_clip = None
+        positioned_clip = None
+        canvas_clip = None
+        try:
+            source_clip = VideoFileClip(str(self.path), has_mask=True)
+            duration = float(source_clip.duration or max_duration or 0)
+            if max_duration and duration > max_duration:
+                duration = float(max_duration)
+                work_clip = source_clip.subclipped(0, duration)
+            else:
+                work_clip = source_clip
+            fit_width, fit_height = self._fit_size(work_clip.size, (self.width, self.height))
+            clip_left = int((self.width - fit_width) / 2)
+            clip_top = int((self.height - fit_height) / 2)
+            resized_clip = work_clip.resized(new_size=(fit_width, fit_height))
+            positioned_clip = resized_clip.with_position((clip_left, clip_top))
+            canvas_clip = CompositeVideoClip(
+                [positioned_clip],
+                size=(self.width, self.height),
+                bg_color=background_color,
+            ).with_duration(duration)
+            fps = getattr(source_clip, "fps", None) or 24
+            canvas_clip = canvas_clip.with_fps(fps)
+            destination = _make_tmp_path(".mp4")
+            canvas_clip.write_videofile(destination, codec="libx264", audio=True, audio_codec="aac")
+            return StoryBuild(mentions=[], path=Path(destination), paths=[], stickers=[])
+        finally:
+            closed = set()
+            for clip in (canvas_clip, positioned_clip, resized_clip, work_clip, source_clip):
+                if not clip or id(clip) in closed:
+                    continue
+                closed.add(id(clip))
+                with contextlib.suppress(AttributeError):
+                    clip.close()
 
     def photo(
         self,

--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -52,11 +52,12 @@ Common arguments:
 * `links` - "Swipe Up" links (now use first)
 * `hashtags` - Add hashtags to story
 * `stickers` - Add stickers to story
+* `resize_mode` - Story media sizing mode: `"fill"` keeps the current crop/fill behavior, `"fit"` renders the full source media on a Story canvas without cropping
 
 | Method                               | Return   | Description
 | ------------------------------------ | -------- | -------------
-| photo_upload_to_story(path: Path, caption: str, upload_id: str, mentions: List[Usertag], locations: List[StoryLocation], links: List[StoryLink], hashtags: List[StoryHashtag], stickers: List[StorySticker], extra_data: Dict[str, str] = {})  | Story  | Upload photo (Support JPG files)
-| video_upload_to_story(path: Path, caption: str, thumbnail: Path, mentions: List[Usertag], locations: List[StoryLocation], links: List[StoryLink], hashtags: List[StoryHashtag], stickers: List[StorySticker], extra_data: Dict[str, str] = {}) | Story  | Upload video (Support MP4 files)
+| photo_upload_to_story(path: Path, caption: str = "", upload_id: str = "", mentions: List[StoryMention] = [], locations: List[StoryLocation] = [], links: List[StoryLink] = [], hashtags: List[StoryHashtag] = [], stickers: List[StorySticker] = [], medias: List[StoryMedia] = [], polls: List[StoryPoll] = [], extra_data: Dict[str, str] = {}, resize_mode: str = "fill")  | Story  | Upload photo to story
+| video_upload_to_story(path: Path, caption: str = "", thumbnail: Path = None, mentions: List[StoryMention] = [], locations: List[StoryLocation] = [], links: List[StoryLink] = [], hashtags: List[StoryHashtag] = [], stickers: List[StorySticker] = [], medias: List[StoryMedia] = [], polls: List[StoryPoll] = [], extra_data: Dict[str, str] = {}, resize_mode: str = "fill") | Story  | Upload video to story
 | photo_upload_to_story_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, duration: float = 15.0, extra_data: Dict = {}) | Story | Upload photo to story as a short video with the selected music track muxed into it
 | video_upload_to_story_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, extra_data: Dict = {}) | Story | Upload video to story with the selected music track muxed into it
 | story_music_extra_data(track: Track or dict, extra_data: Dict = {}) | dict | Build Story music configure fields for manual story upload `extra_data`
@@ -72,6 +73,10 @@ Story music helpers require the optional video dependencies, MoviePy `2.2.1`, an
 a local MP4 before upload. They add Story music metadata and bake the selected track into the uploaded media; they do not
 expose Instagram's native interactive lyrics/music sticker UI.
 
+Sizing notes:
+
+* For story uploads, use a 9:16 asset, pass `resize_mode="fit"` to keep the full source media visible on a Story canvas, or build one manually with `StoryBuilder`.
+* `resize_mode="fill"` is the default and keeps the existing crop/fill behavior.
 
 Examples:
 
@@ -131,6 +136,7 @@ MoviePy `2.2.1` currently declares `Pillow<12`, but aiograpi keeps `Pillow>=12.2
 | ----------------------------------------------------- | ---------- | ---------------------------------------- |
 | StoryBuilder.build_clip(clip: moviepy.Clip, max_duration: int = 0) | StoryBuild | Build CompositeVideoClip with background and mentioned users. Return MP4 file and mentions with coordinates |
 | StoryBuilder.video(max_duration: int = 0)            | StoryBuild | Call build_clip(VideoClip, max_duration) |
+| StoryBuilder.video_fit(max_duration: int = 0)        | StoryBuild | Build a 720x1280 Story video canvas that fits the full source video without cropping |
 | StoryBuilder.photo(max_duration: int = 0)            | StoryBuild | Call build_clip(ImageClip, max_duration) |
 
 Example:
@@ -174,6 +180,13 @@ Upload photo as video:
 ``` python
 buildout = StoryBuilder('/app/image.jpg').photo()
 await cl.video_upload_to_story(buildout.path)
+```
+
+Upload photo or video without cropping:
+
+``` python
+await cl.photo_upload_to_story(Path("/app/landscape.jpg"), resize_mode="fit")
+await cl.video_upload_to_story(Path("/app/landscape.mp4"), resize_mode="fit")
 ```
 
 Like & unlike story:

--- a/examples/upload_story.py
+++ b/examples/upload_story.py
@@ -9,14 +9,27 @@ from _common import env, make_client
 from aiograpi.types import StoryLink
 
 
-async def upload_story(kind: str, path: Path, caption: str, thumbnail: Path | None = None, link: str | None = None):
+async def upload_story(
+    kind: str,
+    path: Path,
+    caption: str,
+    thumbnail: Path | None = None,
+    link: str | None = None,
+    resize_mode: str = "fill",
+):
     cl = await make_client()
     links = [StoryLink(webUri=link)] if link else []
 
     if kind == "photo":
-        return await cl.photo_upload_to_story(path, caption=caption, links=links)
+        return await cl.photo_upload_to_story(path, caption=caption, links=links, resize_mode=resize_mode)
     if kind == "video":
-        return await cl.video_upload_to_story(path, caption=caption, thumbnail=thumbnail, links=links)
+        return await cl.video_upload_to_story(
+            path,
+            caption=caption,
+            thumbnail=thumbnail,
+            links=links,
+            resize_mode=resize_mode,
+        )
 
     raise ValueError(f"Unsupported story kind: {kind}")
 
@@ -28,9 +41,10 @@ async def main() -> None:
     parser.add_argument("--caption", default=env("IG_CAPTION", ""))
     parser.add_argument("--thumbnail", type=Path, default=None)
     parser.add_argument("--link", default=env("IG_STORY_LINK"))
+    parser.add_argument("--resize-mode", choices=["fill", "fit"], default="fill")
     args = parser.parse_args()
 
-    story = await upload_story(args.kind, args.path, args.caption, args.thumbnail, args.link)
+    story = await upload_story(args.kind, args.path, args.caption, args.thumbnail, args.link, args.resize_mode)
     print(f"Uploaded story {story.pk}")
 
 

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -1,3 +1,4 @@
+import io
 import json
 import tempfile
 import types
@@ -6,8 +7,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock
 
+from PIL import Image
+
 from aiograpi import Client
-from aiograpi.types import Media, UserShort
+from aiograpi.types import Media, StoryBuild, UserShort
 
 
 class UploadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
@@ -223,6 +226,59 @@ class UploadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(headers["IG-U-DS-USER-ID"], "1")
         self.assertEqual(headers["X-Entity-Length"], "11")
         self.assertEqual(headers["X-Entity-Name"], "upload-id_0_1234567890")
+
+    async def test_photo_story_fit_resize_letterboxes_without_cropping(self):
+        client = self.build_client()
+        client.authorization_data = {
+            "ds_user_id": "1",
+            "sessionid": "1:session",
+            "should_use_header_over_cookies": True,
+        }
+        response = unittest.mock.Mock(status_code=200)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "wide.jpg"
+            image = Image.new("RGB", (1280, 720), "green")
+            image.paste("red", (0, 0, 320, 720))
+            image.paste("blue", (960, 0, 1280, 720))
+            image.save(path)
+
+            client.private.post = AsyncMock(return_value=response)
+            upload_id, width, height = await client.photo_rupload(
+                path,
+                upload_id="upload-id",
+                for_story=True,
+                resize_mode="fit",
+            )
+
+        self.assertEqual((upload_id, width, height), ("upload-id", 1080, 1920))
+        uploaded = client.private.post.call_args.kwargs["data"]
+        with Image.open(io.BytesIO(uploaded)) as prepared:
+            self.assertEqual(prepared.size, (1080, 1920))
+            self.assertEqual(prepared.getpixel((10, 960)), (254, 0, 0))
+            self.assertEqual(prepared.getpixel((1070, 960)), (0, 0, 254))
+            self.assertEqual(prepared.getpixel((540, 100)), (0, 0, 0))
+
+    async def test_video_story_fit_resize_renders_canvas_before_upload(self):
+        client = self.build_client()
+        client.video_rupload = AsyncMock(return_value=("1", 720, 1280, 5, Path("/tmp/thumb.jpg")))
+        client.video_configure_to_story = AsyncMock(return_value={"status": "ok"})
+        client._current_story_ids = AsyncMock(return_value=set())
+        client._extract_configured_story_or_recent = AsyncMock(return_value="uploaded")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fitted = Path(tmpdir) / "fitted.mp4"
+            fitted.touch()
+            rendered = StoryBuild(path=str(fitted), mentions=[], paths=[], stickers=[])
+            with unittest.mock.patch("aiograpi.mixins.video.StoryBuilder", create=True) as story_builder:
+                story_builder.return_value.video_fit.return_value = rendered
+                with unittest.mock.patch("asyncio.sleep", new=AsyncMock()):
+                    result = await client.video_upload_to_story(Path("wide.mp4"), resize_mode="fit")
+
+        self.assertEqual(result, "uploaded")
+        story_builder.assert_called_once_with(Path("wide.mp4"))
+        story_builder.return_value.video_fit.assert_called_once()
+        client.video_rupload.assert_awaited_once_with(Path(rendered.path), None, to_story=True)
 
     async def test_clip_upload_uses_current_reels_rupload_shape(self):
         client = self.build_client()

--- a/tests/regression/test_video_metadata.py
+++ b/tests/regression/test_video_metadata.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+from PIL import Image
 
 
 def _box(name: str, payload: bytes) -> bytes:
@@ -72,6 +73,41 @@ def _write_real_mp4(folder: Path, name: str = "source.mp4", duration: float = 4.
             "lavfi",
             "-i",
             f"color=c=black:s=640x360:d={duration}",
+            "-pix_fmt",
+            "yuv420p",
+            str(path),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+    return path
+
+
+def _write_wide_panel_mp4(folder: Path, name: str = "wide-source.mp4", duration: float = 2.0) -> Path:
+    path = folder / name
+    subprocess.run(
+        [
+            _ffmpeg_exe(),
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=c=red:s=320x720:r=30:d={duration}",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=c=green:s=640x720:r=30:d={duration}",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=c=blue:s=320x720:r=30:d={duration}",
+            "-filter_complex",
+            "[0:v][1:v][2:v]hstack=inputs=3[v]",
+            "-map",
+            "[v]",
+            "-c:v",
+            "libx264",
             "-pix_fmt",
             "yuv420p",
             str(path),
@@ -196,8 +232,6 @@ def test_prepare_video_reports_video_extra_without_moviepy():
 
 
 def test_story_builder_photo_generates_video_with_moviepy_2():
-    from PIL import Image
-
     from aiograpi.story import StoryBuilder
     from aiograpi.utils.video import read_video_metadata
 
@@ -215,6 +249,42 @@ def test_story_builder_photo_generates_video_with_moviepy_2():
             metadata = read_video_metadata(output)
             assert (metadata.width, metadata.height) == (720, 1280)
             assert metadata.duration == pytest.approx(1.0, abs=0.25)
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(build.path)
+
+
+def test_story_builder_video_fit_generates_canvas_without_cropping():
+    from aiograpi.story import StoryBuilder
+    from aiograpi.utils.video import read_video_metadata
+
+    assert importlib.metadata.version("moviepy") == "2.2.1"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        source = _write_wide_panel_mp4(tmpdir)
+        build = StoryBuilder(source).video_fit(max_duration=1)
+        output = Path(build.path)
+        frame = tmpdir / "frame.jpg"
+        try:
+            assert output.exists()
+            metadata = read_video_metadata(output)
+            assert (metadata.width, metadata.height) == (720, 1280)
+            assert metadata.duration == pytest.approx(1.0, abs=0.25)
+            subprocess.run(
+                [_ffmpeg_exe(), "-y", "-ss", "0.5", "-i", str(output), "-frames:v", "1", str(frame)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=True,
+            )
+            with Image.open(frame) as image:
+                left_mid = image.getpixel((10, 640))[:3]
+                center_mid = image.getpixel((360, 640))[:3]
+                right_mid = image.getpixel((710, 640))[:3]
+                top_center = image.getpixel((360, 100))[:3]
+            assert left_mid[0] > 150
+            assert center_mid[1] > 80
+            assert right_mid[2] > 150
+            assert sum(top_center) < 20
         finally:
             with contextlib.suppress(FileNotFoundError):
                 os.unlink(build.path)


### PR DESCRIPTION
Mirrors the instagrapi Story fit resize API from https://github.com/subzeroid/instagrapi/pull/2667 for https://github.com/subzeroid/instagrapi/issues/1310.

This adds `resize_mode="fit"` for async `photo_upload_to_story(...)` and `video_upload_to_story(...)`, keeping `resize_mode="fill"` as the default/current crop-fill behavior. Photo stories render the full source media onto a 1080x1920 canvas, and video stories render through `StoryBuilder.video_fit()` onto a 720x1280 canvas before the normal rupload/configure path.

Verification:
- `.venv/bin/python -m pytest -q tests/regression/test_upload.py tests/regression/test_story_configure.py tests/regression/test_video_metadata.py` -> 34 passed
- `.venv/bin/ruff check aiograpi tests examples docs` -> passed
- `./scripts/check-mypy-baseline.sh` -> 250/250
- `.venv/bin/python -m build` -> success
