### PR TITLE
v1.12.4 release: async AI label visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
-## [1.12.4] - 2026-07-15
+## [1.12.4] - 2026-07-22
 
-### Fixed
+### Added
 
-- Accepted Instagram signup age eligibility payloads that use `eligible_to_register` without the legacy `eligible` field.
-- Raised `AccountSuspended` for private API suspended-account challenges instead of generic challenge handling.
-- Synced the recorded upstream baseline to `instagrapi` 2.18.8.
+- Added async account AI-label visibility controls through Instagram's GraphQL mutation, with regression and opt-in live coverage.
 
 ## [1.12.3] - 2026-07-07
 

--- a/aiograpi/mixins/account.py
+++ b/aiograpi/mixins/account.py
@@ -9,6 +9,7 @@ from aiograpi.utils.auth import gen_token, generate_signature
 from aiograpi.utils.serialization import dumps
 
 ProfessionalAccountType = Literal[2, 3]
+AIGM_UPDATE_ACCOUNT_LABEL_VISIBILITY_CLIENT_DOC_ID = "85502578717429613610069073956"
 
 
 class AccountMixin(ClientMixin):
@@ -64,6 +65,26 @@ class AccountMixin(ClientMixin):
         """
         result = await self.private_request("accounts/current_user/?edit=true")
         return extract_account(result["user"])
+
+    async def account_set_ai_info(self, enabled: bool) -> Account:
+        """Enable or disable the account's AI-generated content label."""
+        data = {
+            "method": "post",
+            "format": "json",
+            "server_timestamps": "true",
+            "locale": "user",
+            "fb_api_req_friendly_name": "AIGMUpdateAccountLabelVisibilityMutation",
+            "enable_canonical_naming": "true",
+            "enable_canonical_variable_overrides": "true",
+            "enable_canonical_naming_ambiguous_type_prefixing": "true",
+            "client_doc_id": AIGM_UPDATE_ACCOUNT_LABEL_VISIBILITY_CLIENT_DOC_ID,
+            "variables": json.dumps({"is_enabled": enabled}, separators=(",", ":")),
+        }
+        await self.private_graphql_request(
+            data,
+            headers={"X-Client-Doc-Id": AIGM_UPDATE_ACCOUNT_LABEL_VISIBILITY_CLIENT_DOC_ID},
+        )
+        return await self.account_info()
 
     async def account_convert_to_professional(
         self,

--- a/tests/live/test_account.py
+++ b/tests/live/test_account.py
@@ -1,0 +1,37 @@
+import os
+import unittest
+
+from aiograpi import Client
+from tests.live.smoke import _fetch_accounts
+
+
+class ClientAccountLiveTestCase(unittest.IsolatedAsyncioTestCase):
+    async def live_client(self):
+        accounts_url = os.getenv("TEST_ACCOUNTS_URL")
+        if not accounts_url:
+            self.skipTest("TEST_ACCOUNTS_URL is required for account live tests")
+        accounts = await _fetch_accounts(accounts_url, count=20)
+        for account in accounts:
+            try:
+                settings = dict(account.get("client_settings") or account.get("settings") or {})
+                settings.pop("totp_seed", None)
+                client = Client(settings=settings, proxy=account.get("proxy"), override_app_version=True)
+                client._user_id = account.get("user_id")
+                await client.account_info()
+                return client
+            except Exception:
+                continue
+        self.skipTest("No usable saved-session account returned")
+
+    @unittest.skipUnless(
+        os.getenv("IG_RUN_AI_INFO_LIVE"),
+        "set IG_RUN_AI_INFO_LIVE=1 to run the account mutation test",
+    )
+    async def test_account_set_ai_info_live(self):
+        client = await self.live_client()
+        try:
+            enabled = await client.account_set_ai_info(True)
+            self.assertIsNotNone(enabled)
+        finally:
+            disabled = await client.account_set_ai_info(False)
+            self.assertIsNotNone(disabled)

--- a/tests/regression/test_account.py
+++ b/tests/regression/test_account.py
@@ -5,6 +5,32 @@ from aiograpi import Client
 
 
 class AccountRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_account_set_ai_info_posts_visibility_mutation(self):
+        client = Client()
+        account = object()
+        client.private_graphql_request = AsyncMock()
+        client.account_info = AsyncMock(return_value=account)
+
+        result = await client.account_set_ai_info(True)
+
+        self.assertIs(result, account)
+        client.private_graphql_request.assert_awaited_once_with(
+            {
+                "method": "post",
+                "format": "json",
+                "server_timestamps": "true",
+                "locale": "user",
+                "fb_api_req_friendly_name": "AIGMUpdateAccountLabelVisibilityMutation",
+                "enable_canonical_naming": "true",
+                "enable_canonical_variable_overrides": "true",
+                "enable_canonical_naming_ambiguous_type_prefixing": "true",
+                "client_doc_id": "85502578717429613610069073956",
+                "variables": '{"is_enabled":true}',
+            },
+            headers={"X-Client-Doc-Id": "85502578717429613610069073956"},
+        )
+        client.account_info.assert_awaited_once_with()
+
     async def test_send_password_reset_posts_recovery_payload(self):
         client = Client()
         client.public_request = AsyncMock(return_value={"status": "ok"})


### PR DESCRIPTION
## Summary
- Add async `account_set_ai_info` GraphQL mutation.
- Add regression and opt-in live coverage.
- Bump version to 1.12.4 and update changelog.

## Tests
- `pytest -q tests/regression`
- `pytest -q tests/regression/test_account.py tests/live/test_account.py`
- Ruff checks passed.