### PR TITLE
Keep FBNS connected on read timeout

### DIFF
--- a/aiograpi/realtime/fbns.py
+++ b/aiograpi/realtime/fbns.py
@@ -314,6 +314,8 @@ class FbnsClient:
     async def _recv_packet(self) -> bytes:
         try:
             return await asyncio.to_thread(self.transport.recv_packet)
+        except TimeoutError:
+            raise
         except Exception:
             self.connected = False
             raise

--- a/tests/regression/test_fbns.py
+++ b/tests/regression/test_fbns.py
@@ -249,6 +249,18 @@ class FbnsClientRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(fbns.connected)
 
+    async def test_fbns_read_once_keeps_client_connected_on_socket_timeout(self):
+        client = _build_logged_in_client()
+        transport = mock.Mock()
+        transport.recv_packet.side_effect = TimeoutError("timed out")
+        fbns = FbnsClient(client, transport=transport)
+        fbns.connected = True
+
+        with self.assertRaises(TimeoutError):
+            await fbns.read_once()
+
+        self.assertTrue(fbns.connected)
+
     async def test_fbns_disconnect_clears_client_state_after_broken_socket(self):
         client = _build_logged_in_client()
         transport = mock.Mock()


### PR DESCRIPTION
## What

- Keep `FbnsClient.connected` true when a read attempt raises `TimeoutError`.
- Preserve the existing behavior where closed sockets / transport failures mark FBNS disconnected.
- Add regression coverage for the timeout path.

## Why

A read timeout means no MQTT packet arrived before the socket timeout; it does not prove the socket is closed. The previous cleanup fix treated every `_recv_packet()` exception as fatal.

## Verification

- RED: `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q tests/regression/test_fbns.py::FbnsClientRegressionTestCase::test_fbns_read_once_keeps_client_connected_on_socket_timeout` failed before the fix with `fbns.connected` false.
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/ruff check aiograpi/realtime/fbns.py tests/regression/test_fbns.py`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q tests/regression/test_fbns.py`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q tests/regression`

Mirrored in `instagrapi`: subzeroid/instagrapi#2717

Closes #402