### PR TITLE
Preserve media coauthor producers

### DIFF
--- a/aiograpi/extractors.py
+++ b/aiograpi/extractors.py
@@ -91,7 +91,7 @@ def extract_media_v1(data):
     media["sponsor_tags"] = [tag["sponsor"] for tag in media.get("sponsor_tags") or []]
     media["view_count"] = media.get("view_count", media.get("video_view_count", 0))
     media["play_count"] = media.get("play_count", media.get("video_play_count", 0))
-    media["coauthor_producers"] = media.get("coauthor_producers", [])
+    media["coauthor_producers"] = [extract_user_short(user) for user in media.get("coauthor_producers", [])]
     return Media(
         caption_text=(media.get("caption") or {}).get("text", ""),
         resources=[extract_resource_v1(edge) for edge in media.get("carousel_media") or []],

--- a/aiograpi/types.py
+++ b/aiograpi/types.py
@@ -483,6 +483,7 @@ class Media(TypesBaseModel):
     caption_text: str
     accessibility_caption: Optional[str] = None
     usertags: List[Usertag]
+    coauthor_producers: List[UserShort] = []
     sponsor_tags: List[UserShort]
     video_url: Optional[HttpUrl] = None  # for Video and IGTV
     view_count: Optional[int] = 0  # for Video and IGTV

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -388,6 +388,8 @@ In `extra_data`, you can pass additional media settings, for example:
 | disable_comments              | Int    | Disable comments `{"disable_comments": 1}`
 | invite_coauthor_user_ids      | List   | Low-level coauthor invite field. Prefer `coauthor_user_ids=[...]` on `photo_upload`, `video_upload`, or `album_upload`
 
+Accepted Instagram Collabs/coauthor users from private media payloads are available as `media.coauthor_producers`. This is separate from upload-time `coauthor_user_ids`, which only sends collaborator invitations.
+
 ### Example:
 
 ``` python

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, Mock
 
 from aiograpi import Client
 from aiograpi.extractors import extract_media_gql, extract_media_v1
-from aiograpi.types import StoryMedia
+from aiograpi.types import StoryMedia, UserShort
 
 
 class MediaClipsMetadataRegressionTestCase(unittest.TestCase):
@@ -78,6 +78,28 @@ class MediaClipsMetadataRegressionTestCase(unittest.TestCase):
 
         self.assertEqual(media.view_count, 1234)
         self.assertEqual(media.play_count, 5678)
+
+    def test_extract_media_v1_preserves_coauthor_producers(self):
+        payload = self._media_payload()
+        payload["coauthor_producers"] = [
+            {
+                "id": "100",
+                "username": "collab_user",
+                "full_name": "Collab User",
+                "profile_pic_url": "https://example.com/collab.jpg",
+                "is_private": False,
+                "is_verified": True,
+            }
+        ]
+
+        media = extract_media_v1(payload)
+
+        self.assertEqual(len(media.coauthor_producers), 1)
+        coauthor = media.coauthor_producers[0]
+        self.assertIsInstance(coauthor, UserShort)
+        self.assertEqual(coauthor.pk, "100")
+        self.assertEqual(coauthor.username, "collab_user")
+        self.assertTrue(coauthor.is_verified)
 
     def test_extract_media_gql_normalizes_video_counts(self):
         payload = {


### PR DESCRIPTION
## Summary
- Mirror instagrapi's `Media.coauthor_producers` field for accepted Instagram Collabs/coauthor users returned by private media payloads.
- Normalize private `coauthor_producers` entries through `extract_user_short(...)` instead of dropping the field.
- Document that reading `media.coauthor_producers` is separate from upload-time `coauthor_user_ids` invitations.

## Tests
- `.venv/bin/python -m pytest -q tests/regression/test_media.py`
- `.venv/bin/ruff check aiograpi tests/regression/test_media.py`
- `.venv/bin/ruff format --check aiograpi tests/regression/test_media.py`
- `.venv/bin/mkdocs build --strict`

Mirrors https://github.com/subzeroid/instagrapi/issues/629
