### PR TITLE
docs: expose direct media type literal

### DIFF
--- a/aiograpi/mixins/direct.py
+++ b/aiograpi/mixins/direct.py
@@ -62,6 +62,7 @@ SEND_ATTRIBUTE_MEDIA = Literal[
     "feed_contextual_self_profile",
     "feed_contextual_profile",
 ]
+DirectMediaType = Literal["photo", "video"]
 BOX = Literal["general", "primary"]
 
 
@@ -1135,7 +1136,7 @@ class DirectMixin(ClientMixin):
         path: Path,
         user_ids: List[int] = [],
         thread_ids: List[int] = [],
-        content_type: str = "photo",
+        content_type: DirectMediaType = "photo",
     ) -> DirectMessage:
         """
         Send a direct file to list of users or threads
@@ -1681,7 +1682,7 @@ class DirectMixin(ClientMixin):
         user_ids: List[int] = [],
         thread_ids: List[int] = [],
         send_attribute: SEND_ATTRIBUTE_MEDIA = "feed_timeline",
-        media_type: str = "photo",
+        media_type: DirectMediaType = "photo",
     ) -> DirectMessage:
         """
         Share a media to list of users

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -24,7 +24,7 @@
 | direct_thread_add_users(thread_id: int, user_ids: List[int])              | bool                    | Add users to a group thread
 | direct_thread_hide(thread_id: int)                                        | bool                    | Delete (called "hide")
 | direct_thread_update_title(thread_id: int, title: str)                    | bool                    | Update a thread title
-| direct_media_share(media_id: str, user_ids: List[int] = [], thread_ids: List[int] = [], send_attribute: SEND_ATTRIBUTE_MEDIA = "feed_timeline") | DirectMessage | Share a media to users or existing threads
+| direct_media_share(media_id: str, user_ids: List[int] = [], thread_ids: List[int] = [], send_attribute: SEND_ATTRIBUTE_MEDIA = "feed_timeline", media_type: DirectMediaType = "photo") | DirectMessage | Share a media to users or existing threads
 | direct_story_share(story_id: str, user_ids: List[int], thread_ids: List[int]) | DirectMessage       | Share a story to list of users
 | direct_profile_share(user_id: str, user_ids: List[int], thread_ids: List[int]) | DirectMessage      | Share a user profile to list of users
 | direct_thread_mark_unread(thread_id: int)                                 | bool                    | Mark a thread as unread
@@ -47,6 +47,7 @@ Notes:
 
 * Direct recipient arguments accept either one id (`user_ids=123`) or a list of ids (`user_ids=[123]`).
 * For `direct_send()`, `direct_media_share()`, `direct_send_photo()`, `direct_send_video()`, and `direct_send_voice()`, pass exactly one of `user_ids` or `thread_ids`.
+* Direct media type values are exposed as `DirectMediaType = Literal["photo", "video"]` for low-level `direct_send_file(content_type=...)` and `direct_media_share(media_type=...)`.
 * `direct_send_video()` uses the current direct video attachment flow. `video_upload_to_direct()` remains available for the older story-to-direct flow.
 * Direct message requests / invitations are exposed as `direct_requests()`; `direct_pending_inbox()` remains as the older name.
 * `direct_pending_requests_preview()` is the lightweight Android-app preview for request counters; use `direct_requests()` when you need the actual threads.

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -43,11 +43,18 @@
 | direct_send_voice(path: Path, user_ids: List[int], thread_ids: List[int], waveform: Optional[List[float]] = None) | DirectMessage | Send an m4a/AAC voice message to list of users or threads
 | video_upload_to_direct(path: Path, caption: str, thumbnail: Path, mentions: List[StoryMention], thread_ids: List[int] = [], extra_data: Dict[str, str] = {}) | DirectMessage | Upload video to direct thread as a story and configure it
 
+### Option types
+
+Direct media type is exposed as `DirectMediaType = Literal["photo", "video"]`.
+
+| Type | Values | Used by |
+| --- | --- | --- |
+| `DirectMediaType` | `"photo"`, `"video"` | `direct_send_file(content_type=...)`, `direct_media_share(media_type=...)` |
+
 Notes:
 
 * Direct recipient arguments accept either one id (`user_ids=123`) or a list of ids (`user_ids=[123]`).
 * For `direct_send()`, `direct_media_share()`, `direct_send_photo()`, `direct_send_video()`, and `direct_send_voice()`, pass exactly one of `user_ids` or `thread_ids`.
