### PR TITLE
Expose extended media metadata fields

### DIFF
--- a/aiograpi/types.py
+++ b/aiograpi/types.py
@@ -463,6 +463,26 @@ class ClipsMetadata(TypesBaseModel):
     viewer_interaction_settings: Optional[dict] = None
 
 
+class MediaDimensions(TypesBaseModel):
+    height: Optional[int] = None
+    width: Optional[int] = None
+
+
+class MediaDashInfo(TypesBaseModel):
+    is_dash_eligible: Optional[bool] = False
+    video_dash_manifest: Optional[str] = None
+    number_of_qualities: Optional[int] = 0
+
+
+class ClipsMusicAttributionInfo(TypesBaseModel):
+    artist_name: Optional[str] = None
+    song_name: Optional[str] = None
+    uses_original_audio: Optional[bool] = None
+    should_mute_audio: Optional[bool] = None
+    should_mute_audio_reason: Optional[str] = None
+    audio_id: Optional[str] = None
+
+
 class Media(TypesBaseModel):
     pk: Union[str, int]
     id: str
@@ -480,6 +500,16 @@ class Media(TypesBaseModel):
     like_count: int
     play_count: Optional[int] = None
     has_liked: Optional[bool] = None
+    caption_is_edited: Optional[bool] = False
+    dimensions: Optional[MediaDimensions] = None
+    has_audio: Optional[bool] = False
+    like_and_view_counts_disabled: Optional[bool] = False
+    viewer_can_reshare: Optional[bool] = False
+    viewer_has_saved: Optional[bool] = False
+    is_paid_partnership: Optional[bool] = False
+    is_affiliate: Optional[bool] = False
+    dash_info: Optional[MediaDashInfo] = None
+    clips_music_attribution_info: Optional[ClipsMusicAttributionInfo] = None
     caption_text: str
     accessibility_caption: Optional[str] = None
     usertags: List[Usertag]

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -390,6 +390,8 @@ In `extra_data`, you can pass additional media settings, for example:
 
 Accepted Instagram Collabs/coauthor users from private media payloads are available as `media.coauthor_producers`. This is separate from upload-time `coauthor_user_ids`, which only sends collaborator invitations.
 
+Extended media metadata from Instagram payloads is available on `Media` when returned by the source API, including caption edit state, dimensions, audio presence, hidden count state, viewer save/reshare state, paid partnership/affiliate flags, DASH video info, and clips music attribution.
+
 ### Example:
 
 ``` python

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -101,6 +101,50 @@ class MediaClipsMetadataRegressionTestCase(unittest.TestCase):
         self.assertEqual(coauthor.username, "collab_user")
         self.assertTrue(coauthor.is_verified)
 
+    def test_extract_media_v1_preserves_extended_media_fields(self):
+        payload = self._media_payload()
+        payload.update(
+            {
+                "caption_is_edited": True,
+                "dimensions": {"height": 1916, "width": 1080},
+                "has_audio": True,
+                "like_and_view_counts_disabled": True,
+                "viewer_can_reshare": True,
+                "viewer_has_saved": True,
+                "is_paid_partnership": True,
+                "is_affiliate": True,
+                "dash_info": {
+                    "is_dash_eligible": False,
+                    "video_dash_manifest": None,
+                    "number_of_qualities": 0,
+                },
+                "clips_music_attribution_info": {
+                    "artist_name": "example",
+                    "song_name": "Original audio",
+                    "uses_original_audio": True,
+                    "should_mute_audio": False,
+                    "should_mute_audio_reason": "",
+                    "audio_id": "1192260532058807",
+                },
+            }
+        )
+
+        media = extract_media_v1(payload)
+
+        self.assertTrue(media.caption_is_edited)
+        self.assertEqual(media.dimensions.height, 1916)
+        self.assertEqual(media.dimensions.width, 1080)
+        self.assertTrue(media.has_audio)
+        self.assertTrue(media.like_and_view_counts_disabled)
+        self.assertTrue(media.viewer_can_reshare)
+        self.assertTrue(media.viewer_has_saved)
+        self.assertTrue(media.is_paid_partnership)
+        self.assertTrue(media.is_affiliate)
+        self.assertFalse(media.dash_info.is_dash_eligible)
+        self.assertEqual(media.dash_info.number_of_qualities, 0)
+        self.assertEqual(media.clips_music_attribution_info.artist_name, "example")
+        self.assertTrue(media.clips_music_attribution_info.uses_original_audio)
+
     def test_extract_media_gql_normalizes_video_counts(self):
         payload = {
             "__typename": "GraphVideo",
@@ -127,6 +171,63 @@ class MediaClipsMetadataRegressionTestCase(unittest.TestCase):
 
         self.assertEqual(media.view_count, 1234)
         self.assertEqual(media.play_count, 5678)
+
+    def test_extract_media_gql_preserves_extended_media_fields(self):
+        payload = {
+            "__typename": "GraphVideo",
+            "id": "1",
+            "shortcode": "abc",
+            "taken_at_timestamp": 1710000000,
+            "owner": {
+                "id": "2",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "display_resources": [],
+            "edge_media_to_comment": {"count": 0},
+            "edge_media_preview_like": {"count": 0},
+            "edge_media_to_caption": {"edges": []},
+            "edge_media_to_tagged_user": {"edges": []},
+            "edge_sidecar_to_children": {"edges": []},
+            "edge_media_to_sponsor_user": {"edges": []},
+            "caption_is_edited": True,
+            "dimensions": {"height": 1916, "width": 1080},
+            "has_audio": True,
+            "like_and_view_counts_disabled": True,
+            "viewer_can_reshare": True,
+            "viewer_has_saved": True,
+            "is_paid_partnership": True,
+            "is_affiliate": True,
+            "dash_info": {
+                "is_dash_eligible": False,
+                "video_dash_manifest": None,
+                "number_of_qualities": 0,
+            },
+            "clips_music_attribution_info": {
+                "artist_name": "example",
+                "song_name": "Original audio",
+                "uses_original_audio": True,
+                "should_mute_audio": False,
+                "should_mute_audio_reason": "",
+                "audio_id": "1192260532058807",
+            },
+        }
+
+        media = extract_media_gql(payload)
+
+        self.assertTrue(media.caption_is_edited)
+        self.assertEqual(media.dimensions.height, 1916)
+        self.assertEqual(media.dimensions.width, 1080)
+        self.assertTrue(media.has_audio)
+        self.assertTrue(media.like_and_view_counts_disabled)
+        self.assertTrue(media.viewer_can_reshare)
+        self.assertTrue(media.viewer_has_saved)
+        self.assertTrue(media.is_paid_partnership)
+        self.assertTrue(media.is_affiliate)
+        self.assertFalse(media.dash_info.is_dash_eligible)
+        self.assertEqual(media.dash_info.number_of_qualities, 0)
+        self.assertEqual(media.clips_music_attribution_info.artist_name, "example")
+        self.assertTrue(media.clips_music_attribution_info.uses_original_audio)
 
 
 class MediaActionPayloadRegressionTestCase(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
Summary:
- expose caption edit state, dimensions, audio/count/viewer flags, partnership flags, DASH info, and clips music attribution on Media
- cover private v1 and public GraphQL extraction with regression tests
- mirror the instagrapi media metadata surface

Tests:
- .venv/bin/python -m pytest -q tests/regression/test_media.py tests/regression/test_public.py
- .venv/bin/ruff check aiograpi/types.py tests/regression/test_media.py docs/usage-guide/media.md
- live public media_info_gql smoke for C_BM2yAN4Rm