### PR TITLE
Add live-verified user report flow

### DIFF
--- a/aiograpi/mixins/user.py
+++ b/aiograpi/mixins/user.py
@@ -47,11 +47,13 @@ USER_WEB_PROFILE_DOC_ID = "26762473490008061"
 USER_INFO_V2_DOC_ID = "25980296051578533"
 USER_INFO_BY_USERNAME_V2_DOC_ID = "26347858941511777"
 ADDRESS_BOOK_DEFAULT_INCLUDE = ("extra_display_name", "thumbnails")
+USER_REPORT_REASONS = {"spam": ("ig_report_account", "ig_its_inappropriate", "ig_spam_v3")}
 
 logger = logging.getLogger(__name__)
 
 INFO_FROM_MODULE = Literal["self_profile", "feed_timeline", "reel_feed_timeline"]
 FOLLOWERS_ORDER = Literal["date_followed_latest", "date_followed_earliest"]
+USER_REPORT_REASON = Literal["spam"]
 
 
 class UserMixin(ClientMixin):
@@ -1593,6 +1595,68 @@ class UserMixin(ClientMixin):
         assert result.get("status", "") == "ok"
 
         return result.get("friendship_status", {}).get("blocking") is False
+
+    async def user_report(self, user_id: str, reason: USER_REPORT_REASON = "spam") -> bool:
+        """
+        Report a User
+
+        Parameters
+        ----------
+        user_id: str
+            User ID of an Instagram account
+        reason: str, optional
+            Report reason (default "spam")
+
+        Returns
+        -------
+        bool
+            True if Instagram returns the report confirmation state
+        """
+        user_id = str(user_id)
+        if reason not in USER_REPORT_REASONS:
+            raise ValueError(
+                f'Unsupported user report reason "{reason}". Supported reasons: {tuple(USER_REPORT_REASONS)}'
+            )
+
+        result = await self.private_request(
+            "reports/get_frx_prompt/",
+            data={
+                "_uuid": self.uuid,
+                "container_module": "profile",
+                "entry_point": "1",
+                "frx_prompt_request_type": "1",
+                "is_dark_mode": "false",
+                "location": "2",
+                "nua_action": "",
+                "object_id": user_id,
+                "object_type": "5",
+            },
+            with_signature=False,
+        )
+        response = result.get("response", result)
+        context = response.get("context")
+        if not context:
+            raise ClientError("Instagram report flow did not return an initial context", **result)
+
+        for tag in USER_REPORT_REASONS[reason]:
+            result = await self.private_request(
+                "reports/get_frx_prompt/",
+                data={
+                    "_uuid": self.uuid,
+                    "context": context,
+                    "frx_prompt_request_type": "2",
+                    "is_dark_mode": "false",
+                    "nua_action": "",
+                    "selected_tag_types": dumps([tag]),
+                },
+                with_signature=False,
+            )
+            response = result.get("response", result)
+            context = response.get("context")
+            if not context:
+                raise ClientError(f'Instagram report flow did not return context after tag "{tag}"', **result)
+
+        return bool(response.get("follow_up_actions"))
 
     async def user_remove_follower(self, user_id: str) -> bool:
         """

--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -23,6 +23,7 @@ View a list of a user's medias, following and followers
 | user_follow_requests_decline(user_ids: List[str]) | Dict[str, bool]  | Decline pending incoming follow requests                     |
 | user_id_from_username(username: str)          | int                   | Get user_id by username                                      |
 | username_from_user_id(user_id: str)           | str                   | Get username by user_id                                      |
+| user_report(user_id: str, reason: str = "spam") | bool                | Report a user account. Currently supports the live-verified spam report flow |
 | user_remove_follower(user_id: str)            | bool                  | Remove your follower                                         |
 | mute_posts_from_follow(user_id: str)          | bool                  | Mute posts from following user                               |
 | unmute_posts_from_follow(user_id: str)        | bool                  | Unmute posts from following user                             |
@@ -40,6 +41,8 @@ View a list of a user's medias, following and followers
 | user_suggested_profiles(user_id: str, expand_suggestion: bool = False) | dict | Suggested profiles ("Suggested for you") for a profile. Wraps `chaining` and, with `expand_suggestion=True`, returns the raw `fetch_suggestion_details` payload (`items` in current app responses) |
 | address_book_link(contacts: List[AddressBookContact \| dict], include: Sequence[str] \| str = ("extra_display_name", "thumbnails")) | dict | Upload/link address book contacts and return Instagram's raw contact-based suggestions response |
 | address_book_unlink()                         | dict                  | Disconnect the uploaded address book from the current account |
+
+`user_report(user_id, reason="spam")` follows Instagram's current mobile FRX report flow for account spam reports and submits the report. This is a real account action; use it only for accounts you actually intend to report. Unsupported reasons raise `ValueError` until their FRX tag paths are captured and tested.
 
 Low level methods:
 

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -102,6 +102,25 @@ class ClientPrivateGraphQLV2UserFieldsLiveTestCase(unittest.IsolatedAsyncioTestC
                 self.assertEqual(getattr(rich_user, field), str(raw_value))
 
 
+class ClientUserReportLiveTestCase(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        if os.getenv("IG_USER_REPORT_LIVE") != "1":
+            self.skipTest("Set IG_USER_REPORT_LIVE=1 to run the destructive user report live test")
+        self.target_user_id = os.getenv("IG_USER_REPORT_TARGET_ID")
+        if not self.target_user_id:
+            self.skipTest("IG_USER_REPORT_TARGET_ID is required for the user report live test")
+        self.test_accounts_url = os.getenv("TEST_ACCOUNTS_URL")
+        if not self.test_accounts_url:
+            self.skipTest("TEST_ACCOUNTS_URL is required for user report live tests")
+
+    async def test_user_report_spam_live(self):
+        clients = await _fresh_reusable_user_clients(self.test_accounts_url, count=10)
+        if not clients:
+            self.skipTest("At least one reusable TEST_ACCOUNTS_URL session is required")
+
+        self.assertTrue(await clients[0].user_report(self.target_user_id))
+
+
 class ClientIteratorLiveTestCase(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.test_accounts_url = os.getenv("TEST_ACCOUNTS_URL")

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -757,6 +757,68 @@ class UserMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             data={"_uuid": "uuid"},
         )
 
+    async def test_user_report_spam_replays_live_frx_prompt_sequence(self):
+        client = Client()
+        client.uuid = "uuid"
+        responses = [
+            {"response": {"context": "context-0"}},
+            {"response": {"context": "context-1"}},
+            {"response": {"context": "context-2"}},
+            {"response": {"context": "context-3", "follow_up_actions": [{"action_type": "block"}]}},
+        ]
+        client.private_request = AsyncMock(side_effect=responses)
+
+        self.assertTrue(await client.user_report("123"))
+
+        self.assertEqual(client.private_request.await_count, 4)
+        calls = client.private_request.await_args_list
+        self.assertEqual(calls[0].args, ("reports/get_frx_prompt/",))
+        self.assertEqual(
+            calls[0].kwargs,
+            {
+                "data": {
+                    "_uuid": "uuid",
+                    "container_module": "profile",
+                    "entry_point": "1",
+                    "frx_prompt_request_type": "1",
+                    "is_dark_mode": "false",
+                    "location": "2",
+                    "nua_action": "",
+                    "object_id": "123",
+                    "object_type": "5",
+                },
+                "with_signature": False,
+            },
+        )
+        expected_tags = ["ig_report_account", "ig_its_inappropriate", "ig_spam_v3"]
+        for call, expected_context, expected_tag in zip(
+            calls[1:], ["context-0", "context-1", "context-2"], expected_tags
+        ):
+            self.assertEqual(call.args, ("reports/get_frx_prompt/",))
+            self.assertEqual(
+                call.kwargs,
+                {
+                    "data": {
+                        "_uuid": "uuid",
+                        "context": expected_context,
+                        "frx_prompt_request_type": "2",
+                        "is_dark_mode": "false",
+                        "nua_action": "",
+                        "selected_tag_types": json.dumps([expected_tag]),
+                    },
+                    "with_signature": False,
+                },
+            )
+
+    async def test_user_report_rejects_unknown_reason_before_request(self):
+        client = Client()
+        client.private_request = AsyncMock(side_effect=AssertionError("unsupported reason should not request"))
+
+        with self.assertRaisesRegex(ValueError, "Unsupported user report reason"):
+            await client.user_report("123", reason="harassment")
+
+        client.private_request.assert_not_awaited()
+
     async def test_user_stream_by_id_v1_parses_first_json_line_from_stream_response(self):
         client = Client()
         client.last_json = {}


### PR DESCRIPTION
## Summary
- add async `Client.user_report(user_id, reason="spam")` using Instagram's current FRX report prompt flow
- keep unsupported reasons rejected before any request until their FRX tag paths are captured and tested
- mirror the instagrapi implementation with regression coverage, opt-in destructive live coverage, and docs

Mirror of https://github.com/subzeroid/instagrapi/issues/742

## Tests
- `.venv/bin/python -m ruff check aiograpi/mixins/user.py tests/regression/test_user.py tests/live/test_user.py`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m pytest -q tests/regression/test_docs_model_reference.py`
- `.venv/bin/python -m pytest -q -rs tests/live/test_user.py::ClientUserReportLiveTestCase::test_user_report_spam_live` (default skip)
- `IG_USER_REPORT_LIVE=1 IG_USER_REPORT_TARGET_ID=16147964785 .venv/bin/python -m pytest -q -rs tests/live/test_user.py::ClientUserReportLiveTestCase::test_user_report_spam_live` (opt-in live: passed)