### PR TITLE
Add cursor-based Direct message pagination

### DIFF
--- a/aiograpi/mixins/direct.py
+++ b/aiograpi/mixins/direct.py
@@ -370,8 +370,8 @@ class DirectMixin(ClientMixin):
         return threads, cursor
 
     async def direct_thread_chunk(
-        self, thread_id: int, amount: int = 20, cursor: str = None
-    ) -> Tuple[DirectThread, str]:
+        self, thread_id: int, amount: int = 20, cursor: Optional[str] = None
+    ) -> Tuple[DirectThread, Optional[str]]:
         """
         Get one page of a Direct Message thread by cursor
 
@@ -429,7 +429,7 @@ class DirectMixin(ClientMixin):
         """
         assert self.user_id, "Login required"
         cursor = None
-        messages = []
+        messages: List[DirectMessage] = []
         thread = None
         while True:
             limit = min(amount - len(messages), 20) if amount else 20
@@ -463,8 +463,8 @@ class DirectMixin(ClientMixin):
         return (await self.direct_thread(thread_id, amount)).messages
 
     async def direct_messages_chunk(
-        self, thread_id: int, amount: int = 20, cursor: str = None
-    ) -> Tuple[List[DirectMessage], str]:
+        self, thread_id: int, amount: int = 20, cursor: Optional[str] = None
+    ) -> Tuple[List[DirectMessage], Optional[str]]:
         """
         Get one page of messages from a Direct Message thread by cursor
 

--- a/aiograpi/mixins/direct.py
+++ b/aiograpi/mixins/direct.py
@@ -369,6 +369,47 @@ class DirectMixin(ClientMixin):
         cursor = inbox.get("oldest_cursor")
         return threads, cursor
 
+    async def direct_thread_chunk(
+        self, thread_id: int, amount: int = 20, cursor: str = None
+    ) -> Tuple[DirectThread, str]:
+        """
+        Get one page of a Direct Message thread by cursor
+
+        Parameters
+        ----------
+        thread_id: int
+            Unique identifier of a Direct Message thread
+
+        amount: int, optional
+            Maximum number of media to return in this page, default is 20
+
+        cursor: str, optional
+            Cursor from the previous page request
+
+        Returns
+        -------
+        Tuple[DirectThread, str]
+            A tuple of DirectThread and str (cursor)
+        """
+        assert self.user_id, "Login required"
+        params = {
+            "visual_message_return_type": "unseen",
+            "direction": "older",
+            "seq_id": "40065",  # 59663
+            "limit": str(amount or 20),
+        }
+        if cursor:
+            params["cursor"] = cursor
+
+        try:
+            result = await self.private_request(f"direct_v2/threads/{thread_id}/", params=params)
+        except ClientNotFoundError as e:
+            raise DirectThreadNotFound(e, thread_id=thread_id, **self.last_json)
+        thread = result["thread"]
+        if amount:
+            thread["items"] = thread.get("items", [])[:amount]
+        return extract_direct_thread(thread), thread.get("oldest_cursor")
+
     async def direct_thread(self, thread_id: int, amount: int = 20) -> DirectThread:
         """
         Get all the information about a Direct Message thread
@@ -387,31 +428,19 @@ class DirectMixin(ClientMixin):
             An object of DirectThread
         """
         assert self.user_id, "Login required"
-        params = {
-            "visual_message_return_type": "unseen",
-            "direction": "older",
-            "seq_id": "40065",  # 59663
-            "limit": "20",
-        }
         cursor = None
-        items = []
+        messages = []
+        thread = None
         while True:
-            if cursor:
-                params["cursor"] = cursor
-            try:
-                result = await self.private_request(f"direct_v2/threads/{thread_id}/", params=params)
-            except ClientNotFoundError as e:
-                raise DirectThreadNotFound(e, thread_id=thread_id, **self.last_json)
-            thread = result["thread"]
-            for item in thread["items"]:
-                items.append(item)
-            cursor = thread.get("oldest_cursor")
-            if not cursor or (amount and len(items) >= amount):
+            limit = min(amount - len(messages), 20) if amount else 20
+            thread, cursor = await self.direct_thread_chunk(thread_id, limit, cursor=cursor)
+            messages.extend(thread.messages)
+            if not cursor or (amount and len(messages) >= amount):
                 break
         if amount:
-            items = items[:amount]
-        thread["items"] = items
-        return extract_direct_thread(thread)
+            messages = messages[:amount]
+        thread.messages = messages
+        return thread
 
     async def direct_messages(self, thread_id: int, amount: int = 20) -> List[DirectMessage]:
         """
