### PR TITLE
fix: validate loaded sessions during login

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,17 @@ cl = Client()
 await cl.login(USERNAME, PASSWORD)
 cl.dump_settings("session.json")
 
-# reload later without entering credentials again
+# reload later; the saved session is validated before reuse
 cl = Client()
 cl.load_settings("session.json")
 await cl.login(USERNAME, PASSWORD)
+cl.dump_settings("session.json")
 ```
+
+`login()` reuses a valid saved session. If Instagram rejects that session with
+`login_required`, aiograpi clears the stale authorization and logs in again
+with the supplied credentials. Dump the settings after login so a refreshed
+session is persisted.
 
 If you want explicit control over the loaded session object:
 
@@ -232,6 +238,7 @@ from aiograpi import Client
 cl = Client()
 cl.set_settings(cl.load_settings("session.json"))
 await cl.login(USERNAME, PASSWORD)
+cl.dump_settings("session.json")
 ```
 
 ### Login by sessionid

--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -47,7 +47,7 @@ from aiograpi.mixins.video import DownloadVideoMixin, UploadVideoMixin
 # Used as fallback logger if another is not provided.
 DEFAULT_LOGGER = logging.getLogger("aiograpi")
 
-__upstream_instagrapi_version__ = "2.18.8"
+__upstream_instagrapi_version__ = "2.18.12"
 
 
 class Client(

--- a/aiograpi/mixins/auth.py
+++ b/aiograpi/mixins/auth.py
@@ -21,6 +21,7 @@ from aiograpi.exceptions import (
     BadPassword,
     ClientError,
     ClientThrottledError,
+    LoginRequired,
     PleaseWaitFewMinutes,
     PrivateError,
     ReloginAttemptExceeded,
@@ -726,6 +727,12 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         -------
         bool
             A boolean value
+
+        Notes
+        -----
+        An existing session is validated before it is reused. If Instagram
+        rejects it, the saved authorization state is cleared and the supplied
+        credentials are used to log in again.
         """
         if username and password:
             self.username = username
@@ -749,7 +756,11 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         #     if time.time() - self.last_login < 60 * 60 * 24:
         #        return True  # already login
         if self.user_id and not relogin:
-            return True  # already login
+            try:
+                await self.account_info()
+            except LoginRequired:
+                return await self.login(relogin=True, verification_code=verification_code)
+            return True
         try:
             await self.pre_login_flow()
         except (PleaseWaitFewMinutes, ClientThrottledError):

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,6 +43,19 @@ If `login()` raises `ChallengeRequired` or `BadPassword`, that's
 Instagram pushing back — see the [Challenge Resolver](usage-guide/challenge_resolver.md)
 and [Handle Exceptions](usage-guide/handle_exception.md) guides.
 
+## Reuse a saved session
+
+```python
+client = Client()
+client.load_settings("session.json")
+await client.login("YOUR_USERNAME", "YOUR_PASSWORD")
+client.dump_settings("session.json")
+```
+
+The saved session is validated during `login()`. If Instagram rejects it with
+`login_required`, aiograpi performs a fresh login with the supplied
+credentials. Saving the settings again persists any refreshed session.
+
 ## Public, anonymous calls (no login)
 
 For some endpoints you can skip login entirely:

--- a/docs/usage-guide/best-practices.md
+++ b/docs/usage-guide/best-practices.md
@@ -79,63 +79,30 @@ from aiograpi import Client
 async def main():
     cl = Client()
     cl.load_settings("session.json")
-    await cl.login(USERNAME, PASSWORD) # this doesn't actually login using username/password but uses the session
-    await cl.get_timeline_feed() # check session
+    await cl.login(USERNAME, PASSWORD)
+    cl.dump_settings("session.json")
 ```
 
-You'll notice we do a call to `await cl.get_timeline_feed()` to check if the session is valid. If it's not valid, you'll get an exception.
+`login()` validates the loaded session before reusing it. When Instagram
+returns `login_required`, aiograpi clears the rejected authorization and logs
+in again with the supplied credentials. Other errors still propagate so rate
+limits, challenges, and network failures are not mistaken for an expired
+session. Save the settings again in case the session was refreshed.
 
-Putting this all together, we could write a login function like this
+Putting this all together, you can write a reusable login helper like this:
 
 ``` python
 from aiograpi import Client
-from aiograpi.exceptions import LoginRequired
-import logging
-
-logger = logging.getLogger()
+from pathlib import Path
 
 async def login_user():
-    """
-    Attempts to login to Instagram using either the provided session information
-    or the provided username and password.
-    """
-
+    """Login with a saved session and refresh it only when required."""
+    session_file = Path("session.json")
     cl = Client()
-    session = cl.load_settings("session.json")
+    if session_file.exists():
+        cl.load_settings(session_file)
 
-    login_via_session = False
-    login_via_pw = False
-
-    if session:
-        try:
-            cl.set_settings(session)
-            await cl.login(USERNAME, PASSWORD)
-
-            # check if session is valid
-            try:
-                await cl.get_timeline_feed()
-            except LoginRequired:
-                logger.info("Session is invalid, need to login via username and password")
-
-                old_session = cl.get_settings()
-
-                # use the same device uuids across logins
-                cl.set_settings({})
-                cl.set_uuids(old_session["uuids"])
-
-                await cl.login(USERNAME, PASSWORD)
-            login_via_session = True
-        except Exception as e:
-            logger.info("Couldn't login user using session information: %s" % e)
-
-    if not login_via_session:
-        try:
-            logger.info("Attempting to login via username and password. username: %s" % USERNAME)
-            if await cl.login(USERNAME, PASSWORD):
-                login_via_pw = True
-        except Exception as e:
-            logger.info("Couldn't login user using username and password: %s" % e)
-
-    if not login_via_pw and not login_via_session:
-        raise Exception("Couldn't login user with either password or session")
+    await cl.login(USERNAME, PASSWORD)
+    cl.dump_settings(session_file)
+    return cl
 ```

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -135,7 +135,7 @@ Next time:
 cl = Client()
 cl.load_settings('/tmp/dump.json')
 await cl.login(USERNAME, PASSWORD)
-await cl.get_timeline_feed()  # check session
+cl.dump_settings('/tmp/dump.json')
 ```
 
 ### Manage device, proxy and other account settings

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -1160,15 +1160,17 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(client.private.cookies_dict(), {})
         self.assertEqual(client.public.cookies_dict(), {})
 
-    async def test_login_returns_early_when_user_is_already_authorized(self):
+    async def test_login_validates_existing_session_before_returning(self):
         client = Client()
         client.authorization_data = {"ds_user_id": "123"}
+        client.account_info = AsyncMock(return_value=object())
         client.pre_login_flow = AsyncMock()
         client.private_request = AsyncMock()
 
         result = await client.login("example", "password")
 
         self.assertTrue(result)
+        client.account_info.assert_awaited_once_with()
         client.pre_login_flow.assert_not_called()
         client.private_request.assert_not_called()
 

--- a/tests/live/smoke.py
+++ b/tests/live/smoke.py
@@ -175,7 +175,7 @@ async def main():
             ("user_followers", lambda: cl.user_followers("25025320", amount=10, use_cache=False)),
             ("user_following", lambda: cl.user_following("25025320", amount=10, use_cache=False)),
             ("user_stories", lambda: cl.user_stories("25025320", amount=10)),
-            ("highlight_info", lambda: cl.highlight_info(17983407089364361)),
+            ("user_highlights", lambda: cl.user_highlights("25025320", amount=1)),
         ]:
             try:
                 out = await fn()

--- a/tests/live/smoke.py
+++ b/tests/live/smoke.py
@@ -15,6 +15,7 @@ import json
 import os
 import ssl
 import sys
+import tempfile
 import urllib.request
 import uuid
 from pathlib import Path
@@ -116,6 +117,35 @@ async def main():
     if cl is None:
         failures.append(("login", "all pool accounts unusable"))
     else:
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                session_file = Path(tmpdir) / "session.json"
+                cl.dump_settings(session_file)
+
+                restored = Client()
+                proxy = getattr(cl, "proxy", None)
+                if isinstance(proxy, str) and proxy:
+                    restored.set_proxy(proxy)
+                restored.load_settings(session_file)
+                account_info = restored.account_info
+                validation_calls = 0
+
+                async def validating_account_info():
+                    nonlocal validation_calls
+                    validation_calls += 1
+                    return await account_info()
+
+                restored.account_info = validating_account_info
+                logged_in = await restored.login(cl.username, cl.password)
+                restored.dump_settings(session_file)
+
+            assert logged_in
+            assert validation_calls == 1
+            assert str(restored.user_id) == str(cl.user_id)
+            print("REQ saved_session_login: validated/reused")
+        except Exception as e:
+            failures.append(("saved_session_login", f"{type(e).__name__}: {str(e)[:140]}"))
+
         try:
             if not cl.sessionid:
                 raise RuntimeError("logged-in client did not expose sessionid")

--- a/tests/regression/test_auth.py
+++ b/tests/regression/test_auth.py
@@ -4,11 +4,70 @@ from unittest.mock import AsyncMock, Mock
 from pydantic import ValidationError
 
 from aiograpi import Client
-from aiograpi.exceptions import BadPassword, PrivateError, TwoFactorRequired
+from aiograpi.exceptions import (
+    BadPassword,
+    LoginRequired,
+    PleaseWaitFewMinutes,
+    PrivateError,
+    TwoFactorRequired,
+)
 from aiograpi.types import UserShort
 
 
 class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_login_validates_existing_session_before_returning(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "123"}
+        client.account_info = AsyncMock(return_value=object())
+        client.pre_login_flow = AsyncMock()
+        client.private_request = AsyncMock()
+
+        result = await client.login("example", "password")
+
+        self.assertTrue(result)
+        client.account_info.assert_awaited_once_with()
+        client.pre_login_flow.assert_not_awaited()
+        client.private_request.assert_not_awaited()
+
+    async def test_login_refreshes_session_rejected_during_validation(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "123", "sessionid": "stale"}
+        client.private.set_cookies({"sessionid": "stale"})
+        client.public.set_cookies({"sessionid": "public-stale"})
+        client.private.headers["Authorization"] = "Bearer stale"
+        client.account_info = AsyncMock(side_effect=LoginRequired())
+        client.last_response = Mock(headers={"ig-set-authorization": "Bearer fresh"})
+        client.parse_authorization = Mock(return_value={"ds_user_id": "123", "sessionid": "fresh"})
+        client.pre_login_flow = AsyncMock(return_value=True)
+        client.password_encrypt = AsyncMock(return_value="enc-password")
+        client.private_request = AsyncMock(return_value=True)
+        client.login_flow = AsyncMock()
+
+        result = await client.login("example", "password")
+
+        self.assertTrue(result)
+        client.account_info.assert_awaited_once_with()
+        client.pre_login_flow.assert_awaited_once_with()
+        self.assertEqual(client.private_request.await_args.args[0], "accounts/login/")
+        self.assertNotIn("Authorization", client.private.headers)
+        self.assertEqual(client.private.cookies_dict(), {})
+        self.assertEqual(client.public.cookies_dict(), {})
+        self.assertEqual(client.authorization_data["sessionid"], "fresh")
+        self.assertEqual(client.relogin_attempt, 0)
+
+    async def test_login_does_not_mask_other_session_validation_errors(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "123"}
+        client.account_info = AsyncMock(side_effect=PleaseWaitFewMinutes())
+        client.pre_login_flow = AsyncMock()
+        client.private_request = AsyncMock()
+
+        with self.assertRaises(PleaseWaitFewMinutes):
+            await client.login("example", "password")
+
+        client.pre_login_flow.assert_not_awaited()
+        client.private_request.assert_not_awaited()
+
     async def test_login_by_sessionid_falls_back_to_private_stream_before_public(self):
         client = Client()
         sessionid = "1234567890123456789012345678901%3Atoken"

--- a/tests/regression/test_live_smoke.py
+++ b/tests/regression/test_live_smoke.py
@@ -115,8 +115,8 @@ class _FakeLiveClient:
     async def user_stories(self, user_id, amount=0):
         return [types.SimpleNamespace(pk=str(i)) for i in range(amount)]
 
-    async def highlight_info(self, highlight_id):
-        return types.SimpleNamespace(pk=str(highlight_id))
+    async def user_highlights(self, user_id, amount=0):
+        return [types.SimpleNamespace(pk=str(i)) for i in range(amount)]
 
 
 class _LoginClient:
@@ -265,6 +265,7 @@ print(sys.modules["aiograpi"].__file__)
             "fbsearch_suggested_profiles",
             "user_following",
             "user_stories",
+            "user_highlights",
         ]:
             self.assertIn(f"REQ {required_name}:", smoke_output)
         for public_name in [

--- a/tests/regression/test_live_smoke.py
+++ b/tests/regression/test_live_smoke.py
@@ -24,6 +24,21 @@ class _FakeLiveClient:
     user_id = "1"
     sessionid = "1%3Asession"
     proxy = None
+    username = "example"
+    password = "password"
+
+    def dump_settings(self, path):
+        Path(path).write_text("{}")
+        return True
+
+    def load_settings(self, path):
+        return {}
+
+    async def login(self, username, password):
+        self.username = username
+        self.password = password
+        await self.account_info()
+        return True
 
     async def login_by_sessionid(self, sessionid):
         self.sessionid = sessionid
@@ -240,6 +255,7 @@ print(sys.modules["aiograpi"].__file__)
         self.assertEqual(status, 0, output.getvalue())
         smoke_output = output.getvalue()
         for required_name in [
+            "saved_session_login",
             "user_info_by_username",
             "user_info",
             "username_from_user_id",

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -2,4 +2,4 @@ import aiograpi
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.18.8"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.18.12"


### PR DESCRIPTION
## Summary

- validate loaded sessions with `account_info()` before `login()` reuses them
- retry with the supplied credentials only when validation raises `LoginRequired`, clearing stale authorization and cookies first
- propagate rate limits, challenges, and other validation failures without treating them as expired sessions
- document the simplified saved-session flow and sync the recorded upstream baseline to `instagrapi 2.18.12`
- cover saved-session reuse in the required live smoke and replace its removed fixed highlight fixture with a current user-highlights lookup

## Testing

- `483 passed, 3 skipped, 31 subtests passed` in `tests/regression`
- `61 passed` across focused auth, live-smoke, legacy auth, and upstream-baseline regressions
- Ruff check and format check
- `mkdocs build --strict`
- live smoke against a real saved session: all required checks passed, including `saved_session_login: validated/reused`

Mirrors subzeroid/instagrapi#2753 and resolves the async side of subzeroid/instagrapi#2751.