### PR TITLE
v1.12.5 chore: align release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [1.12.5] - 2026-07-22
+
+### Changed
+
+- Bump package metadata for the async AI-label visibility release.
+
 ## [1.12.4] - 2026-07-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.12.4"
+version = "1.12.5"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]


### PR DESCRIPTION
Align pyproject and changelog with the 1.12.5 release tag.