-* Direct media type values are exposed as `DirectMediaType = Literal["photo", "video"]` for low-level `direct_send_file(content_type=...)` and `direct_media_share(media_type=...)`.
 * `direct_send_video()` uses the current direct video attachment flow. `video_upload_to_direct()` remains available for the older story-to-direct flow.
 * Direct message requests / invitations are exposed as `direct_requests()`; `direct_pending_inbox()` remains as the older name.
 * `direct_pending_requests_preview()` is the lightweight Android-app preview for request counters; use `direct_requests()` when you need the actual threads.

--- a/tests/regression/test_public_literal_types.py
+++ b/tests/regression/test_public_literal_types.py
@@ -97,7 +97,13 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         docs = Path("docs/usage-guide/direct.md").read_text()
 
         self.assertIn('media_type: DirectMediaType = "photo"', docs)
+        self.assertIn("### Option types", docs)
         self.assertIn('DirectMediaType = Literal["photo", "video"]', docs)
+        self.assertIn(
+            '| `DirectMediaType` | `"photo"`, `"video"` | `direct_send_file(content_type=...)`, '
+            "`direct_media_share(media_type=...)` |",
+            docs,
+        )
 
     def test_insights_media_feed_all_uses_public_literal_aliases(self):
         insights_media_feed_all = signature(InsightsMixin.insights_media_feed_all)

--- a/tests/regression/test_public_literal_types.py
+++ b/tests/regression/test_public_literal_types.py
@@ -5,7 +5,7 @@ from typing import get_args
 
 from aiograpi.mixins.account import ProfessionalAccountType
 from aiograpi.mixins.clip import UploadClipMixin
-from aiograpi.mixins.direct import BOX, SELECTED_FILTER, SEND_ATTRIBUTE_MEDIA, DirectMixin
+from aiograpi.mixins.direct import BOX, SELECTED_FILTER, SEND_ATTRIBUTE_MEDIA, DirectMediaType, DirectMixin
 from aiograpi.mixins.hashtag import HashtagTab
 from aiograpi.mixins.insights import DATA_ORDERING, POST_TYPE, TIME_FRAME, InsightsMixin
 from aiograpi.mixins.location import LocationTab
@@ -65,6 +65,7 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         self.assertEqual(set(get_args(NotificationContentType)), EXPECTED_NOTIFICATION_CONTENT_TYPES)
         self.assertEqual(set(get_args(PublicTransport)), {"requests", "curl"})
         self.assertEqual(set(get_args(SEND_ATTRIBUTE_MEDIA)), EXPECTED_DIRECT_MEDIA_SEND_ATTRIBUTES)
+        self.assertEqual(set(get_args(DirectMediaType)), {"photo", "video"})
         self.assertEqual(set(get_args(MUSIC_PRODUCT)), EXPECTED_MUSIC_PRODUCTS)
         self.assertEqual(set(get_args(StoryResizeMode)), {"fill", "fit"})
 
@@ -84,6 +85,19 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         direct_media_share = signature(DirectMixin.direct_media_share)
 
         self.assertEqual(direct_media_share.parameters["send_attribute"].annotation, SEND_ATTRIBUTE_MEDIA)
+
+    def test_direct_media_methods_use_public_media_type_literal(self):
+        direct_send_file = signature(DirectMixin.direct_send_file)
+        direct_media_share = signature(DirectMixin.direct_media_share)
+
+        self.assertEqual(direct_send_file.parameters["content_type"].annotation, DirectMediaType)
+        self.assertEqual(direct_media_share.parameters["media_type"].annotation, DirectMediaType)
+
+    def test_direct_usage_guide_documents_public_media_type_literal(self):
+        docs = Path("docs/usage-guide/direct.md").read_text()
+
+        self.assertIn('media_type: DirectMediaType = "photo"', docs)
+        self.assertIn('DirectMediaType = Literal["photo", "video"]', docs)
 
     def test_insights_media_feed_all_uses_public_literal_aliases(self):
         insights_media_feed_all = signature(InsightsMixin.insights_media_feed_all)


### PR DESCRIPTION
## Summary
- Add `DirectMediaType = Literal["photo", "video"]` for Direct media helpers.
- Annotate `direct_send_file(content_type=...)` and `direct_media_share(media_type=...)` with the shared alias.
- Document the supported values in the Direct usage guide and cover the public signatures with regression tests.

## Test plan
- [x] `.venv/bin/ruff check .`
- [x] `.venv/bin/mkdocs build --strict`
- [x] `.venv/bin/python -m pytest tests/regression -q`