### PR TITLE
Clarify BadPassword login-context hint

### DIFF
--- a/aiograpi/mixins/private.py
+++ b/aiograpi/mixins/private.py
@@ -63,6 +63,10 @@ _DIRECT_MESSAGE_REQUESTS_DISABLED_MARKERS = (
 )
 
 _ACCOUNT_CONTACT_POINT_REQUIRED_MARKERS = ("need an email or confirmed phone number",)
+_LOGIN_CONTEXT_REJECTION_HINT = (
+    "This can also happen when Instagram rejects the proxy/IP, device fingerprint, "
+    "or login context, even if the password is correct."
+)
 
 
 def _private_message_text(message) -> str:
@@ -595,16 +599,14 @@ class PrivateRequestMixin(ClientMixin):
                 elif error_type == "rate_limit_error":
                     raise RateLimitError(**last_json)
                 elif error_type == "bad_password":
-                    msg = last_json.get("message", "").strip()
-                    if msg:
-                        if not msg.endswith("."):
-                            msg = "%s." % msg
-                        msg = "%s " % msg
-                    last_json["message"] = (
-                        "%sIf you are sure that the password is correct, "
-                        "then change your IP address, because it is added "
-                        "to the blacklist of the Instagram Server"
-                    ) % msg
+                    last_json["message"] = " ".join(
+                        part
+                        for part in (
+                            last_json.get("message") or "Instagram rejected the login credentials.",
+                            _LOGIN_CONTEXT_REJECTION_HINT,
+                        )
+                        if part
+                    )
                     raise BadPassword(**last_json)
                 elif error_type == "two_factor_required":
                     if not last_json.get("message"):

--- a/tests/regression/test_private.py
+++ b/tests/regression/test_private.py
@@ -6,6 +6,7 @@ from aiograpi import Client, httpx_ext
 from aiograpi.exceptions import (
     AccountContactPointRequired,
     AccountEditError,
+    BadPassword,
     ClientNotFoundError,
     DirectMessageRequestsDisabled,
 )
@@ -108,6 +109,26 @@ class PrivateRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(cm.exception.message, payload["message"])
         self.assertEqual(cm.exception.status, "fail")
+
+    async def test_send_private_request_preserves_bad_password_message_with_login_context_hint(self):
+        client = self._build_client()
+        raw_message = "The password you entered is incorrect. Please try again."
+        payload = {
+            "message": raw_message,
+            "status": "fail",
+            "error_type": "bad_password",
+            "exception_name": "UserInvalidCredentials",
+        }
+        client.private.post = AsyncMock(return_value=self._response(payload, status_code=400))
+
+        with self.assertRaises(BadPassword) as cm:
+            await client._send_private_request("accounts/login/", data={"username": "example"}, login=True)
+
+        self.assertTrue(cm.exception.message.startswith(raw_message))
+        self.assertIn("proxy/IP", cm.exception.message)
+        self.assertIn("device fingerprint", cm.exception.message)
+        self.assertNotIn("change your IP", cm.exception.message)
+        self.assertNotIn("blacklist", cm.exception.message)
 
     async def test_send_private_request_ignores_non_json_body_on_http_error(self):
         client = self._build_client()


### PR DESCRIPTION
Mirrors the instagrapi BadPassword diagnostic clarification from the 2.18.7 work around subzeroid/instagrapi#2732 / subzeroid/instagrapi#2734.\n\nChanges:\n- preserve Instagram's raw bad_password message as the leading exception text\n- replace the old hard-coded IP blacklist diagnosis with a neutral proxy/IP/device/login-context hint\n- add regression coverage for the async private request path\n\nVerification:\n- RED: the new regression test failed on the old `change your IP / blacklist` wording\n- `/Users/colinfrl/work/sub/aiograpi/.venv/bin/python -m pytest tests/regression/test_private.py -q` -> 10 passed\n- `/Users/colinfrl/work/sub/aiograpi/.venv/bin/python -m ruff check aiograpi/mixins/private.py tests/regression/test_private.py` -> passed