### PR TITLE
Fix FBNS cleanup after socket failures

### DIFF
--- a/aiograpi/mixins/realtime.py
+++ b/aiograpi/mixins/realtime.py
@@ -54,8 +54,10 @@ class RealtimeMixin:
 
     async def fbns_disconnect(self) -> None:
         if self.fbns:
-            await self.fbns.disconnect()
-            self.fbns = None
+            try:
+                await self.fbns.disconnect()
+            finally:
+                self.fbns = None
 
     def fbns_on(self, event: str, handler) -> None:
         if not self.fbns:

--- a/aiograpi/realtime/fbns.py
+++ b/aiograpi/realtime/fbns.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import json
 import time
 import uuid
@@ -133,10 +134,13 @@ class FbnsClient:
             self.emit("registered", {"token": token, "response": response})
 
     async def disconnect(self) -> None:
-        if self.connected:
-            await self._send(write_disconnect_packet())
-        await asyncio.to_thread(self.transport.disconnect)
-        self.connected = False
+        try:
+            if self.connected:
+                with contextlib.suppress(Exception):
+                    await self._send(write_disconnect_packet())
+            await asyncio.to_thread(self.transport.disconnect)
+        finally:
+            self.connected = False
 
     def build_connection(self) -> MQTToTConnection:
         phone_id = getattr(self.client, "phone_id", "") or ""
@@ -301,10 +305,18 @@ class FbnsClient:
             await self._send(b"\x40\x02" + packet.packet_id.to_bytes(2, "big"))
 
     async def _send(self, packet: bytes) -> None:
-        await asyncio.to_thread(self.transport.send, packet)
+        try:
+            await asyncio.to_thread(self.transport.send, packet)
+        except Exception:
+            self.connected = False
+            raise
 
     async def _recv_packet(self) -> bytes:
-        return await asyncio.to_thread(self.transport.recv_packet)
+        try:
+            return await asyncio.to_thread(self.transport.recv_packet)
+        except Exception:
+            self.connected = False
+            raise
 
     def emit(self, event: str, payload: Any) -> None:
         for handler in self._handlers.get(event, []):

--- a/tests/regression/test_fbns.py
+++ b/tests/regression/test_fbns.py
@@ -237,6 +237,32 @@ class FbnsClientRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         await client.fbns_disconnect()
         transport.disconnect.assert_called_once()
 
+    async def test_fbns_read_once_marks_client_disconnected_when_socket_closes(self):
+        client = _build_logged_in_client()
+        transport = mock.Mock()
+        transport.recv_packet.side_effect = ConnectionError("Socket closed while reading MQTT packet")
+        fbns = FbnsClient(client, transport=transport)
+        fbns.connected = True
+
+        with self.assertRaises(ConnectionError):
+            await fbns.read_once()
+
+        self.assertFalse(fbns.connected)
+
+    async def test_fbns_disconnect_clears_client_state_after_broken_socket(self):
+        client = _build_logged_in_client()
+        transport = mock.Mock()
+        transport.send.side_effect = ConnectionError("Socket is already closed")
+        fbns = FbnsClient(client, transport=transport)
+        fbns.connected = True
+        client.fbns = fbns
+
+        await client.fbns_disconnect()
+
+        transport.disconnect.assert_called_once()
+        self.assertFalse(fbns.connected)
+        self.assertIsNone(client.fbns)
+
     def test_fbns_default_transport_uses_mqtt_mini_and_client_proxy(self):
         client = _build_logged_in_client()
         client.proxy = "socks5://127.0.0.1:8888"


### PR DESCRIPTION
## Summary
- mark `FbnsClient.connected` false when FBNS transport send/read fails
- make FBNS disconnect best-effort so a broken socket still closes the transport
- always clear `Client.fbns` after `fbns_disconnect()`, even if lower-level cleanup raises

This addresses the broken-state part of #396. It does not claim Instagram MQTT sockets will stay connected indefinitely; long-lived workers should still reconnect after remote/network disconnects.

## Tests
- PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q tests/regression/test_fbns.py::FbnsClientRegressionTestCase::test_fbns_read_once_marks_client_disconnected_when_socket_closes tests/regression/test_fbns.py::FbnsClientRegressionTestCase::test_fbns_disconnect_clears_client_state_after_broken_socket
- PYTHONDONTWRITEBYTECODE=1 .venv/bin/ruff check aiograpi/realtime/fbns.py aiograpi/mixins/realtime.py tests/regression/test_fbns.py
- PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q tests/regression/test_fbns.py tests/regression/test_realtime.py
- PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q tests/regression
- git diff --check