### PR TITLE
Expose inline media comment previews

### DIFF
--- a/aiograpi/extractors.py
+++ b/aiograpi/extractors.py
@@ -178,8 +178,45 @@ def extract_media_gql(data):
             extract_user_short(edge["node"]["sponsor"])
             for edge in media.get("edge_media_to_sponsor_user", {}).get("edges", [])
         ],
+        comments_preview=extract_media_comments_preview_gql(
+            media.get("edge_media_to_parent_comment") or media.get("edge_media_preview_comment")
+        ),
+        hoisted_comments=[
+            extract_media_inline_comment_gql(edge["node"])
+            for edge in media.get("edge_media_to_hoisted_comment", {}).get("edges", [])
+        ],
         **media,
     )
+
+
+def extract_media_comments_preview_gql(data):
+    if not data:
+        return None
+    page_info = data.get("page_info") or {}
+    return {
+        "count": data.get("count", 0),
+        "has_next_page": page_info.get("has_next_page", False),
+        "end_cursor": page_info.get("end_cursor"),
+        "comments": [extract_media_inline_comment_gql(edge["node"]) for edge in data.get("edges", [])],
+    }
+
+
+def extract_media_inline_comment_gql(data, replied_to_comment_id=None):
+    comment = deepcopy(data)
+    comment["pk"] = str(comment.get("id"))
+    comment["user"] = extract_user_short(comment.get("owner"))
+    comment["created_at_utc"] = comment.get("created_at")
+    comment["has_liked"] = comment.get("has_liked", comment.get("viewer_has_liked"))
+    comment["like_count"] = json_value(comment, "edge_liked_by", "count")
+    if replied_to_comment_id is not None:
+        comment["replied_to_comment_id"] = str(replied_to_comment_id)
+    threaded_comments = comment.get("edge_threaded_comments") or {}
+    comment["replies_count"] = threaded_comments.get("count", 0)
+    comment["replies"] = [
+        extract_media_inline_comment_gql(edge["node"], replied_to_comment_id=comment["pk"])
+        for edge in threaded_comments.get("edges", [])
+    ]
+    return comment
 
 
 def extract_resource_v1(data):

--- a/aiograpi/types.py
+++ b/aiograpi/types.py
@@ -483,6 +483,27 @@ class ClipsMusicAttributionInfo(TypesBaseModel):
     audio_id: Optional[str] = None
 
 
+class MediaInlineComment(TypesBaseModel):
+    pk: str
+    text: str
+    user: UserShort
+    created_at_utc: datetime
+    has_liked: Optional[bool] = None
+    like_count: Optional[int] = None
+    replied_to_comment_id: Optional[str] = None
+    did_report_as_spam: Optional[bool] = None
+    is_restricted_pending: Optional[bool] = None
+    replies_count: Optional[int] = 0
+    replies: List["MediaInlineComment"] = []
+
+
+class MediaCommentsPreview(TypesBaseModel):
+    count: Optional[int] = 0
+    has_next_page: Optional[bool] = False
+    end_cursor: Optional[str] = None
+    comments: List[MediaInlineComment] = []
+
+
 class Media(TypesBaseModel):
     pk: Union[str, int]
     id: str
@@ -510,6 +531,8 @@ class Media(TypesBaseModel):
     is_affiliate: Optional[bool] = False
     dash_info: Optional[MediaDashInfo] = None
     clips_music_attribution_info: Optional[ClipsMusicAttributionInfo] = None
+    comments_preview: Optional[MediaCommentsPreview] = None
+    hoisted_comments: List[MediaInlineComment] = []
     caption_text: str
     accessibility_caption: Optional[str] = None
     usertags: List[Usertag]

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -390,7 +390,29 @@ In `extra_data`, you can pass additional media settings, for example:
 
 Accepted Instagram Collabs/coauthor users from private media payloads are available as `media.coauthor_producers`. This is separate from upload-time `coauthor_user_ids`, which only sends collaborator invitations.
 
