### PR TITLE
fix: fail fast for native challenge checkpoints

### DIFF
--- a/aiograpi/mixins/challenge.py
+++ b/aiograpi/mixins/challenge.py
@@ -167,6 +167,16 @@ class ChallengeResolveMixin(ClientMixin):
                 "This challenge is not yet supported automatically."
             )
             raise ChallengeRequired(**last_json)
+        if last_json.get("challenge", {}).get("native_flow") and challenge_url.startswith("/challenge/"):
+            error_context = dict(last_json)
+            error_context.pop("message", None)
+            raise ChallengeRequired(
+                "Manual verification required via Instagram native challenge flow. "
+                "This checkpoint is not handled by challenge_code_handler or change_password_handler; "
+                "complete it in the official Instagram app or web flow on a trusted device. "
+                "Retry with the same saved client settings, device identifiers, and proxy/IP.",
+                **error_context,
+            )
         try:
             user_id, nonce_code = challenge_url.split("/")[2:4]
             challenge_context = last_json.get("challenge", {}).get("challenge_context")

--- a/docs/usage-guide/challenge_resolver.md
+++ b/docs/usage-guide/challenge_resolver.md
@@ -50,6 +50,8 @@ Phone-only signup is supported with `await cl.signup(username, password, email="
 
 `signup_caa_email(...)` is the experimental modern CAA/Bloks email signup helper. It sends the current Android registration flow and uses `challenge_code_handler(username, ChallengeChoice.EMAIL)` to fetch the email confirmation code.
 
+Native challenge payloads with `challenge.native_flow=true` and an opaque `/challenge/...` `api_path` are manual checkpoints. They do not expose an SMS/email/password step, so `challenge_code_handler` and `change_password_handler` will not be called for them.
+
 Bloks redirect checkpoints such as `bloks_action="com.bloks.www.ig.challenge.redirect.async"` or placeholder `step_name="STEP_NAME"` require manual confirmation in the official Instagram app or web flow on a trusted device; aiograpi raises `ChallengeRequired` with the sanitized challenge context instead of treating this as a legacy step.
 
 For example, you can get the code through the IMAP of Gmail:

--- a/tests/regression/test_challenge.py
+++ b/tests/regression/test_challenge.py
@@ -2,9 +2,31 @@ import unittest
 from unittest.mock import AsyncMock
 
 from aiograpi import Client
+from aiograpi.exceptions import ChallengeRequired
 
 
 class ChallengeRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_native_flow_opaque_challenge_fails_fast_before_legacy_resolve(self):
+        client = Client()
+        last_json = {
+            "message": "challenge_required",
+            "challenge": {
+                "api_path": "/challenge/opaque-user/opaque-nonce/",
+                "native_flow": True,
+                "challenge_context": "opaque-context",
+            },
+            "status": "fail",
+        }
+        client._send_private_request = AsyncMock()
+        client.challenge_resolve_simple = AsyncMock(return_value=True)
+
+        with self.assertRaises(ChallengeRequired) as cm:
+            await client.challenge_resolve(last_json)
+
+        self.assertIn("native challenge flow", str(cm.exception))
+        client._send_private_request.assert_not_called()
+        client.challenge_resolve_simple.assert_not_called()
+
     async def test_challenge_resolve_normalizes_prefixed_api_challenge_path(self):
         client = Client()
         client.uuid = "uuid-1"


### PR DESCRIPTION
## Summary
- mirror the instagrapi native challenge checkpoint handling in the async port
- fail fast in `challenge_resolve()` for `challenge.native_flow=true` opaque `/challenge/...` payloads before sending unsupported legacy challenge requests
- document that these native checkpoints do not invoke `challenge_code_handler` or `change_password_handler`

Mirrors subzeroid/instagrapi#2720.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_challenge.py -q`
- `.venv/bin/python -m ruff check aiograpi/mixins/challenge.py tests/regression/test_challenge.py`
- `.venv/bin/python -m pytest tests/regression -q`
