### PR TITLE
refactor: route direct_messages through chunk pagination

### DIFF
--- a/aiograpi/mixins/direct.py
+++ b/aiograpi/mixins/direct.py
@@ -460,7 +460,17 @@ class DirectMixin(ClientMixin):
             A list of objects of DirectMessage
         """
         assert self.user_id, "Login required"
-        return (await self.direct_thread(thread_id, amount)).messages
+        cursor = None
+        messages: List[DirectMessage] = []
+        while True:
+            limit = min(amount - len(messages), 20) if amount else 20
+            new_messages, cursor = await self.direct_messages_chunk(thread_id, limit, cursor=cursor)
+            messages.extend(new_messages)
+            if not cursor or (amount and len(messages) >= amount):
+                break
+        if amount:
+            messages = messages[:amount]
+        return messages
 
     async def direct_messages_chunk(
         self, thread_id: int, amount: int = 20, cursor: Optional[str] = None

--- a/tests/live/test_direct.py
+++ b/tests/live/test_direct.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import time
+from contextlib import asynccontextmanager
 
 from aiograpi.exceptions import DirectMessageNotFound
 from aiograpi.types import DirectMessage
@@ -11,8 +12,8 @@ logger = logging.getLogger("aiograpi.tests")
 
 
 class ClientDirectLiveTestCase(RealtimeLiveHelpers, _legacy.ClientPrivateTestCase):
-    async def test_direct_messages_chunk_paginates_thread_history_live(self):
-        sender = self.cl
+    @asynccontextmanager
+    async def direct_pagination_thread(self, sender, test_name):
         try:
             first_recipient = await self.fresh_account_excluding({sender.user_id})
             second_recipient = await self.fresh_account_excluding({sender.user_id, first_recipient.user_id})
@@ -21,8 +22,8 @@ class ClientDirectLiveTestCase(RealtimeLiveHelpers, _legacy.ClientPrivateTestCas
 
         thread_id = None
         sent_messages = []
-        title = f"aiograpi-pagination-{int(time.time())}"
-        text_prefix = f"aiograpi pagination live {int(time.time())}"
+        title = f"aiograpi-{test_name}-{int(time.time())}"
+        text_prefix = f"aiograpi {test_name} live {int(time.time())}"
 
         try:
             thread_id = await sender.direct_thread_create(
@@ -37,7 +38,24 @@ class ClientDirectLiveTestCase(RealtimeLiveHelpers, _legacy.ClientPrivateTestCas
                 self.assertTrue(message.id)
                 sent_messages.append(message)
                 await asyncio.sleep(1)
+            yield thread_id
 
+        finally:
+            if thread_id:
+                for message in reversed(sent_messages):
+                    try:
+                        await sender.direct_message_unsend(thread_id, message.id)
+                    except Exception as exc:
+                        logger.warning("Direct pagination message cleanup failed: %s", exc)
+                for client in (sender, first_recipient, second_recipient):
+                    try:
+                        await client.direct_thread_hide(thread_id)
+                    except Exception as exc:
+                        logger.warning("Direct pagination thread cleanup failed: %s", exc)
+
+    async def test_direct_messages_chunk_paginates_thread_history_live(self):
+        sender = self.cl
+        async with self.direct_pagination_thread(sender, "chunk-pagination") as thread_id:
             first_page = []
             cursor = None
             deadline = time.time() + 30
@@ -57,18 +75,39 @@ class ClientDirectLiveTestCase(RealtimeLiveHelpers, _legacy.ClientPrivateTestCas
             self.assertIsInstance(second_page[0], DirectMessage)
             self.assertNotEqual(first_page[0].id, second_page[0].id)
             self.assertTrue(next_cursor is None or isinstance(next_cursor, str))
-        finally:
-            if thread_id:
-                for message in reversed(sent_messages):
-                    try:
-                        await sender.direct_message_unsend(thread_id, message.id)
-                    except Exception as exc:
-                        logger.warning("Direct pagination message cleanup failed: %s", exc)
-                for client in (sender, first_recipient, second_recipient):
-                    try:
-                        await client.direct_thread_hide(thread_id)
-                    except Exception as exc:
-                        logger.warning("Direct pagination thread cleanup failed: %s", exc)
+
+    async def test_direct_messages_auto_paginates_thread_history_live(self):
+        sender = self.cl
+        async with self.direct_pagination_thread(sender, "messages-pagination") as thread_id:
+            original_direct_messages_chunk = sender.direct_messages_chunk
+            requested_cursors = []
+
+            async def one_message_chunk(thread_id, amount=20, cursor=None):
+                requested_cursors.append(cursor)
+                return await original_direct_messages_chunk(thread_id, amount=1, cursor=cursor)
+
+            sender.direct_messages_chunk = one_message_chunk
+            messages = []
+            try:
+                deadline = time.time() + 30
+                while time.time() < deadline:
+                    requested_cursors.clear()
+                    messages = await sender.direct_messages(thread_id, amount=2)
+                    if len(messages) == 2:
+                        break
+                    await asyncio.sleep(2)
+            finally:
+                sender.direct_messages_chunk = original_direct_messages_chunk
+
+            if len(messages) < 2 and len(requested_cursors) < 2:
+                self.skipTest("Instagram did not return oldest_cursor for the live thread")
+
+            self.assertEqual(len(messages), 2)
+            self.assertTrue(all(isinstance(message, DirectMessage) for message in messages))
+            self.assertEqual(len({message.id for message in messages}), 2)
+            self.assertGreaterEqual(len(requested_cursors), 2)
+            self.assertIsNone(requested_cursors[0])
+            self.assertIsInstance(requested_cursors[1], str)
 
     async def test_direct_media_share_to_group_thread_live(self):
         sender = self.cl

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -225,6 +225,25 @@ class DirectMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         assert cursor == "cursor-2"
         client.direct_thread_chunk.assert_awaited_once_with(123, 1, cursor="cursor-1")
 
+    async def test_direct_messages_uses_chunk_pagination_until_amount_is_reached(self):
+        client = _build_client()
+        first = [
+            DirectMessage(id="m1", user_id="1", timestamp=1),
+            DirectMessage(id="m2", user_id="1", timestamp=2),
+        ]
+        second = [DirectMessage(id="m3", user_id="1", timestamp=3)]
+        client.direct_messages_chunk = AsyncMock(side_effect=[(first, "cursor-1"), (second, None)])
+        client.direct_thread = AsyncMock(return_value=mock.Mock(messages=first + second))
+
+        messages = await client.direct_messages(123, amount=3)
+
+        assert [message.id for message in messages] == ["m1", "m2", "m3"]
+        assert client.direct_messages_chunk.await_args_list == [
+            mock.call(123, 3, cursor=None),
+            mock.call(123, 1, cursor="cursor-1"),
+        ]
+        client.direct_thread.assert_not_called()
+
     async def test_direct_thread_uses_chunk_pagination_until_amount_is_reached(self):
         client = _build_client()
         first = extract_direct_thread(_direct_thread_page_payload(["m1", "m2"], oldest_cursor="cursor-1"))


### PR DESCRIPTION
## Summary
- make `direct_messages()` collect pages via `direct_messages_chunk()` instead of `direct_thread()`
- keep public behavior unchanged: it still auto-paginates until `amount` messages or no cursor remains
- add regression coverage proving `direct_messages()` delegates to `direct_messages_chunk()` page by page
- add live coverage for both `direct_messages_chunk()` cursor paging and `direct_messages()` auto-pagination over live chunk requests

## Test plan
- [x] `.venv/bin/python -m pytest tests/regression/test_direct.py -q` -> 40 passed
- [x] `.venv/bin/python -m ruff check aiograpi/mixins/direct.py tests/regression/test_direct.py tests/live/test_direct.py` -> passed
- [x] `.venv/bin/python -m ruff format --check aiograpi/mixins/direct.py tests/regression/test_direct.py tests/live/test_direct.py` -> passed
- [x] `./scripts/check-mypy-baseline.sh` -> mypy baseline 229, current 229
- [x] `.venv/bin/python -m pytest tests/live/test_direct.py::ClientDirectLiveTestCase::test_direct_messages_chunk_paginates_thread_history_live tests/live/test_direct.py::ClientDirectLiveTestCase::test_direct_messages_auto_paginates_thread_history_live -q -s` -> attempted locally, blocked in `asyncSetUp` by test-account proxy auth (`AuthRequiredProxyError 302 Found`) before either test body ran