### PR TITLE
feat: paginate collection media lookups by name

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -214,6 +214,9 @@ jobs:
         # by the unit-test job; user_followers and highlight_info are
         # covered by the smoke above.
         run: PYTHONPATH=. python tests/live/smoke.py
+      - name: Run collection pagination live test
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.test_target == 'smoke' || github.event.inputs.test_target == 'all'
+        run: PYTHONPATH=. pytest -q tests/live/test_collection.py::ClientCollectionLiveTestCase::test_collection_medias_by_name_pagination_live
       - name: Run comment write test
         if: github.event_name == 'workflow_dispatch' && (github.event.inputs.test_target == 'comment' || github.event.inputs.test_target == 'all')
         run: |

--- a/aiograpi/mixins/collection.py
+++ b/aiograpi/mixins/collection.py
@@ -62,7 +62,12 @@ class CollectionMixin(ClientMixin):
                 return item.id
         raise CollectionNotFound(name=name)
 
-    async def collection_medias_by_name(self, name: str) -> List[Collection]:
+    async def collection_medias_by_name(
+        self,
+        name: str,
+        amount: int = 21,
+        last_media_pk: int = 0,
+    ) -> List[Media]:
         """
         Get medias by collection name
 
@@ -70,14 +75,23 @@ class CollectionMixin(ClientMixin):
         ----------
         name: str
             Name of the collection
+        amount: int, optional
+            Maximum number of media to return, default is 21
+        last_media_pk: int, optional
+            Last PK user has seen, function will return medias after this pk. Default is 0
 
         Returns
         -------
-        List[Collection]
-            A list of collections
+        List[Media]
+            A list of objects of Media
         """
 
-        return await self.collection_medias(await self.collection_pk_by_name(name))
+        collection_pk = await self.collection_pk_by_name(name)
+        return await self.collection_medias(
+            str(collection_pk),
+            amount=amount,
+            last_media_pk=last_media_pk,
+        )
 
     async def liked_medias(self, amount: int = 21, last_media_pk: int = 0) -> List[Media]:
         """

--- a/docs/usage-guide/collection.md
+++ b/docs/usage-guide/collection.md
@@ -1,11 +1,11 @@
 # Collections
 
-| Method                                                                          | Return             | Description                                      |
-| ------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------ |
-| collections()                                                                   | List\[Collection]  | Get all account collections
-| collection_pk_by_name(name: str)                                                | int                | Get collection_pk by name
-| collection_medias_by_name(name: str)                                            | List\[Media]       | Get medias in collection by name
-| collection_medias(collection_pk: int, amount: int = 21, last_media_pk: int = 0) | List\[Media]       | Get medias in collection by collection_id; Use **amount=0** to return all medias in collection; Use **last_media_pk** to return medias by cursor
-| liked_medias(amount: int = 21, last_media_pk: int = 0)                          | List\[Media]       | Get media you have liked
-| media_save(media_id: str, collection_pk: int = None)                            | bool               | Save media to collection
-| media_unsave(media_id: str, collection_pk: int = None)                          | bool               | Unsave media from collection
+| Method                                                                                       | Return             | Description                                      |
+| -------------------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------ |
+| collections()                                                                                | List\[Collection]  | Get all account collections
+| collection_pk_by_name(name: str)                                                             | int                | Get collection_pk by name
+| collection_medias_by_name(name: str, amount: int = 21, last_media_pk: int = 0)               | List\[Media]       | Get medias in collection by name
+| collection_medias(collection_pk: int, amount: int = 21, last_media_pk: int = 0)              | List\[Media]       | Get medias in collection by collection_id; Use **amount=0** to return all medias in collection; Use **last_media_pk** to return medias by cursor
+| liked_medias(amount: int = 21, last_media_pk: int = 0)                                       | List\[Media]       | Get media you have liked
+| media_save(media_id: str, collection_pk: int = None)                                         | bool               | Save media to collection
+| media_unsave(media_id: str, collection_pk: int = None)                                       | bool               | Unsave media from collection

--- a/tests/live/test_collection.py
+++ b/tests/live/test_collection.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+
+from aiograpi.types import Media
+from tests.live.smoke import _fetch_accounts, _login_first_usable
+
+
+class ClientCollectionLiveTestCase(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        test_accounts_url = os.getenv("TEST_ACCOUNTS_URL")
+        if not test_accounts_url:
+            self.skipTest("TEST_ACCOUNTS_URL is required for collection live tests")
+        accounts = await _fetch_accounts(test_accounts_url, count=20)
+        self.cl = await _login_first_usable(accounts)
+        if self.cl is None:
+            self.skipTest("Could not login with any test account")
+
+    async def test_collection_medias_by_name_pagination_live(self):
+        user_id = await self.cl.user_id_from_username("instagram")
+        media = (await self.cl.user_medias(user_id, amount=1))[0]
+        self.assertTrue(await self.cl.media_save(media.id))
+        try:
+            collection = next((item for item in await self.cl.collections() if item.media_count), None)
+            self.assertIsNotNone(collection)
+
+            medias = await self.cl.collection_medias_by_name(collection.name, amount=1)
+            self.assertEqual(len(medias), 1)
+            self.assertIsInstance(medias[0], Media)
+            self.assertEqual(
+                await self.cl.collection_medias_by_name(
+                    collection.name,
+                    amount=1,
+                    last_media_pk=medias[0].pk,
+                ),
+                [],
+            )
+        finally:
+            await self.cl.media_unsave(media.id)

--- a/tests/regression/test_collection.py
+++ b/tests/regression/test_collection.py
@@ -101,3 +101,15 @@ class CollectionRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(client.private_request.await_count, 2)
         self.assertNotIn("max_id", client.private_request.call_args_list[0].kwargs["params"])
         self.assertEqual(client.private_request.call_args_list[1].kwargs["params"]["max_id"], "cursor-2")
+
+    async def test_collection_medias_by_name_forwards_pagination_arguments(self):
+        client = Client()
+        expected_medias = [object()]
+        client.collection_pk_by_name = AsyncMock(return_value="123")
+        client.collection_medias = AsyncMock(return_value=expected_medias)
+
+        medias = await client.collection_medias_by_name("Favorites", amount=50, last_media_pk=456)
+
+        self.assertIs(medias, expected_medias)
+        client.collection_pk_by_name.assert_awaited_once_with("Favorites")
+        client.collection_medias.assert_awaited_once_with("123", amount=50, last_media_pk=456)


### PR DESCRIPTION
## Summary
- add `amount` and `last_media_pk` to async `collection_medias_by_name`
- correct the return annotation and collection API documentation
- add regression and live coverage, wired into canonical smoke CI

## Testing
- `pytest` unit/regression workflow targets: 675 passed, 13 skipped
- `./scripts/check-mypy-baseline.sh`
- `ruff check --output-format=github .`
- `ruff format --check .`
- `mkdocs build --strict`
- targeted collection test with a live account

Mirrors subzeroid/instagrapi#2748 and subzeroid/instagrapi#2749.