### PR TITLE
Fix photo upload usertags readback

### DIFF
--- a/aiograpi/mixins/photo.py
+++ b/aiograpi/mixins/photo.py
@@ -309,13 +309,52 @@ class UploadPhotoMixin(ClientMixin):
                 extra_data=extra_data,
             ):
                 await self.expose()
-                return await self._extract_configured_media_or_recent(
+                media = await self._extract_configured_media_or_recent(
                     self.last_json,
                     PhotoConfigureError,
                     "Photo upload",
                     previous_media_ids,
                 )
+                return await self._photo_upload_apply_usertags_if_needed(
+                    media,
+                    caption,
+                    usertags,
+                    location,
+                    can_edit=extra_data.get("publish_mode") != "scheduled",
+                )
         raise PhotoConfigureError(response=self.last_response, **self.last_json)
+
+    @staticmethod
+    def _media_contains_usertags(media: Media, usertags: List[Usertag]) -> bool:
+        if not usertags:
+            return True
+        existing = {(str(tag.user.pk), tag.x, tag.y) for tag in media.usertags}
+        requested = {(str(tag.user.pk), tag.x, tag.y) for tag in usertags}
+        return requested.issubset(existing)
+
+    async def _photo_upload_apply_usertags_if_needed(
+        self,
+        media: Media,
+        caption: str,
+        usertags: List[Usertag],
+        location: Location = None,
+        can_edit: bool = True,
+    ) -> Media:
+        if not can_edit or self._media_contains_usertags(media, usertags):
+            return media
+        try:
+            edited = await self.media_edit(media.id, caption, usertags=usertags, location=location)
+        except Exception as e:
+            self.logger.debug("Unable to apply photo usertags with media_edit: %s", e)
+            return media
+        updated = self._extract_configured_media(edited)
+        if updated is not None:
+            return updated
+        try:
+            return await self.media_info_v1(media.pk)
+        except Exception as e:
+            self.logger.debug("Unable to refresh photo after media_edit usertags: %s", e)
+            return media
 
     async def photo_upload_with_music(
         self,

--- a/aiograpi/mixins/photo.py
+++ b/aiograpi/mixins/photo.py
@@ -337,13 +337,18 @@ class UploadPhotoMixin(ClientMixin):
         media: Media,
         caption: str,
         usertags: List[Usertag],
-        location: Location = None,
+        location: Optional[Location] = None,
         can_edit: bool = True,
     ) -> Media:
         if not can_edit or self._media_contains_usertags(media, usertags):
             return media
         try:
-            edited = await self.media_edit(media.id, caption, usertags=usertags, location=location)
+            edited = await self.media_edit(  # type: ignore[attr-defined]
+                media.id,
+                caption,
+                usertags=usertags,
+                location=location,
+            )
         except Exception as e:
             self.logger.debug("Unable to apply photo usertags with media_edit: %s", e)
             return media

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from aiograpi import Client
 from aiograpi.exceptions import PhotoConfigureError, PhotoNotUpload
-from aiograpi.types import Media
+from aiograpi.types import Media, UserShort, Usertag
 from tests.live.auth_helpers import login_with_timeout
 from tests.live.smoke import _fetch_accounts
 
@@ -73,6 +73,26 @@ class ClientUploadCoauthorLiveTestCase(unittest.IsolatedAsyncioTestCase):
         if caption_text is not None:
             self.assertEqual((payload.get("caption") or {}).get("text", ""), caption_text)
         return payload
+
+    async def assertPhotoUsertagsAccessible(self, client, media, expected_usertags, attempts=8, delay=5):
+        last_tags = []
+        for attempt in range(attempts):
+            if attempt:
+                await asyncio.sleep(delay)
+            info = await client.media_info_v1(media.pk)
+            last_tags = info.usertags
+            if len(last_tags) < len(expected_usertags):
+                continue
+            for actual_tag, expected_tag in zip(last_tags, expected_usertags):
+                if (
+                    str(actual_tag.user.pk) != str(expected_tag.user.pk)
+                    or actual_tag.x != expected_tag.x
+                    or actual_tag.y != expected_tag.y
+                ):
+                    break
+            else:
+                return info
+        self.fail(f"Photo usertags were not visible after {attempts} media_info_v1 attempts: {last_tags}")
 
     def make_clip_mp4(self):
         try:
@@ -157,6 +177,55 @@ class ClientUploadCoauthorLiveTestCase(unittest.IsolatedAsyncioTestCase):
                 self.assertIsInstance(media, Media)
                 self.assertEqual(media.caption_text, caption_text)
                 await self.assertUploadedMediaAccessible(uploader, media, media_type=1, caption_text=caption_text)
+                return
+            except PhotoConfigureError:
+                raise
+            except PhotoNotUpload as exc:
+                upload_failures[exc.__class__.__name__] = upload_failures.get(exc.__class__.__name__, 0) + 1
+                continue
+            finally:
+                if media:
+                    self.assertTrue(await uploader.media_delete(media.id))
+
+        self.skipTest(
+            "No upload-capable test account was available "
+            f"(login_failures={login_failures}, upload_failures={upload_failures})"
+        )
+
+    async def test_photo_upload_with_usertags_visible_after_media_info(self):
+        path = self.copy_media_fixture("examples/kanada.jpg")
+        self.assertIsInstance(path, Path)
+        accounts = await _fetch_accounts(self.test_accounts_url, count=50)
+
+        login_failures = {}
+        upload_failures = {}
+        for account in accounts:
+            try:
+                uploader = await _client_from_test_account(account)
+            except Exception as exc:
+                login_failures[exc.__class__.__name__] = login_failures.get(exc.__class__.__name__, 0) + 1
+                continue
+
+            media = None
+            try:
+                instagram = await uploader.user_info_by_username_v1("instagram")
+                usertag = Usertag(
+                    user=UserShort(
+                        pk=instagram.pk,
+                        username=instagram.username,
+                        full_name=instagram.full_name,
+                        profile_pic_url=instagram.profile_pic_url,
+                        is_private=instagram.is_private,
+                    ),
+                    x=0.5,
+                    y=0.5,
+                )
+                caption_text = f"Test caption for photo usertags {int(time.time())}"
+                media = await uploader.photo_upload(path, caption_text, usertags=[usertag])
+                self.assertIsInstance(media, Media)
+                self.assertEqual(media.caption_text, caption_text)
+                info = await self.assertPhotoUsertagsAccessible(uploader, media, [usertag])
+                self.assertEqual(info.caption_text, caption_text)
                 return
             except PhotoConfigureError:
                 raise

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock
 from PIL import Image
 
 from aiograpi import Client
-from aiograpi.types import Media, StoryBuild, UserShort
+from aiograpi.types import Media, StoryBuild, UserShort, Usertag
 
 
 class UploadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
@@ -46,6 +46,40 @@ class UploadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             thumbnail_url="https://example.com/photo.jpg",
         )
 
