### PR TITLE
Add media_search helper

### DIFF
--- a/aiograpi/mixins/fbsearch.py
+++ b/aiograpi/mixins/fbsearch.py
@@ -3,14 +3,35 @@ from typing import Dict, List, Optional, Tuple, Union
 from aiograpi.extractors import (
     extract_hashtag_v1,
     extract_location,
+    extract_media_v1,
     extract_track,
     extract_user_short,
 )
 from aiograpi.mixins.base import ClientMixin
-from aiograpi.types import Hashtag, Location, Track, UserShort
+from aiograpi.types import Hashtag, Location, Media, Track, UserShort
 
 
 class FbSearchMixin(ClientMixin):
+    def _fbsearch_media_grid_nodes(self, media_grid: dict):
+        for section in media_grid.get("sections") or []:
+            layout_content = section.get("layout_content") or {}
+            one_by_two_item = layout_content.get("one_by_two_item") or {}
+            if isinstance(one_by_two_item, dict):
+                media = one_by_two_item.get("media")
+                if isinstance(media, dict):
+                    yield media
+                clips = one_by_two_item.get("clips") or {}
+                if isinstance(clips, dict):
+                    for item in clips.get("items") or []:
+                        media = item.get("media") if isinstance(item, dict) else None
+                        if isinstance(media, dict):
+                            yield media
+            for key in ("fill_items", "medias"):
+                for item in layout_content.get(key) or []:
+                    media = item.get("media") if isinstance(item, dict) else None
+                    if isinstance(media, dict):
+                        yield media
+
     async def fbsearch_places(self, query: str, lat: float = 40.74, lng: float = -73.94) -> List[Location]:
         params = {
             "search_surface": "places_search_page",
@@ -373,6 +394,55 @@ class FbSearchMixin(ClientMixin):
         if reels_max_id:
             params["reels_max_id"] = reels_max_id
         return await self.private_request("fbsearch/top_serp/", params=params)
+
+    async def media_search(self, query: str, amount: int = 27) -> List[Media]:
+        """
+        Search top media by keyword via the private fbsearch SERP.
+
+        Parameters
+        ----------
+        query: str
+            Search query.
+        amount: int, optional
+            Maximum number of media to return, default is 27.
+
+        Returns
+        -------
+        List[Media]
+            List of media results.
+        """
+        medias: List[Media] = []
+        next_max_id = None
+        reels_max_id = None
+        rank_token = None
+        while True:
+            kwargs: Dict[str, str] = {}
+            if next_max_id:
+                kwargs["next_max_id"] = next_max_id
+            if reels_max_id:
+                kwargs["reels_max_id"] = reels_max_id
+            if rank_token:
+                kwargs["rank_token"] = rank_token
+            result = await self.fbsearch_topsearch_v2(query, **kwargs)
+            media_grid = result.get("media_grid") or {}
+            for node in self._fbsearch_media_grid_nodes(media_grid):
+                if amount and len(medias) >= amount:
+                    break
+                try:
+                    medias.append(extract_media_v1(node))
+                except (KeyError, AttributeError, TypeError) as exc:
+                    self.logger.warning("Skipping malformed fbsearch media node: %s", exc)
+                    continue
+            if amount and len(medias) >= amount:
+                break
+            next_max_id = media_grid.get("next_max_id") or result.get("next_max_id")
+            if not media_grid.get("has_more") or not next_max_id:
+                break
+            reels_max_id = media_grid.get("reels_max_id") or result.get("reels_max_id")
+            rank_token = media_grid.get("rank_token") or result.get("rank_token")
+        if amount:
+            medias = medias[:amount]
+        return medias
 
     async def fbsearch_typehead(self, query: str) -> List[dict]:
         """

--- a/tests/live/test_fbsearch.py
+++ b/tests/live/test_fbsearch.py
@@ -1,8 +1,9 @@
 import os
 import unittest
 
-from aiograpi.types import UserShort
-from tests.live.smoke import _fetch_accounts, _login_first_usable
+from aiograpi import Client
+from aiograpi.types import Media, UserShort
+from tests.live.smoke import _fetch_accounts
 
 INSTAGRAM_USER_ID = "25025320"
 
@@ -13,10 +14,16 @@ class ClientFbSearchLiveTestCase(unittest.IsolatedAsyncioTestCase):
         if not test_accounts_url:
             self.skipTest("TEST_ACCOUNTS_URL is required for fbsearch live tests")
         accounts = await _fetch_accounts(test_accounts_url, count=20)
-        cl = await _login_first_usable(accounts)
-        if cl is None:
-            self.skipTest("Could not login with any test account")
-        return cl
+        last_error = None
+        for account in accounts:
+            try:
+                cl = Client(settings=dict(account["client_settings"]), proxy=os.getenv("IG_PROXY") or account["proxy"])
+                cl._user_id = account.get("user_id")
+                await cl.fbsearch_topsearch_v2("instagram")
+                return cl
+            except Exception as exc:
+                last_error = f"{type(exc).__name__}: {str(exc)[:120]}"
+        self.skipTest(f"Could not build a usable fbsearch test client: {last_error}")
 
     async def test_fbsearch_suggested_profiles_returns_user_short_live(self):
         cl = await self.live_client()
@@ -27,3 +34,15 @@ class ClientFbSearchLiveTestCase(unittest.IsolatedAsyncioTestCase):
             self.skipTest("Instagram returned no suggested profiles")
         self.assertIsInstance(users[0], UserShort)
         self.assertIsInstance(users[0].stories, list)
+
+    async def test_media_search_returns_media_live(self):
+        cl = await self.live_client()
+
+        medias = await cl.media_search("space", amount=3)
+
+        if not medias:
+            self.skipTest("Instagram returned no media search results")
+        self.assertLessEqual(len(medias), 3)
+        self.assertIsInstance(medias[0], Media)
+        self.assertTrue(medias[0].pk)
+        self.assertTrue(medias[0].code)

--- a/tests/regression/test_fbsearch.py
+++ b/tests/regression/test_fbsearch.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import AsyncMock
 
 from aiograpi import Client
-from aiograpi.types import UserShort
+from aiograpi.types import Media, UserShort
 
 
 class FbSearchRegressionTestCase(unittest.IsolatedAsyncioTestCase):
@@ -61,3 +61,132 @@ class FbSearchRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(users[0], UserShort)
         self.assertEqual(users[0].pk, "123")
         self.assertEqual(users[0].stories, [])
+
+    async def test_media_search_extracts_media_grid_and_paginates(self):
+        client = self._build_client()
+
+        def media(pk):
+            return {
+                "pk": pk,
+                "id": f"{pk}_2",
+                "code": f"code-{pk}",
+                "taken_at": 1710000000,
+                "media_type": 1,
+                "user": {
+                    "pk": "2",
+                    "username": "example",
+                    "profile_pic_url": "https://example.com/profile.jpg",
+                },
+                "image_versions2": {
+                    "candidates": [
+                        {
+                            "url": f"https://example.com/{pk}.jpg",
+                            "width": 100,
+                            "height": 100,
+                        }
+                    ]
+                },
+                "caption": {"text": "space"},
+            }
+
+        client.fbsearch_topsearch_v2 = AsyncMock(
+            side_effect=[
+                {
+                    "media_grid": {
+                        "sections": [
+                            {
+                                "layout_content": {
+                                    "fill_items": [
+                                        {"media": media("1")},
+                                        {"media": media("2")},
+                                    ]
+                                }
+                            }
+                        ],
+                        "has_more": True,
+                        "next_max_id": "next-page",
+                        "reels_max_id": "next-reels",
+                        "rank_token": "next-rank",
+                    }
+                },
+                {
+                    "media_grid": {
+                        "sections": [
+                            {
+                                "layout_content": {
+                                    "fill_items": [
+                                        {"media": media("3")},
+                                    ]
+                                }
+                            }
+                        ],
+                        "has_more": False,
+                    }
+                },
+            ]
+        )
+
+        medias = await client.media_search("space", amount=3)
+
+        self.assertEqual([media.pk for media in medias], ["1", "2", "3"])
+        self.assertTrue(all(isinstance(media, Media) for media in medias))
+        self.assertEqual(client.fbsearch_topsearch_v2.call_args_list[0].kwargs, {})
+        self.assertEqual(
+            client.fbsearch_topsearch_v2.call_args_list[1].kwargs,
+            {
+                "next_max_id": "next-page",
+                "reels_max_id": "next-reels",
+                "rank_token": "next-rank",
+            },
+        )
+
+    async def test_media_search_stops_at_amount_without_next_page(self):
+        client = self._build_client()
+
+        def media(pk):
+            return {
+                "pk": pk,
+                "id": f"{pk}_2",
+                "code": f"code-{pk}",
+                "taken_at": 1710000000,
+                "media_type": 1,
+                "user": {
+                    "pk": "2",
+                    "username": "example",
+                    "profile_pic_url": "https://example.com/profile.jpg",
+                },
+                "image_versions2": {
+                    "candidates": [
+                        {
+                            "url": f"https://example.com/{pk}.jpg",
+                            "width": 100,
+                            "height": 100,
+                        }
+                    ]
+                },
+                "caption": {"text": "space"},
+            }
+
+        client.fbsearch_topsearch_v2 = AsyncMock(
+            return_value={
+                "media_grid": {
+                    "sections": [
+                        {
+                            "layout_content": {
+                                "fill_items": [
+                                    {"media": media("1")},
+                                    {"media": media("2")},
+                                ]
+                            }
+                        }
+                    ],
+                    "has_more": True,
+                    "next_max_id": "next-page",
+                }
+            }
+        )
+
+        medias = await client.media_search("space", amount=1)
+
+        self.assertEqual([media.pk for media in medias], ["1"])
+        client.fbsearch_topsearch_v2.assert_awaited_once_with("space")


### PR DESCRIPTION
Async mirror of the instagrapi media search helper for https://github.com/subzeroid/instagrapi/issues/826.

Adds `await Client.media_search(query, amount=...)`, extracting `Media` objects from `fbsearch/top_serp` `media_grid` and following the returned pagination cursors.

Verification:
- `ruff check aiograpi/mixins/fbsearch.py tests/regression/test_fbsearch.py tests/live/test_fbsearch.py`
- `pytest -q tests/regression/test_fbsearch.py`
- `./scripts/check-mypy-baseline.sh`
- Remote fresh-clone verification on sk.test: targeted regression + `test_media_search_returns_media_live`