### PR TITLE
Relax runtime dependency pins

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -76,6 +76,33 @@ jobs:
           ruff check --output-format=github .
           ruff format --check .
 
+  minimum-runtime-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install package with minimum runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            "httpx==0.28.1" \
+            "orjson==3.11.8" \
+            "PySocks==1.7.1" \
+            "pydantic==2.12.5" \
+            "Pillow==12.2.0" \
+            "pycryptodomex==3.23.0" \
+            "zstandard==0.25.0"
+          python -m pip install .
+          python -m pip check
+          python - <<'PY'
+          from aiograpi import Client
+
+          Client()
+          PY
+
   mypy:
     # Mypy regression gate. Counts errors against .mypy-baseline and fails
     # if the count goes up. Strict-pass is years away (legacy upstream port

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -86,6 +86,8 @@ Setuptools is used to package the library through `pyproject.toml`.
 
 * `[project].dependencies` lists runtime dependencies imported by the library.
 * `[project.optional-dependencies].test` lists tools needed for tests, linting, docs, and local development.
+* Runtime dependency lower bounds should stay at the currently tested/security-patched version, with an upper bound before the next breaking release line.
+* Android-specific pins are allowed when the mobile Python ecosystem needs an exact wheel-compatible version, for example the Termux pydantic-core wheel constraint.
 
 Publishing is handled by the tag-based `publish.yml` workflow. Pushes and pull requests run the package workflow first;
 maintainers cut a version tag only after the checks are green.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,14 +55,14 @@ keywords = [
     "aiograpi",
 ]
 dependencies = [
-    "httpx==0.28.1",
-    "orjson==3.11.8",
-    "PySocks==1.7.1",
+    "httpx>=0.28.1,<0.29",
+    "orjson>=3.11.8,<4",
+    "PySocks>=1.7.1,<2",
     "pydantic==2.12.5; sys_platform == 'android'",
     "pydantic>=2.12.5,<2.14; sys_platform != 'android'",
-    "pycryptodomex==3.23.0",
-    "zstandard==0.25.0",
-    "Pillow>=12.2.0",
+    "pycryptodomex>=3.23.0,<4",
+    "zstandard>=0.25.0,<0.26",
+    "Pillow>=12.2.0,<13",
 ]
 
 [project.urls]

--- a/tests/regression/test_packaging.py
+++ b/tests/regression/test_packaging.py
@@ -10,6 +10,25 @@ def test_pydantic_dependency_allows_termux_android_wheel_version():
     assert '"pydantic==2.13.4"' not in required_dependencies
 
 
+def test_runtime_dependencies_use_compatible_ranges():
+    pyproject = Path("pyproject.toml").read_text()
+    required_dependencies = pyproject.split("[project.optional-dependencies]", 1)[0]
+
+    assert '"httpx>=0.28.1,<0.29"' in required_dependencies
+    assert '"orjson>=3.11.8,<4"' in required_dependencies
+    assert '"PySocks>=1.7.1,<2"' in required_dependencies
+    assert '"Pillow>=12.2.0,<13"' in required_dependencies
+    assert '"pycryptodomex>=3.23.0,<4"' in required_dependencies
+    assert '"zstandard>=0.25.0,<0.26"' in required_dependencies
+
+    assert '"httpx==0.28.1"' not in required_dependencies
+    assert '"orjson==3.11.8"' not in required_dependencies
+    assert '"PySocks==1.7.1"' not in required_dependencies
+    assert '"Pillow>=12.2.0"' not in required_dependencies
+    assert '"pycryptodomex==3.23.0"' not in required_dependencies
+    assert '"zstandard==0.25.0"' not in required_dependencies
+
+
 def test_termux_guide_documents_android_pydantic_core_wheel_index():
     termux_guide = Path("docs/usage-guide/termux.md").read_text()
 


### PR DESCRIPTION
## Summary
- Mirror the dependency-range policy from https://github.com/subzeroid/instagrapi/pull/2671 for aiograpi runtime dependencies.
- Relax runtime exact pins to conservative compatibility ranges, using narrow next-minor upper bounds for pre-1.0 packages (`httpx`, `zstandard`).
- Keep the Android pydantic pin because that path depends on mobile wheel availability for pydantic-core.
- Add a minimum-runtime-dependencies CI job that installs the lower-bound runtime set, installs aiograpi, runs `pip check`, and imports `Client`.
- Document the runtime dependency policy in the development guide.

Related upstream issue: https://github.com/subzeroid/instagrapi/issues/716

## Tests
- `.venv/bin/python -m pytest -q tests/regression/test_packaging.py`
- `.venv/bin/python -m pytest -q tests/regression/test_packaging.py tests/regression/test_video_metadata.py tests/regression/test_public_transport.py`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `./scripts/check-mypy-baseline.sh`
- fresh venv lower-bound install smoke with `pip check` and `Client()` import
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/mkdocs build --strict`
- `.venv/bin/python -m build`