@@ -432,6 +461,31 @@ class DirectMixin(ClientMixin):
         """
         assert self.user_id, "Login required"
         return (await self.direct_thread(thread_id, amount)).messages
+
+    async def direct_messages_chunk(
+        self, thread_id: int, amount: int = 20, cursor: str = None
+    ) -> Tuple[List[DirectMessage], str]:
+        """
+        Get one page of messages from a Direct Message thread by cursor
+
+        Parameters
+        ----------
+        thread_id: int
+            Unique identifier of a Direct Message thread
+
+        amount: int, optional
+            Maximum number of media to return in this page, default is 20
+
+        cursor: str, optional
+            Cursor from the previous page request
+
+        Returns
+        -------
+        Tuple[List[DirectMessage], str]
+            A tuple of list of objects of DirectMessage and str (cursor)
+        """
+        thread, cursor = await self.direct_thread_chunk(thread_id, amount, cursor=cursor)
+        return thread.messages, cursor
 
     async def direct_message(self, thread_id: int, message_id: int, amount: int = 20) -> DirectMessage:
         """

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -12,7 +12,9 @@
 | direct_channels(user_id: Optional[int] = None, thread_subtypes: Optional[List[int]] = None) | List[Dict] | Get Direct channels for a user
 | direct_set_e2ee_eligibility(e2ee_eligibility: int = 4)                    | bool                    | Set Direct E2EE eligibility state
 | direct_thread(thread_id: int, amount: int = 20)                           | DirectThread            | Get Thread with Messages
+| direct_thread_chunk(thread_id: int, amount: int = 20, cursor: str = None) | Tuple[DirectThread, str] | Get one page of Thread with Messages and older-page cursor
 | direct_messages(thread_id: int, amount: int = 20)                         | List[DirectMessage]     | Get only Messages in Thread
+| direct_messages_chunk(thread_id: int, amount: int = 20, cursor: str = None) | Tuple[List[DirectMessage], str] | Get one page of Messages in Thread and older-page cursor
 | direct_message(thread_id: int, message_id: int, amount: int = 20)         | DirectMessage           | Get one Message from Thread by id
 | direct_answer(thread_id: int, text: str)                                  | DirectMessage           | Add Message to exist Thread
 | direct_send(text: str, user_ids: List[int] = [], thread_ids: List[int] = []) | DirectMessage        | Send Message to Users or Threads
@@ -49,6 +51,7 @@ Notes:
 * Direct message requests / invitations are exposed as `direct_requests()`; `direct_pending_inbox()` remains as the older name.
 * `direct_pending_requests_preview()` is the lightweight Android-app preview for request counters; use `direct_requests()` when you need the actual threads.
 * `direct_channels()` and `direct_search_gen_ai_bots()` expose raw app surfaces whose response shape may vary by rollout.
+* `direct_thread_chunk()` and `direct_messages_chunk()` expose Instagram's `oldest_cursor` for message history pagination.
 * `direct_message()` scans the latest `amount` messages in a thread and raises `DirectMessageNotFound` if the id is not present in that window.
 * Shared XMA items such as `xma_clip`, `xma_media_share`, `xma_story_share`, and `xma_profile` keep their original payload in `message.raw_xma`. When Instagram includes `target_url`, the normalized link is also available through `message.xma_share`.
 * Disappearing direct photos and videos with `item_type == "raven_media"` are exposed through `message.visual_media`.

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -12,9 +12,9 @@
 | direct_channels(user_id: Optional[int] = None, thread_subtypes: Optional[List[int]] = None) | List[Dict] | Get Direct channels for a user
 | direct_set_e2ee_eligibility(e2ee_eligibility: int = 4)                    | bool                    | Set Direct E2EE eligibility state
 | direct_thread(thread_id: int, amount: int = 20)                           | DirectThread            | Get Thread with Messages
