### PR TITLE
Handle delta acknowledge challenge step

### DIFF
--- a/aiograpi/mixins/challenge.py
+++ b/aiograpi/mixins/challenge.py
@@ -513,7 +513,7 @@ class ChallengeResolveMixin(ClientMixin):
             A boolean value
         """
         step_name = self.last_json.get("step_name", "")
-        if step_name == "delta_login_review" or step_name == "scraping_warning":
+        if step_name in ("delta_login_review", "delta_acknowledge_approved", "scraping_warning"):
             # IT WAS ME (by GEO)
             await self._send_private_request(challenge_url, {"choice": "0"})
             return True

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -788,6 +788,26 @@ class ChallengeRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn("UFAC web bloks checkpoint", str(cm.exception))
 
+    async def test_challenge_resolve_simple_delta_acknowledge_approved_posts_ack_choice(
+        self,
+    ):
+        client = Client()
+        client.username = "example"
+        client.last_json = {
+            "step_name": "delta_acknowledge_approved",
+            "flow_render_type": 3,
+            "bloks_action": "com.instagram.challenge.navigation.take_challenge",
+            "challenge_context": ('{"step_name":"delta_acknowledge_approved","challenge_type_enum":"GENERIC_PHISHED"}'),
+            "challenge_type_enum_str": "GENERIC_PHISHED",
+            "status": "ok",
+        }
+        client._send_private_request = AsyncMock()
+
+        result = await client.challenge_resolve_simple("/challenge/test/")
+
+        self.assertTrue(result)
+        client._send_private_request.assert_awaited_once_with("/challenge/test/", {"choice": "0"})
+
     async def test_challenge_resolve_uses_default_context_when_missing(self):
         client = Client()
         client.uuid = "uuid-1"


### PR DESCRIPTION
## Summary
- Mirror instagrapi's `delta_acknowledge_approved` challenge handling in the async resolver.
- Post `{"choice": "0"}` through the existing private challenge URL path instead of raising `ChallengeUnknownStep`.
- Add async regression coverage for the reported `GENERIC_PHISHED` payload.

## Tests
- `.venv/bin/python -m pytest -q tests/legacy.py::ChallengeRegressionTestCase tests/regression/test_bloks.py`
- `.venv/bin/ruff check aiograpi tests/legacy.py`
- `.venv/bin/ruff format --check aiograpi tests/legacy.py`

Mirrors https://github.com/subzeroid/instagrapi/issues/630
