### PR TITLE
v1.10.26 fix: normalize sponsor tag users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [1.10.26] - 2026-06-23
+
+### Fixed
+
+- Normalized private API sponsor tag users for media and stories so partial `friendship_status` payloads deserialize without validation errors.
+- Synced the recorded upstream baseline to `instagrapi` 2.16.25.
+
 ## [1.10.25] - 2026-06-20
 
 ### Fixed

--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -46,7 +46,7 @@ from aiograpi.mixins.video import DownloadVideoMixin, UploadVideoMixin
 # Used as fallback logger if another is not provided.
 DEFAULT_LOGGER = logging.getLogger("aiograpi")
 
-__upstream_instagrapi_version__ = "2.16.24"
+__upstream_instagrapi_version__ = "2.16.25"
 
 
 class Client(

--- a/aiograpi/extractors.py
+++ b/aiograpi/extractors.py
@@ -88,7 +88,7 @@ def extract_media_v1(data):
     )
     media["like_count"] = media.get("like_count", 0)
     media["has_liked"] = media.get("has_liked", False)
-    media["sponsor_tags"] = [tag["sponsor"] for tag in media.get("sponsor_tags") or []]
+    media["sponsor_tags"] = [extract_user_short(tag["sponsor"]) for tag in media.get("sponsor_tags") or []]
     media["view_count"] = media.get("view_count", media.get("video_view_count", 0))
     media["play_count"] = media.get("play_count", media.get("video_play_count", 0))
     media["coauthor_producers"] = [extract_user_short(user) for user in media.get("coauthor_producers", [])]
@@ -655,7 +655,7 @@ def extract_story_v1(data):
         for link in cta.get("links", []):
             story["links"].append(StoryLink(**link))
     story["user"] = extract_user_short(story.get("user"))
-    story["sponsor_tags"] = [tag["sponsor"] for tag in story.get("sponsor_tags", [])]
+    story["sponsor_tags"] = [extract_user_short(tag["sponsor"]) for tag in story.get("sponsor_tags", [])]
     story["is_paid_partnership"] = story.get("is_paid_partnership")
     if not story.get("code"):
         story["code"] = InstagramIdCodec.encode(story["pk"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.10.25"
+version = "1.10.26"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -79,6 +79,26 @@ class MediaClipsMetadataRegressionTestCase(unittest.TestCase):
         self.assertEqual(media.view_count, 1234)
         self.assertEqual(media.play_count, 5678)
 
+    def test_extract_media_v1_normalizes_sponsor_tag_friendship_status(self):
+        payload = self._media_payload()
+        payload["sponsor_tags"] = [
+            {
+                "sponsor": {
+                    "pk": "3",
+                    "username": "sponsor",
+                    "profile_pic_url": "https://example.com/sponsor.jpg",
+                    "friendship_status": {"following": False},
+                }
+            }
+        ]
+
+        media = extract_media_v1(payload)
+
+        self.assertEqual(media.sponsor_tags[0].pk, "3")
+        self.assertEqual(media.sponsor_tags[0].friendship_status.user_id, "3")
+        self.assertFalse(media.sponsor_tags[0].friendship_status.following)
+        self.assertFalse(media.sponsor_tags[0].friendship_status.incoming_request)
+
     def test_extract_media_v1_preserves_coauthor_producers(self):
         payload = self._media_payload()
         payload["coauthor_producers"] = [

--- a/tests/regression/test_story.py
+++ b/tests/regression/test_story.py
@@ -117,6 +117,46 @@ class StoryMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(story.polls[0].options, ["Yes", "No"])
         self.assertTrue(story.polls[0].viewer_can_vote)
 
+    async def test_extract_story_v1_normalizes_sponsor_tag_friendship_status(self):
+        story = extract_story_v1(
+            {
+                "pk": "1",
+                "id": "1_2",
+                "code": "abc",
+                "taken_at": 1710000000,
+                "media_type": 1,
+                "image_versions2": {
+                    "candidates": [
+                        {
+                            "url": "https://example.com/thumbnail.jpg",
+                            "width": 720,
+                            "height": 1280,
+                        }
+                    ]
+                },
+                "user": {
+                    "pk": "2",
+                    "username": "example",
+                    "profile_pic_url": "https://example.com/profile.jpg",
+                },
+                "sponsor_tags": [
+                    {
+                        "sponsor": {
+                            "pk": "3",
+                            "username": "sponsor",
+                            "profile_pic_url": "https://example.com/sponsor.jpg",
+                            "friendship_status": {"following": False},
+                        }
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(story.sponsor_tags[0].pk, "3")
+        self.assertEqual(story.sponsor_tags[0].friendship_status.user_id, "3")
+        self.assertFalse(story.sponsor_tags[0].friendship_status.following)
+        self.assertFalse(story.sponsor_tags[0].friendship_status.incoming_request)
+
     async def test_story_poll_vote_posts_vote_to_poll_endpoint(self):
         client = Client()
         client.authorization_data = {"sessionid": "sessionid-value", "ds_user_id": "1"}

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -2,4 +2,4 @@ import aiograpi
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.16.24"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.16.25"


### PR DESCRIPTION
## Summary
- Normalize private API sponsor tag users for media and stories through extract_user_short
- Add regression coverage for partial sponsor friendship_status payloads
- Bump aiograpi to 1.10.26 and record upstream instagrapi baseline 2.16.25

## Tests
- .venv/bin/python -m pytest tests/regression -q
- .venv/bin/python -m ruff check aiograpi/extractors.py aiograpi/__init__.py tests/regression/test_media.py tests/regression/test_story.py tests/regression/test_upstream_sync.py
- git diff --check