### PR TITLE
Strip outer whitespace from login username

### DIFF
--- a/aiograpi/mixins/auth.py
+++ b/aiograpi/mixins/auth.py
@@ -732,6 +732,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             self.password = password
         if self.username is None or self.password is None:
             raise BadCredentials("Both username and password must be provided.")
+        if isinstance(self.username, str):
+            self.username = self.username.strip()
 
         if relogin:
             self._clear_session_state(

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -1189,6 +1189,23 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         payload = client.private_request.call_args.args[1]
         self.assertEqual(payload["username"], "example")
 
+    async def test_login_strips_outer_username_whitespace(self):
+        client = Client()
+        client.authorization_data = {}
+        client.last_response = Mock(headers={"ig-set-authorization": "Bearer token"})
+        client.parse_authorization = Mock(return_value={"sessionid": "abc"})
+        client.pre_login_flow = AsyncMock(return_value=True)
+        client.private_request = AsyncMock(return_value=True)
+        client.login_flow = AsyncMock()
+        client.password_encrypt = AsyncMock(return_value="enc-password")
+
+        result = await client.login(" example ", "password")
+
+        self.assertTrue(result)
+        payload = client.private_request.call_args.args[1]
+        self.assertEqual(payload["username"], "example")
+        self.assertEqual(client.username, "example")
+
     async def test_login_two_factor_requires_verification_code(self):
         client = Client()
         client.username = "example"


### PR DESCRIPTION
## Summary
- strip leading/trailing whitespace from async `Client.login()` usernames before building the `accounts/login/` payload
- keep passwords unchanged because whitespace can be part of a valid password
- add a regression test for the sanitized login payload

## Context
Mirror of subzeroid/instagrapi#2739. This addresses one concrete signal from subzeroid/instagrapi#2732 where Instagram echoed `login_user_input` with leading whitespace. It does not claim to bypass Instagram's `bad_password` / `UserInvalidCredentials` response for correctly normalized credentials.

## Tests
- `/Users/colinfrl/work/sub/aiograpi/.venv/bin/python -m pytest tests/legacy.py::AuthAndStoryRegressionTestCase::test_login_strips_outer_username_whitespace -q`
- `/Users/colinfrl/work/sub/aiograpi/.venv/bin/python -m pytest tests/legacy.py::AuthAndStoryRegressionTestCase -q`
- `/Users/colinfrl/work/sub/aiograpi/.venv/bin/python -m pytest tests/regression -q`
