### PR TITLE
Add async iterator helpers for paginated lists

### DIFF
--- a/aiograpi/mixins/hashtag.py
+++ b/aiograpi/mixins/hashtag.py
@@ -2,7 +2,7 @@ import base64
 import json
 import logging
 import warnings
-from typing import List, Optional, Tuple
+from typing import AsyncIterator, List, Optional, Tuple
 
 from aiograpi.exceptions import (
     ClientError,
@@ -20,6 +20,7 @@ from aiograpi.extractors import (
 )
 from aiograpi.mixins.base import ClientMixin
 from aiograpi.types import Hashtag, Media
+from aiograpi.utils.iterators import iter_paginated
 from aiograpi.utils.serialization import dumps
 
 logger = logging.getLogger(__name__)
@@ -335,6 +336,44 @@ class HashtagMixin(ClientMixin):
             if not isinstance(e, ClientError):
                 logger.exception(e)
             return await private_lookup()
+
+    def iter_hashtag_medias(
+        self,
+        name: str,
+        amount: int = 0,
+        page_size: int = 27,
+        tab_key: str = "recent",
+    ) -> AsyncIterator[Media]:
+        """
+        Iterate over medias for a hashtag.
+
+        Parameters
+        ----------
+        name: str
+            Name of the hashtag
+        amount: int, optional
+            Maximum number of media to yield, default is 0 (all medias)
+        page_size: int, optional
+            Maximum number of media to fetch per page, default is 27
+        tab_key: str, optional
+            Tab key: "top", "recent" or "clips", default is "recent". Public GraphQL only supports "recent".
+
+        Returns
+        -------
+        AsyncIterator[Media]
+            Async iterator of Media objects
+        """
+        name = self._normalize_hashtag_name(name)
+
+        async def fetch_page(end_cursor: Optional[str], page_amount: int) -> Tuple[List[Media], Optional[str]]:
+            return await self.hashtag_medias_paginated(
+                name,
+                amount=page_amount,
+                tab_key=tab_key,
+                end_cursor=end_cursor,
+            )
+
+        return iter_paginated(fetch_page, amount=amount, page_size=page_size, initial_cursor=None)
 
     async def hashtag_medias_v1(self, name: str, amount: int = 27, tab_key: str = "") -> List[Media]:
         """

--- a/aiograpi/mixins/media.py
+++ b/aiograpi/mixins/media.py
@@ -5,7 +5,7 @@ import tempfile
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import AsyncIterator, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 from aiograpi import httpx_ext
@@ -33,6 +33,7 @@ from aiograpi.mixins.graphql import GQL_STUFF
 from aiograpi.types import Location, Media, Story, StoryMedia, UserShort, Usertag
 from aiograpi.utils.auth import generate_jazoest
 from aiograpi.utils.ids import InstagramIdCodec
+from aiograpi.utils.iterators import iter_paginated
 from aiograpi.utils.serialization import dumps, json_value
 
 IG_PROFILE_TIMELINE_DOC_ID = "56030350814417327502004290437"
@@ -1248,6 +1249,35 @@ class MediaMixin(ClientMixin):
                     self.logger.exception(e)
                 medias, end_cursor = await self.user_medias_paginated_v1(user_id, amount, end_cursor=end_cursor)
         return medias, end_cursor
+
+    def iter_user_medias(
+        self,
+        user_id: Union[str, int],
+        amount: int = 0,
+        page_size: int = 0,
+    ) -> AsyncIterator[Media]:
+        """
+        Iterate over a user's media.
+
+        Parameters
+        ----------
+        user_id: str
+        amount: int, optional
+            Maximum number of media to yield, default is 0 (all medias)
+        page_size: int, optional
+            Maximum number of media to fetch per page. Default value 0 keeps the endpoint default.
+
+        Returns
+        -------
+        AsyncIterator[Media]
+            Async iterator of Media objects
+        """
+        user_id = str(user_id)
+
+        async def fetch_page(end_cursor: Optional[str], page_amount: int) -> Tuple[List[Media], Optional[str]]:
+            return await self.user_medias_paginated(user_id, amount=page_amount, end_cursor=end_cursor or "")
+
+        return iter_paginated(fetch_page, amount=amount, page_size=page_size, initial_cursor="")
 
     async def user_pinned_medias(self, user_id) -> List[Media]:
         """

--- a/aiograpi/mixins/user.py
+++ b/aiograpi/mixins/user.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from copy import deepcopy
-from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
+from typing import Any, AsyncIterator, Dict, List, Literal, Optional, Sequence, Tuple, Union
 
 from orjson import JSONDecodeError
 
@@ -37,6 +37,7 @@ from aiograpi.types import (
     User,
     UserShort,
 )
+from aiograpi.utils.iterators import iter_paginated
 from aiograpi.utils.serialization import dumps, json_value
 
 MAX_USER_COUNT = 200
@@ -896,6 +897,36 @@ class UserMixin(ClientMixin):
             users = users[:amount]
         return users
 
+    def iter_user_following_v1(
+        self,
+        user_id: str,
+        amount: int = 0,
+        page_size: int = MAX_USER_COUNT,
+    ) -> AsyncIterator[UserShort]:
+        """
+        Iterate over user's following users by Private Mobile API.
+
+        Parameters
+        ----------
+        user_id: str
+            User id of an instagram account
+        amount: int, optional
+            Maximum number of users to yield, default is 0 - Inf
+        page_size: int, optional
+            Maximum number of users to fetch per page, default is 200
+
+        Returns
+        -------
+        AsyncIterator[UserShort]
+            Async iterator of UserShort objects
+        """
+        user_id = str(user_id)
+
+        async def fetch_page(max_id: Optional[str], max_amount: int) -> Tuple[List[UserShort], Optional[str]]:
+            return await self.user_following_v1_chunk(user_id, max_amount=max_amount, max_id=max_id or "")
+
+        return iter_paginated(fetch_page, amount=amount, page_size=page_size, initial_cursor="")
+
     async def user_following(self, user_id: str, amount: int = 0, use_cache: bool = True) -> Dict[str, UserShort]:
         """
         Get user's followers information
@@ -1090,6 +1121,46 @@ class UserMixin(ClientMixin):
         if amount:
             users = users[:amount]
         return users
+
+    def iter_user_followers_v1(
+        self,
+        user_id: str,
+        amount: int = 0,
+        page_size: int = MAX_USER_COUNT,
+        order: Optional[FOLLOWERS_ORDER] = None,
+    ) -> AsyncIterator[UserShort]:
+        """
+        Iterate over user's followers by Private Mobile API.
+
+        Parameters
+        ----------
+        user_id: str
+            User id of an instagram account
+        amount: int, optional
+            Maximum number of users to yield, default is 0 - Inf
+        page_size: int, optional
+            Maximum number of users to fetch per page, default is 200
+        order: str, optional
+            Followers sort order: date_followed_latest or date_followed_earliest
+
+        Returns
+        -------
+        AsyncIterator[UserShort]
+            Async iterator of UserShort objects
+        """
+        user_id = str(user_id)
+
+        async def fetch_page(max_id: Optional[str], max_amount: int) -> Tuple[List[UserShort], Optional[str]]:
+            if order:
+                return await self.user_followers_v1_chunk(
+                    user_id,
+                    max_amount=max_amount,
+                    max_id=max_id or "",
+                    order=order,
+                )
+            return await self.user_followers_v1_chunk(user_id, max_amount=max_amount, max_id=max_id or "")
+
+        return iter_paginated(fetch_page, amount=amount, page_size=page_size, initial_cursor="")
 
     @staticmethod
     def _private_graphql_root(data: Dict, root_field_name: str) -> Dict:

--- a/aiograpi/utils/iterators.py
+++ b/aiograpi/utils/iterators.py
@@ -1,0 +1,40 @@
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from typing import TypeVar
+
+T = TypeVar("T")
+Cursor = str | None
+PageFetcher = Callable[[Cursor, int], Awaitable[tuple[Sequence[T], Cursor]]]
+
+
+async def iter_paginated(
+    fetch_page: PageFetcher[T],
+    amount: int = 0,
+    page_size: int = 0,
+    initial_cursor: Cursor = None,
+) -> AsyncIterator[T]:
+    amount = int(amount)
+    page_size = int(page_size)
+    cursor = initial_cursor
+    yielded = 0
+
+    while True:
+        page_amount = page_size
+        if amount:
+            remaining = amount - yielded
+            if remaining <= 0:
+                return
+            page_amount = min(page_size, remaining) if page_size else remaining
+
+        items, next_cursor = await fetch_page(cursor, page_amount)
+        if not items:
+            return
+
+        for item in items:
+            if amount and yielded >= amount:
+                return
+            yield item
+            yielded += 1
+
+        if not next_cursor or next_cursor == cursor:
+            return
+        cursor = next_cursor

--- a/docs/usage-guide/hashtag.md
+++ b/docs/usage-guide/hashtag.md
@@ -10,6 +10,7 @@ Pass hashtag names without the leading `#`, for example `pizza`. If a leading `#
 | hashtag_medias_top(name: str, amount: int = 9)     | List[Media]         | Return Top posts by Hashtag
 | hashtag_medias_recent(name: str, amount: int = 27) | List[Media]         | Return Most recent posts by Hashtag
 | hashtag_medias_paginated(name: str, amount: int = 27, tab_key: str = "recent", end_cursor: str = None) | Tuple[List[Media], str] | Return one hashtag media page plus the next cursor; authenticated sessions use private/mobile pagination first
+| iter_hashtag_medias(name: str, amount: int = 0, page_size: int = 27, tab_key: str = "recent") | AsyncIterator[Media] | Stream hashtag media page by page without building a full list
 | hashtag_following(amount: int = 0)                 | List[Hashtag]       | Return hashtags followed by the authenticated account
 
 
@@ -118,6 +119,13 @@ Example:
 ['python', 'instagramapi']
 ```
 
+Stream hashtag media without storing every fetched page:
+
+``` python
+async for media in cl.iter_hashtag_medias("downhill", amount=100, page_size=25, tab_key="recent"):
+    print(media.pk, media.code)
+```
+
 Low level methods:
 
 | Method                                         | Return  | Description
@@ -126,6 +134,7 @@ Low level methods:
 | hashtag_info_v1(name: str) | Hashtag | Get information about a hashtag by Private Mobile API
 | hashtag_medias_paginated_gql(name: str, amount: int = 27, end_cursor: str = None) | Tuple[List[Media], str] | Get one recent hashtag media page by Public GraphQL API
 | hashtag_medias_paginated_v1(name: str, amount: int = 27, tab_key: str = "top\|recent\|clips", end_cursor: str = None) | Tuple[List[Media], str] | Get one hashtag media page by Private Mobile API
+| iter_hashtag_medias(name: str, amount: int = 0, page_size: int = 27, tab_key: str = "recent") | AsyncIterator[Media] | Stream hashtag medias page by page through `hashtag_medias_paginated()`
 | hashtag_medias_v1_chunk(name: str, max_amount: int = 27, tab_key: str = "top\|recent", max_id: str = None) | Tuple[List[Media], str] | Get chunk of medias for a hashtag and max_id (cursor) by Private Mobile API
 | hashtag_medias_v1(name: str, amount: int = 27, tab_key: str = "top\|recent") | List[Media] | Get medias for a hashtag by Private Mobile API
 | hashtag_medias_top_v1(name: str, amount: int = 9) | List[Media] | Get top medias for a hashtag by Private Mobile API
@@ -158,3 +167,4 @@ Notes:
 * Instagram's old public hashtag web page JSON (`?__a=1`) is no longer reliable and the `_a1` helpers were removed. Use the high-level hashtag methods or the authenticated private/mobile `_v1` helpers.
 * High-level `hashtag_info()`, `hashtag_medias_top()`, and `hashtag_medias_recent()` use the private/mobile helpers.
 * For resumable pagination, prefer `hashtag_medias_paginated()` and persist the returned cursor. Use `hashtag_medias_v1_chunk()` only when you need the low-level private/mobile helper.
+* Use `iter_hashtag_medias()` when you want to process large hashtag result sets incrementally. It uses the same pagination path as `hashtag_medias_paginated()`.

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -28,6 +28,7 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_pk_from_code(code: str)                                   | int                | Return media_pk
 | media_pk_from_url(url: str)                                     | int                | Return media_pk
 | user_medias(user_id: str, amount: int = 20)                     | List\[Media]       | Get list of medias by user_id
+| iter_user_medias(user_id: str, amount: int = 0, page_size: int = 0) | AsyncIterator\[Media] | Stream user feed media page by page without building a full list
 | user_medias_chunk(user_id: str, end_cursor: str = "")           | Tuple\[List\[Media], str] | Get one page of medias by user_id
 | user_medias_paginated(user_id: str, amount: int = 0, end_cursor: str = "") | Tuple\[List\[Media], str] | Get one page of medias by user_id; compatibility alias for `instagrapi`
 | user_clips(user_id: str, amount: int = 50)                      | List\[Media]       | Get list of clips (reels) by user_id
@@ -212,13 +213,19 @@ True
 
 >>> end_cursor = None
 ... for page in range(3):
-...     medias, end_cursor = client.user_medias_chunk_v1(1903424587, 5, end_cursor=end_cursor)
+...     medias, end_cursor = await client.user_medias_paginated(1903424587, 5, end_cursor=end_cursor)
 ...     print([ m.taken_at.date().isoformat() for m in medias ])
 ...
 
 ['2021-06-09', '2019-10-16', '2019-10-14', '2019-06-13', '2019-06-06']
 ['2019-06-05', '2019-03-23', '2019-03-23', '2018-11-15', '2018-10-16']
 ['2018-10-16', '2018-10-11', '2018-10-09', '2018-10-09', '2018-08-02']
+
+# Stream user media without storing every fetched page
+
+>>> async for media in client.iter_user_medias(1903424587, amount=100, page_size=25):
+...     print(media.pk, media.code)
+...
 
 ```
 

--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -8,6 +8,8 @@ View a list of a user's medias, following and followers
 |-----------------------------------------------|-----------------------|--------------------------------------------------------------|
 | user_followers(user_id: str, amount: int = 0, order: str = None) | Dict\[str, UserShort] | Get dict of follower users (amount=0 - fetch all followers); `order` uses the private mobile followers endpoint |
 | user_following(user_id: str, amount: int = 0) | Dict\[str, UserShort] | Get dict of following users (amount=0 - fetch all)           |
+| iter_user_followers_v1(user_id: str, amount: int = 0, page_size: int = 200, order: str = None) | AsyncIterator[UserShort] | Stream followers from the private/mobile API without building a full dict |
+| iter_user_following_v1(user_id: str, amount: int = 0, page_size: int = 200) | AsyncIterator[UserShort] | Stream following users from the private/mobile API without building a full dict |
 | search_followers(user_id: str, query: str)    | List[UserShort]       | Search by followers                                          |
 | search_following(user_id: str, query: str)    | List[UserShort]       | Search by following                                          |
 | user_info(user_id: str)                       | User                  | Get user info                                                |
@@ -47,9 +49,11 @@ Low level methods:
 | user_followers_gql(user_id: str, amount: int = 0)                                   | List[UserShort]             | Get user's followers information by Public Graphql API                     |
 | user_followers_v1_chunk(user_id: str, max_amount: int = 0, max_id: str = "", order: str = None) | Tuple[List[UserShort], str] | Get user's followers information by Private Mobile API and max_id (cursor) |
 | user_followers_v1(user_id: str, amount: int = 0, order: str = None)                 | List[UserShort]             | Get user's followers information by Private Mobile API                     |
+| iter_user_followers_v1(user_id: str, amount: int = 0, page_size: int = 200, order: str = None) | AsyncIterator[UserShort] | Stream followers page by page through `user_followers_v1_chunk()` |
 | user_followers_private_gql_chunk(user_id: str, max_amount: int = 0, max_id: str = None, rank_token: str = None, order: str = None) | Tuple[List[UserShort], str] | Get user's followers information by Private GraphQL API and max_id         |
 | user_followers_private_gql(user_id: str, amount: int = 0, rank_token: str = None, order: str = None) | List[UserShort] | Get user's followers information by Private GraphQL API                    |
 | user_following_v1(user_id: str, amount: int = 0)                                    | List[UserShort]             | Get user's following users information by Private Mobile API               |
+| iter_user_following_v1(user_id: str, amount: int = 0, page_size: int = 200)         | AsyncIterator[UserShort]     | Stream following users page by page through `user_following_v1_chunk()` |
 | user_following_gql(user_id: str, amount: int = 0)                                   | List[UserShort]             | Get user's following information by Public Graphql API                     |
 | user_follow_requests_chunk(max_amount: int = 0, max_id: str = "")                   | Tuple[List[UserShort], str] | Get pending incoming follow requests by Private Mobile API and max_id      |
 | search_followers_v1(user_id: str, query: str)                                       | List[UserShort]             | Search by followers by Private Mobile API                                  |
@@ -118,6 +122,16 @@ await cl.login(USERNAME, PASSWORD)
 followers = await cl.user_followers(cl.user_id)
 for follower in followers.values():
     await cl.user_unfollow(follower.pk)
+```
+
+Example: Stream large follow lists without storing the full result:
+
+``` python
+async for follower in cl.iter_user_followers_v1(cl.user_id, amount=1000, page_size=100, order="date_followed_latest"):
+    print(follower.pk, follower.username)
+
+async for user in cl.iter_user_following_v1(cl.user_id, amount=1000, page_size=100):
+    print(user.pk, user.username)
 ```
 
 Example: Suggested profiles ("Suggested for you") for a target user:

--- a/tests/live/test_hashtag.py
+++ b/tests/live/test_hashtag.py
@@ -43,3 +43,14 @@ class ClientHashtagLiveTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertGreater(len(next_medias), 0)
         self.assertNotEqual(max_id, next_max_id)
         self.assertTrue({media.pk for media in medias}.isdisjoint({media.pk for media in next_medias}))
+
+    async def test_iter_hashtag_medias_recent_live(self):
+        cl = await self.live_client()
+        medias = []
+
+        async for media in cl.iter_hashtag_medias("instagram", amount=5, page_size=2, tab_key="recent"):
+            medias.append(media)
+
+        self.assertEqual(len(medias), 5)
+        self.assertIsInstance(medias[0], Media)
+        self.assertEqual(len({media.pk for media in medias}), len(medias))

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -4,6 +4,7 @@ import unittest
 from aiograpi import Client
 from aiograpi import types as ig_types
 from aiograpi.extractors import extract_user_short
+from aiograpi.types import Media, UserShort
 from tests.live.smoke import _fetch_accounts
 
 
@@ -99,3 +100,47 @@ class ClientPrivateGraphQLV2UserFieldsLiveTestCase(unittest.IsolatedAsyncioTestC
             raw_value = raw_user.get(field)
             if raw_value is not None:
                 self.assertEqual(getattr(rich_user, field), str(raw_value))
+
+
+class ClientIteratorLiveTestCase(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.test_accounts_url = os.getenv("TEST_ACCOUNTS_URL")
+        if not self.test_accounts_url:
+            self.skipTest("TEST_ACCOUNTS_URL is required for iterator live tests")
+        clients = await _fresh_reusable_user_clients(self.test_accounts_url, count=10)
+        if not clients:
+            self.skipTest("At least one reusable TEST_ACCOUNTS_URL session is required")
+        self.cl = clients[0]
+
+    async def test_iter_user_followers_v1_live(self):
+        user_id = await self.cl.user_id_from_username("instagram")
+        followers = []
+
+        async for follower in self.cl.iter_user_followers_v1(user_id, amount=5, page_size=2):
+            followers.append(follower)
+
+        self.assertEqual(len(followers), 5)
+        self.assertIsInstance(followers[0], UserShort)
+        self.assertEqual(len({user.pk for user in followers}), len(followers))
+
+    async def test_iter_user_following_v1_live(self):
+        user_id = await self.cl.user_id_from_username("instagram")
+        following = []
+
+        async for user in self.cl.iter_user_following_v1(user_id, amount=5, page_size=2):
+            following.append(user)
+
+        self.assertEqual(len(following), 5)
+        self.assertIsInstance(following[0], UserShort)
+        self.assertEqual(len({user.pk for user in following}), len(following))
+
+    async def test_iter_user_medias_live(self):
+        user_id = await self.cl.user_id_from_username("instagram")
+        medias = []
+
+        async for media in self.cl.iter_user_medias(user_id, amount=4, page_size=2):
+            medias.append(media)
+
+        self.assertEqual(len(medias), 4)
+        self.assertIsInstance(medias[0], Media)
+        self.assertEqual(len({media.pk for media in medias}), len(medias))

--- a/tests/regression/test_hashtag.py
+++ b/tests/regression/test_hashtag.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from aiograpi import Client
 from aiograpi.exceptions import ClientError
@@ -220,6 +220,24 @@ class HashtagRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(medias, ["m1"])
         self.assertEqual(end_cursor, "next-page")
+
+    async def test_iter_hashtag_medias_streams_paginated_pages_and_respects_amount(self):
+        client = Client()
+        medias = [Mock(pk=str(i)) for i in range(1, 5)]
+        client.hashtag_medias_paginated = AsyncMock(side_effect=[(medias[:2], "cursor-1"), (medias[2:], "cursor-2")])
+
+        result = []
+        async for media in client.iter_hashtag_medias("python", amount=3, page_size=2, tab_key="recent"):
+            result.append(media)
+
+        self.assertEqual([media.pk for media in result], ["1", "2", "3"])
+        client.hashtag_medias_paginated.assert_has_awaits(
+            [
+                unittest.mock.call("python", amount=2, tab_key="recent", end_cursor=None),
+                unittest.mock.call("python", amount=1, tab_key="recent", end_cursor="cursor-1"),
+            ]
+        )
+        self.assertEqual(client.hashtag_medias_paginated.await_count, 2)
 
     async def test_hashtag_following_fetches_current_account_hashtags(self):
         client = Client()

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -461,6 +461,24 @@ class MediaActionPayloadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.user_medias_paginated_v1.assert_awaited_once_with("123", 1, end_cursor="")
         client.user_medias_paginated_gql.assert_not_awaited()
 
+    async def test_iter_user_medias_streams_paginated_pages_and_respects_amount(self):
+        client = self._build_logged_in_client()
+        medias = [Mock(pk=str(i)) for i in range(1, 5)]
+        client.user_medias_paginated = AsyncMock(side_effect=[(medias[:2], "cursor-1"), (medias[2:], "cursor-2")])
+
+        result = []
+        async for media in client.iter_user_medias("456", amount=3, page_size=2):
+            result.append(media)
+
+        self.assertEqual([media.pk for media in result], ["1", "2", "3"])
+        client.user_medias_paginated.assert_has_awaits(
+            [
+                unittest.mock.call("456", amount=2, end_cursor=""),
+                unittest.mock.call("456", amount=1, end_cursor="cursor-1"),
+            ]
+        )
+        self.assertEqual(client.user_medias_paginated.await_count, 2)
+
     async def test_usertag_medias_uses_private_first_when_authorized(self):
         client = self._build_logged_in_client()
         client.authorization_data = {"sessionid": "sessionid-value", "ds_user_id": "1"}

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -364,6 +364,60 @@ class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.private_request.assert_awaited_once()
         self.assertEqual(client.private_request.call_args.kwargs["params"]["count"], MAX_USER_COUNT)
 
+    async def test_iter_user_followers_v1_streams_chunks_and_respects_amount(self):
+        client = self._build_private_client()
+        users = [
+            UserShort(pk="1", username="one"),
+            UserShort(pk="2", username="two"),
+            UserShort(pk="3", username="three"),
+            UserShort(pk="4", username="four"),
+        ]
+        client.user_followers_v1_chunk = AsyncMock(side_effect=[(users[:2], "cursor-1"), (users[2:], "cursor-2")])
+
+        result = []
+        async for user in client.iter_user_followers_v1(
+            "123",
+            amount=3,
+            page_size=2,
+            order="date_followed_latest",
+        ):
+            result.append(user)
+
+        self.assertEqual([user.pk for user in result], ["1", "2", "3"])
+        self.assertEqual(
+            client.user_followers_v1_chunk.await_args_list[0].kwargs,
+            {"max_amount": 2, "max_id": "", "order": "date_followed_latest"},
+        )
+        self.assertEqual(
+            client.user_followers_v1_chunk.await_args_list[1].kwargs,
+            {"max_amount": 1, "max_id": "cursor-1", "order": "date_followed_latest"},
+        )
+        self.assertEqual(client.user_followers_v1_chunk.await_count, 2)
+
+    async def test_iter_user_following_v1_streams_chunks_and_respects_amount(self):
+        client = self._build_private_client()
+        users = [
+            UserShort(pk="1", username="one"),
+            UserShort(pk="2", username="two"),
+            UserShort(pk="3", username="three"),
+        ]
+        client.user_following_v1_chunk = AsyncMock(side_effect=[(users[:2], "cursor-1"), (users[2:], "")])
+
+        result = []
+        async for user in client.iter_user_following_v1("123", amount=3, page_size=2):
+            result.append(user)
+
+        self.assertEqual([user.pk for user in result], ["1", "2", "3"])
+        self.assertEqual(
+            client.user_following_v1_chunk.await_args_list[0].kwargs,
+            {"max_amount": 2, "max_id": ""},
+        )
+        self.assertEqual(
+            client.user_following_v1_chunk.await_args_list[1].kwargs,
+            {"max_amount": 1, "max_id": "cursor-1"},
+        )
+        self.assertEqual(client.user_following_v1_chunk.await_count, 2)
+
     async def test_user_followers_falls_back_when_private_list_is_limited(self):
         client = Client()
         client.authorization_data = {"sessionid": "sessionid-value", "ds_user_id": "1"}


### PR DESCRIPTION
## Summary
- Mirror instagrapi iterator helpers for async clients.
- Add async `iter_user_followers_v1()`, `iter_user_following_v1()`, `iter_user_medias()`, and `iter_hashtag_medias()`.
- Add regression tests, live iterator tests, and usage-guide examples with `async for`.

Mirror of https://github.com/subzeroid/instagrapi/pull/2678
Fixes https://github.com/subzeroid/instagrapi/issues/1141

## Verification
- `ruff check aiograpi/mixins/user.py aiograpi/mixins/media.py aiograpi/mixins/hashtag.py aiograpi/utils/iterators.py tests/regression/test_user.py tests/regression/test_media.py tests/regression/test_hashtag.py tests/live/test_user.py tests/live/test_hashtag.py docs/usage-guide/user.md docs/usage-guide/media.md docs/usage-guide/hashtag.md`
- `python -m pytest -q tests/regression/test_user.py tests/regression/test_media.py tests/regression/test_hashtag.py`
- `./scripts/check-mypy-baseline.sh`
- Live iterator tests: `4 passed`