+    def build_media_payload(self, media_type=1):
+        payload = {
+            "pk": "1",
+            "id": "1_1",
+            "code": "abc",
+            "taken_at": 1710000000,
+            "media_type": media_type,
+            "caption": {"text": "caption"},
+            "user": {
+                "pk": "1",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "like_count": 0,
+            "image_versions2": {
+                "candidates": [
+                    {
+                        "url": "https://example.com/photo.jpg",
+                        "width": 720,
+                        "height": 720,
+                    }
+                ]
+            },
+        }
+        if media_type == 2:
+            payload["video_versions"] = [
+                {
+                    "url": "https://example.com/video.mp4",
+                    "width": 720,
+                    "height": 1280,
+                }
+            ]
+        return payload
+
     async def test_photo_upload_sends_scheduled_publish_metadata(self):
         client = self.build_client()
         schedule_at = 1779808917
@@ -71,6 +105,44 @@ class UploadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         extra_data = client.photo_configure.call_args.kwargs["extra_data"]
         self.assertEqual(json.loads(extra_data["content_scheduling_metadata"]), {"scheduled_publish_time": 1779808917})
+
+    async def test_photo_upload_applies_usertags_with_media_edit_when_configure_ignores_them(self):
+        client = self.build_client()
+        tagged_payload = self.build_media_payload(media_type=1)
+        tagged_payload["usertags"] = {
+            "in": [
+                {
+                    "user": {
+                        "pk": "25025320",
+                        "username": "instagram",
+                        "profile_pic_url": "https://example.com/instagram.jpg",
+                    },
+                    "position": [0.5, 0.5],
+                }
+            ]
+        }
+        usertag = Usertag(
+            user=UserShort(
+                pk="25025320",
+                username="instagram",
+                profile_pic_url="https://example.com/instagram.jpg",
+            ),
+            x=0.5,
+            y=0.5,
+        )
+        client.photo_rupload = AsyncMock(return_value=("1", 720, 720))
+        client.photo_configure = AsyncMock(return_value={"status": "ok"})
+        client._extract_configured_media_or_recent = AsyncMock(return_value=self.build_media(media_type=1))
+        client.media_edit = AsyncMock(return_value={"status": "ok", "media": tagged_payload})
+
+        with unittest.mock.patch("asyncio.sleep", new=AsyncMock()):
+            media = await client.photo_upload(Path("example.jpg"), "caption", usertags=[usertag])
+
+        client.media_edit.assert_awaited_once_with("1_1", "caption", usertags=[usertag], location=None)
+        self.assertEqual(len(media.usertags), 1)
+        self.assertEqual(media.usertags[0].user.pk, "25025320")
+        self.assertEqual(media.usertags[0].x, 0.5)
+        self.assertEqual(media.usertags[0].y, 0.5)
 
     async def test_video_upload_sends_scheduled_publish_metadata(self):
         client = self.build_client()


### PR DESCRIPTION
Mirrors https://github.com/subzeroid/instagrapi/issues/937 for async photo uploads.

Single-photo media/configure accepts the usertags payload but current readback can still return an untagged media object. When photo_upload receives a Media without the requested tags, it now applies the same usertags through media_edit and returns the updated Media. Scheduled photo publishing is left unchanged.

Tests:
- .venv/bin/python -m pytest -q tests/regression/test_upload.py
- .venv/bin/python -m ruff check aiograpi/mixins/photo.py tests/regression/test_upload.py tests/live/test_upload.py
- live: tests/live/test_upload.py::ClientUploadCoauthorLiveTestCase::test_photo_upload_with_usertags_visible_after_media_info