-Extended media metadata from Instagram payloads is available on `Media` when returned by the source API, including caption edit state, dimensions, audio presence, hidden count state, viewer save/reshare state, paid partnership/affiliate flags, DASH video info, and clips music attribution.
+Extended media metadata from Instagram payloads is available on `Media` when returned by the source API, including caption edit state, dimensions, audio presence, hidden count state, viewer save/reshare state, paid partnership/affiliate flags, DASH video info, clips music attribution, and inline comment previews.
+
+Extended `Media` metadata fields:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `comments_preview` | `MediaCommentsPreview` or `None` | Inline public/web comment preview when Instagram includes `edge_media_to_parent_comment` or preview comment edges. Use full comments helpers for complete pagination. |
+| `hoisted_comments` | `List[MediaInlineComment]` | Comments Instagram hoists separately from the regular preview list. Usually empty. |
+| `comments_preview.count` | `int` | Total count reported for the inline preview edge. |
+| `comments_preview.has_next_page` | `bool` | Whether the inline preview edge has more comments after `end_cursor`. |
+| `comments_preview.end_cursor` | `str` or `None` | Cursor reported by the inline preview edge. |
+| `comments_preview.comments` | `List[MediaInlineComment]` | Inline parent comments already present in the media payload. |
+| `MediaInlineComment.pk` | `str` | Comment id. |
+| `MediaInlineComment.text` | `str` | Comment text. |
+| `MediaInlineComment.user` | `UserShort` | Comment author. |
+| `MediaInlineComment.created_at_utc` | `datetime` | Comment creation time. |
+| `MediaInlineComment.has_liked` | `bool` or `None` | Current viewer like state when Instagram sends it. |
+| `MediaInlineComment.like_count` | `int` or `None` | Inline like count from the comment edge. |
+| `MediaInlineComment.replied_to_comment_id` | `str` or `None` | Parent comment id for inline replies. |
+| `MediaInlineComment.did_report_as_spam` | `bool` or `None` | Viewer report state when Instagram sends it. |
+| `MediaInlineComment.is_restricted_pending` | `bool` or `None` | Restricted/pending state when Instagram sends it. |
+| `MediaInlineComment.replies_count` | `int` | Number of threaded replies reported inline. |
+| `MediaInlineComment.replies` | `List[MediaInlineComment]` | Inline threaded replies already present in the media payload. |
 
 ### Example:
 

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -229,6 +229,77 @@ class MediaClipsMetadataRegressionTestCase(unittest.TestCase):
         self.assertEqual(media.clips_music_attribution_info.artist_name, "example")
         self.assertTrue(media.clips_music_attribution_info.uses_original_audio)
 
+    def test_extract_media_gql_preserves_inline_comment_preview(self):
+        def comment_node(comment_id, text, user_id, username):
+            return {
+                "id": comment_id,
+                "text": text,
+                "created_at": 1710000000,
+                "did_report_as_spam": False,
+                "owner": {
+                    "id": user_id,
+                    "username": username,
+                    "profile_pic_url": f"https://example.com/{username}.jpg",
+                    "is_verified": False,
+                },
+                "viewer_has_liked": False,
+                "edge_liked_by": {"count": 2},
+                "is_restricted_pending": False,
+                "edge_threaded_comments": {"count": 0, "page_info": {"has_next_page": False}, "edges": []},
+            }
+
+        parent = comment_node("c1", "parent", "10", "parent_user")
+        reply = comment_node("r1", "reply", "11", "reply_user")
+        parent["edge_threaded_comments"] = {
+            "count": 1,
+            "page_info": {"has_next_page": False, "end_cursor": None},
+            "edges": [{"node": reply}],
+        }
+        hoisted = comment_node("h1", "hoisted", "12", "hoisted_user")
+        payload = {
+            "__typename": "GraphImage",
+            "id": "1",
+            "shortcode": "abc",
+            "taken_at_timestamp": 1710000000,
+            "owner": {
+                "id": "2",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "display_resources": [],
+            "edge_media_to_comment": {"count": 1},
+            "edge_media_preview_like": {"count": 0},
+            "edge_media_to_caption": {"edges": []},
+            "edge_media_to_tagged_user": {"edges": []},
+            "edge_sidecar_to_children": {"edges": []},
+            "edge_media_to_sponsor_user": {"edges": []},
+            "edge_media_to_parent_comment": {
+                "count": 1,
+                "page_info": {"has_next_page": True, "end_cursor": "cursor"},
+                "edges": [{"node": parent}],
+            },
+            "edge_media_to_hoisted_comment": {"edges": [{"node": hoisted}]},
+        }
+
+        media = extract_media_gql(payload)
+
+        self.assertEqual(media.comments_preview.count, 1)
+        self.assertTrue(media.comments_preview.has_next_page)
+        self.assertEqual(media.comments_preview.end_cursor, "cursor")
+        comment = media.comments_preview.comments[0]
+        self.assertEqual(comment.pk, "c1")
+        self.assertEqual(comment.text, "parent")
+        self.assertEqual(comment.user.pk, "10")
+        self.assertEqual(comment.user.username, "parent_user")
+        self.assertEqual(comment.like_count, 2)
+        self.assertFalse(comment.has_liked)
+        self.assertFalse(comment.is_restricted_pending)
+        self.assertEqual(comment.replies_count, 1)
+        self.assertEqual(comment.replies[0].pk, "r1")
+        self.assertEqual(comment.replies[0].replied_to_comment_id, "c1")
+        self.assertEqual(media.hoisted_comments[0].pk, "h1")
+        self.assertEqual(media.hoisted_comments[0].text, "hoisted")
+
 
 class MediaActionPayloadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
     def _build_logged_in_client(self):


### PR DESCRIPTION
Summary:
- expose public GraphQL inline comment previews on Media as typed MediaCommentsPreview and MediaInlineComment models
- expose hoisted inline comments separately as Media.hoisted_comments
- document every new field and cover parent comments, nested replies, and hoisted comments with regression tests

Tests:
- .venv/bin/python -m pytest -q tests/regression/test_media.py tests/regression/test_public.py
- .venv/bin/ruff check aiograpi/types.py aiograpi/extractors.py tests/regression/test_media.py docs/usage-guide/media.md
- .venv/bin/mkdocs build --strict
- async live public media_info_gql smoke for C_BM2yAN4Rm