-| direct_thread_chunk(thread_id: int, amount: int = 20, cursor: str = None) | Tuple[DirectThread, str] | Get one page of Thread with Messages and older-page cursor
+| direct_thread_chunk(thread_id: int, amount: int = 20, cursor: Optional[str] = None) | Tuple[DirectThread, Optional[str]] | Get one page of Thread with Messages and older-page cursor
 | direct_messages(thread_id: int, amount: int = 20)                         | List[DirectMessage]     | Get only Messages in Thread
-| direct_messages_chunk(thread_id: int, amount: int = 20, cursor: str = None) | Tuple[List[DirectMessage], str] | Get one page of Messages in Thread and older-page cursor
+| direct_messages_chunk(thread_id: int, amount: int = 20, cursor: Optional[str] = None) | Tuple[List[DirectMessage], Optional[str]] | Get one page of Messages in Thread and older-page cursor
 | direct_message(thread_id: int, message_id: int, amount: int = 20)         | DirectMessage           | Get one Message from Thread by id
 | direct_answer(thread_id: int, text: str)                                  | DirectMessage           | Add Message to exist Thread
 | direct_send(text: str, user_ids: List[int] = [], thread_ids: List[int] = []) | DirectMessage        | Send Message to Users or Threads

--- a/tests/live/test_direct.py
+++ b/tests/live/test_direct.py
@@ -11,6 +11,65 @@ logger = logging.getLogger("aiograpi.tests")
 
 
 class ClientDirectLiveTestCase(RealtimeLiveHelpers, _legacy.ClientPrivateTestCase):
+    async def test_direct_messages_chunk_paginates_thread_history_live(self):
+        sender = self.cl
+        try:
+            first_recipient = await self.fresh_account_excluding({sender.user_id})
+            second_recipient = await self.fresh_account_excluding({sender.user_id, first_recipient.user_id})
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+        thread_id = None
+        sent_messages = []
+        title = f"aiograpi-pagination-{int(time.time())}"
+        text_prefix = f"aiograpi pagination live {int(time.time())}"
+
+        try:
+            thread_id = await sender.direct_thread_create(
+                [int(first_recipient.user_id), int(second_recipient.user_id)],
+                title=title,
+            )
+            self.assertTrue(thread_id)
+
+            for index in range(3):
+                message = await sender.direct_answer(thread_id, f"{text_prefix} {index}")
+                self.assertIsInstance(message, DirectMessage)
+                self.assertTrue(message.id)
+                sent_messages.append(message)
+                await asyncio.sleep(1)
+
+            first_page = []
+            cursor = None
+            deadline = time.time() + 30
+            while time.time() < deadline:
+                first_page, cursor = await sender.direct_messages_chunk(thread_id, amount=1)
+                if first_page:
+                    break
+                await asyncio.sleep(2)
+
+            self.assertEqual(len(first_page), 1)
+            self.assertIsInstance(first_page[0], DirectMessage)
+            if not cursor:
+                self.skipTest("Instagram did not return oldest_cursor for the live thread")
+
+            second_page, next_cursor = await sender.direct_messages_chunk(thread_id, amount=1, cursor=cursor)
+            self.assertEqual(len(second_page), 1)
+            self.assertIsInstance(second_page[0], DirectMessage)
+            self.assertNotEqual(first_page[0].id, second_page[0].id)
+            self.assertTrue(next_cursor is None or isinstance(next_cursor, str))
+        finally:
+            if thread_id:
+                for message in reversed(sent_messages):
+                    try:
+                        await sender.direct_message_unsend(thread_id, message.id)
+                    except Exception as exc:
+                        logger.warning("Direct pagination message cleanup failed: %s", exc)
+                for client in (sender, first_recipient, second_recipient):
+                    try:
+                        await client.direct_thread_hide(thread_id)
+                    except Exception as exc:
+                        logger.warning("Direct pagination thread cleanup failed: %s", exc)
+
     async def test_direct_media_share_to_group_thread_live(self):
         sender = self.cl
         try:

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -82,6 +82,23 @@ def _direct_thread_with_left_user_payload():
     }
 
 
