### PR TITLE
Raise AccountSuspended for suspended challenges

### DIFF
--- a/aiograpi/mixins/private.py
+++ b/aiograpi/mixins/private.py
@@ -10,6 +10,7 @@ from aiograpi import config, httpx_ext
 from aiograpi.exceptions import (
     AccountContactPointRequired,
     AccountEditError,
+    AccountSuspended,
     AuthRequiredProxyError,
     BadPassword,
     ChallengeRequired,
@@ -580,6 +581,9 @@ class PrivateRequestMixin(ClientMixin):
                         last_json["error_type"] = "two_factor_required"
                     raise TwoFactorRequired(**last_json)
                 elif message == "challenge_required":
+                    challenge = last_json.get("challenge") or {}
+                    if "/suspended/" in (challenge.get("url") or ""):
+                        raise AccountSuspended(**last_json)
                     raise ChallengeRequired(**last_json)
                 elif message == "feedback_required":
                     raise FeedbackRequired(

--- a/tests/regression/test_private.py
+++ b/tests/regression/test_private.py
@@ -6,6 +6,7 @@ from aiograpi import Client, httpx_ext
 from aiograpi.exceptions import (
     AccountContactPointRequired,
     AccountEditError,
+    AccountSuspended,
     BadPassword,
     ClientNotFoundError,
     DirectMessageRequestsDisabled,
@@ -129,6 +130,21 @@ class PrivateRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIn("device fingerprint", cm.exception.message)
         self.assertNotIn("change your IP", cm.exception.message)
         self.assertNotIn("blacklist", cm.exception.message)
+
+    async def test_send_private_request_promotes_suspended_challenge_to_account_suspended(self):
+        client = self._build_client()
+        payload = {
+            "message": "challenge_required",
+            "status": "fail",
+            "challenge": {"url": "https://i.instagram.com/challenge/action/123/suspended/"},
+        }
+        client.private.post = AsyncMock(return_value=self._response(payload, status_code=400))
+
+        with self.assertRaises(AccountSuspended) as cm:
+            await client._send_private_request("accounts/login/", data={"username": "example"}, login=True)
+
+        self.assertEqual(cm.exception.message, "challenge_required")
+        self.assertEqual(cm.exception.challenge["url"], payload["challenge"]["url"])
 
     async def test_send_private_request_ignores_non_json_body_on_http_error(self):
         client = self._build_client()


### PR DESCRIPTION
Mirrors subzeroid/instagrapi#2737 for the async private request mapper.

Instagram can return `message=challenge_required` with a challenge URL that points at `/suspended/`. Treating that as a generic `ChallengeRequired` hides a terminal account-state response behind the normal challenge handler path.

Changes:
- map private API suspended challenge URLs to the existing `AccountSuspended` exception
- add async regression coverage for the private request error mapper

Verification:
- RED: new regression test first failed with `ChallengeRequired`
- `/Users/colinfrl/work/sub/aiograpi/.venv/bin/python -m pytest tests/regression/test_private.py::PrivateRequestRegressionTestCase::test_send_private_request_promotes_suspended_challenge_to_account_suspended -q` -> 1 passed
- `/Users/colinfrl/work/sub/aiograpi/.venv/bin/python -m pytest tests/regression/test_private.py -q` -> 11 passed
- `/Users/colinfrl/work/sub/aiograpi/.venv/bin/python -m pytest tests/regression/test_challenge.py -q` -> 3 passed
- `/Users/colinfrl/work/sub/aiograpi/.venv/bin/python -m ruff check aiograpi/mixins/private.py tests/regression/test_private.py` -> passed