+def _direct_thread_page_payload(item_ids, oldest_cursor=None):
+    thread = _direct_thread_with_left_user_payload()
+    thread["items"] = [
+        {
+            "item_id": item_id,
+            "user_id": "1",
+            "timestamp": 1761953663000000 + index,
+            "item_type": "text",
+            "text": f"message {item_id}",
+        }
+        for index, item_id in enumerate(item_ids)
+    ]
+    if oldest_cursor is not None:
+        thread["oldest_cursor"] = oldest_cursor
+    return thread
+
+
 def _temp_file(suffix, data):
     tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
     tmp.write(data)
@@ -175,6 +192,52 @@ class DirectMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             await client.direct_message(123, 222, amount=1)
 
         assert "222" in str(ctx.exception)
+
+    async def test_direct_thread_chunk_returns_page_and_cursor(self):
+        client = _build_client()
+        client.private_request = AsyncMock(
+            return_value={"thread": _direct_thread_page_payload(["m1", "m2"], oldest_cursor="cursor-2")}
+        )
+
+        thread, cursor = await client.direct_thread_chunk(123, amount=2, cursor="cursor-1")
+
+        assert [message.id for message in thread.messages] == ["m1", "m2"]
+        assert cursor == "cursor-2"
+        client.private_request.assert_awaited_once_with(
+            "direct_v2/threads/123/",
+            params={
+                "visual_message_return_type": "unseen",
+                "direction": "older",
+                "seq_id": "40065",
+                "limit": "2",
+                "cursor": "cursor-1",
+            },
+        )
+
+    async def test_direct_messages_chunk_returns_messages_and_cursor(self):
+        client = _build_client()
+        thread = extract_direct_thread(_direct_thread_page_payload(["m1"], oldest_cursor="cursor-2"))
+        client.direct_thread_chunk = AsyncMock(return_value=(thread, "cursor-2"))
+
+        messages, cursor = await client.direct_messages_chunk(123, amount=1, cursor="cursor-1")
+
+        assert [message.id for message in messages] == ["m1"]
+        assert cursor == "cursor-2"
+        client.direct_thread_chunk.assert_awaited_once_with(123, 1, cursor="cursor-1")
+
+    async def test_direct_thread_uses_chunk_pagination_until_amount_is_reached(self):
+        client = _build_client()
+        first = extract_direct_thread(_direct_thread_page_payload(["m1", "m2"], oldest_cursor="cursor-1"))
+        second = extract_direct_thread(_direct_thread_page_payload(["m3"], oldest_cursor=None))
+        client.direct_thread_chunk = AsyncMock(side_effect=[(first, "cursor-1"), (second, None)])
+
+        thread = await client.direct_thread(123, amount=3)
+
+        assert [message.id for message in thread.messages] == ["m1", "m2", "m3"]
+        assert client.direct_thread_chunk.await_args_list == [
+            mock.call(123, 3, cursor=None),
+            mock.call(123, 1, cursor="cursor-1"),
+        ]
 
     async def test_direct_message_unsend_delegates_to_delete_endpoint(self):
         client = _build_client()


### PR DESCRIPTION
## Summary

Adds cursor-based pagination helpers for Direct message history:

- `direct_thread_chunk(thread_id, amount=20, cursor=None)` fetches one thread page and returns the next older-page cursor.
- `direct_messages_chunk(thread_id, amount=20, cursor=None)` returns the messages for one page plus the cursor.
- Keeps `direct_thread()` and `direct_messages()` as the existing high-level APIs, now internally using the chunk helper until `amount` is reached.
- Adds regression coverage and a live Direct smoke test for cursor pagination.
- Documents the new methods in the Direct usage guide.

This is a follow-up to the pagination question in #375.

Closes #379

## Test plan

- [x] `.venv/bin/python -m pytest tests/live/test_direct.py::ClientDirectLiveTestCase::test_direct_messages_chunk_paginates_thread_history_live --collect-only -q` (`1 test collected`)
- [x] `.venv/bin/python -m pytest tests/regression/test_direct.py -q` (`39 passed`)
- [x] `.venv/bin/python -m ruff check tests/live/test_direct.py aiograpi/mixins/direct.py tests/regression/test_direct.py`
- [x] `.venv/bin/python -m ruff format --check tests/live/test_direct.py aiograpi/mixins/direct.py tests/regression/test_direct.py`
- [x] `.venv/bin/python -m pytest tests/regression -q` (`415 passed, 3 skipped, 13 subtests passed`)
