### PR TITLE
fix: allow CAA two-factor requests before login

### DIFF
--- a/aiograpi/mixins/bloks.py
+++ b/aiograpi/mixins/bloks.py
@@ -64,7 +64,13 @@ class BloksMixin(ClientMixin):
             kwargs["login"] = True
         return await self.private_request(f"bloks/async_action/{action}/", **kwargs)
 
-    async def bloks_app(self, app: str, params: Dict, bloks_versioning_id: str = "") -> Dict:
+    async def bloks_app(
+        self,
+        app: str,
+        params: Dict,
+        bloks_versioning_id: str = "",
+        login: bool = False,
+    ) -> Dict:
         """
         Perform a raw Bloks app request.
 
@@ -76,6 +82,8 @@ class BloksMixin(ClientMixin):
             Bloks ``params`` payload.
         bloks_versioning_id: str, optional
             Bloks versioning id. Uses ``Client.bloks_versioning_id`` when omitted.
+        login: bool, optional
+            Allow pre-login requests for registration/login flows.
 
         Returns
         -------
@@ -83,7 +91,10 @@ class BloksMixin(ClientMixin):
             Raw Instagram response.
         """
         data = self._bloks_payload(params, bloks_versioning_id=bloks_versioning_id)
-        return await self.private_request(f"bloks/apps/{app}/", data=data, with_signature=False)
+        kwargs: Dict[str, Any] = {"data": data, "with_signature": False}
+        if login:
+            kwargs["login"] = True
+        return await self.private_request(f"bloks/apps/{app}/", **kwargs)
 
     async def bloks_graphql_app(
         self,
@@ -241,6 +252,7 @@ class BloksMixin(ClientMixin):
             "com.bloks.www.two_step_verification.entrypoint",
             params,
             bloks_versioning_id=bloks_versioning_id,
+            login=True,
         )
 
     async def bloks_two_step_verification_method_picker(
@@ -275,6 +287,7 @@ class BloksMixin(ClientMixin):
             "com.bloks.www.two_step_verification.method_picker",
             params,
             bloks_versioning_id=bloks_versioning_id,
+            login=True,
         )
 
     async def bloks_two_step_verification_select_method(
@@ -319,6 +332,7 @@ class BloksMixin(ClientMixin):
             "com.bloks.www.two_step_verification.method_picker.navigation.async",
             params,
             bloks_versioning_id=bloks_versioning_id,
+            login=True,
         )
 
     async def bloks_two_step_verification_enter_totp_code(
@@ -348,6 +362,7 @@ class BloksMixin(ClientMixin):
             "com.bloks.www.two_factor_login.enter_totp_code",
             params,
             bloks_versioning_id=bloks_versioning_id,
+            login=True,
         )
 
     async def bloks_two_step_verification_enter_backup_code(
@@ -377,6 +392,7 @@ class BloksMixin(ClientMixin):
             "com.bloks.www.two_factor_login.enter_backup_code",
             params,
             bloks_versioning_id=bloks_versioning_id,
+            login=True,
         )
 
     async def bloks_two_step_verification_verify_code(
@@ -436,6 +452,7 @@ class BloksMixin(ClientMixin):
             "com.bloks.www.two_step_verification.verify_code.async",
             params,
             bloks_versioning_id=bloks_versioning_id,
+            login=True,
         )
 
     async def bloks_caa_login_send_request(
@@ -580,6 +597,7 @@ class BloksMixin(ClientMixin):
             "com.bloks.www.bloks.caa.login.async.send_login_request",
             params,
             bloks_versioning_id=bloks_versioning_id,
+            login=True,
         )
 
     def _find_bloks_value(self, data: Any, key: str) -> Any:

--- a/tests/regression/test_bloks.py
+++ b/tests/regression/test_bloks.py
@@ -214,6 +214,60 @@ class BloksRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             with_signature=False,
         )
 
+    async def test_bloks_app_can_allow_prelogin_request(self):
+        client = self.build_client()
+        params = {"server_params": {"flow": "example_flow"}}
+        expected = {"status": "ok"}
+        client.private_request = AsyncMock(return_value=expected)
+
+        result = await client.bloks_app("com.example.app", params, login=True)
+
+        self.assertEqual(result, expected)
+        client.private_request.assert_awaited_once_with(
+            "bloks/apps/com.example.app/",
+            data={
+                "params": dumps(params),
+                "_uuid": "uuid-1",
+                "bk_client_context": dumps({"bloks_version": "bloks-version", "styles_id": "instagram"}),
+                "bloks_versioning_id": "bloks-version",
+            },
+            with_signature=False,
+            login=True,
+        )
+
+    async def test_bloks_login_helpers_allow_prelogin_private_requests(self):
+        client = self.build_client()
+        client.username = "example"
+        client.android_device_id = "android-1"
+        client.phone_id = "family-device-1"
+        client.mid = "machine-1"
+        client.password_encrypt = AsyncMock(return_value="#PWD_INSTAGRAM:4:1:encrypted")
+        client._send_private_request = AsyncMock()
+
+        self.assertFalse(client.user_id)
+
+        await client.bloks_caa_login_send_request("password")
+        await client.bloks_two_step_verification_entrypoint("context-1")
+        await client.bloks_two_step_verification_method_picker("context-1")
+        await client.bloks_two_step_verification_select_method("context-1", "totp")
+        await client.bloks_two_step_verification_enter_totp_code("context-1")
+        await client.bloks_two_step_verification_enter_backup_code("context-1")
+        await client.bloks_two_step_verification_verify_code("context-1", "123456")
+
+        self.assertEqual(
+            [call.args[0] for call in client._send_private_request.await_args_list],
+            [
+                "bloks/async_action/com.bloks.www.bloks.caa.login.async.send_login_request/",
+                "bloks/apps/com.bloks.www.two_step_verification.entrypoint/",
+                "bloks/apps/com.bloks.www.two_step_verification.method_picker/",
+                "bloks/async_action/com.bloks.www.two_step_verification.method_picker.navigation.async/",
+                "bloks/apps/com.bloks.www.two_factor_login.enter_totp_code/",
+                "bloks/apps/com.bloks.www.two_factor_login.enter_backup_code/",
+                "bloks/async_action/com.bloks.www.two_step_verification.verify_code.async/",
+            ],
+        )
+        self.assertTrue(all(call.kwargs["login"] is True for call in client._send_private_request.await_args_list))
+
     async def test_bloks_graphql_app_posts_wrapped_bloks_payload(self):
         client = self.build_client()
         params = {
@@ -359,6 +413,7 @@ class BloksRegressionTestCase(unittest.IsolatedAsyncioTestCase):
                 },
             },
             bloks_versioning_id="",
+            login=True,
         )
 
     async def test_bloks_two_step_verification_method_picker_uses_current_payload(self):
@@ -382,6 +437,7 @@ class BloksRegressionTestCase(unittest.IsolatedAsyncioTestCase):
                 },
             },
             bloks_versioning_id="",
+            login=True,
         )
 
     async def test_bloks_two_step_verification_select_method_uses_current_payload(self):
@@ -417,6 +473,7 @@ class BloksRegressionTestCase(unittest.IsolatedAsyncioTestCase):
                 },
             },
             bloks_versioning_id="",
+            login=True,
         )
 
     async def test_bloks_two_step_verification_verify_code_uses_current_payload(self):
@@ -459,6 +516,7 @@ class BloksRegressionTestCase(unittest.IsolatedAsyncioTestCase):
                 },
             },
             bloks_versioning_id="",
+            login=True,
         )
 
     async def test_bloks_two_step_verification_enter_backup_code_uses_current_payload(self):
@@ -484,6 +542,7 @@ class BloksRegressionTestCase(unittest.IsolatedAsyncioTestCase):
                 },
             },
             bloks_versioning_id="",
+            login=True,
         )
 
     async def test_bloks_caa_login_send_request_uses_current_payload(self):
@@ -502,6 +561,10 @@ class BloksRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, expected)
         bloks_async_action.assert_awaited_once()
         action, params = bloks_async_action.call_args.args[:2]
+        self.assertEqual(
+            bloks_async_action.call_args.kwargs,
+            {"bloks_versioning_id": "", "login": True},
+        )
         self.assertEqual(action, "com.bloks.www.bloks.caa.login.async.send_login_request")
         self.assertEqual(params["client_input_params"]["contact_point"], "example")
         self.assertEqual(params["client_input_params"]["password"], "#PWD_INSTAGRAM:4:1:encrypted")


### PR DESCRIPTION
## What

- Add an opt-in `login` flag to `bloks_app`, matching `bloks_async_action`.
- Mark the dedicated CAA login and Bloks two-factor helpers as pre-login requests.
- Add guard-level regression coverage that keeps the real `private_request` path and mocks only the transport boundary.

## Why

aiograpi's async private-request guard currently raises `PreLoginRequired` before these login helpers can reach Instagram. This affects the CAA/Bloks two-factor path reported in https://github.com/subzeroid/instagrapi/issues/2732#issuecomment-5149917561.

## Notes for reviewers

The general private-request authentication guard is unchanged. Only the seven dedicated CAA/Bloks login and two-factor helpers opt in to pre-login requests.

## Live validation

The draft branch was tested against multiple live account states. The regression is confirmed: released aiograpi stops locally with `PreLoginRequired`, while this branch reaches the CAA/Bloks endpoint and receives an Instagram response. A healthy legacy TOTP login also completed end to end with no regression.

Instagram did not offer the downstream Bloks two-factor context on the tested affected accounts, so this PR remains intentionally scoped to removing the incorrect client-side pre-login guard. Broader recovery and current CAA-flow work remains tracked in the upstream issue.

## Checklist

- [x] Regression test verified RED against the previous production behavior and GREEN with this fix
- [x] Full PR CI regression selection: 699 passed, 13 skipped
- [x] Non-live pytest collection: 485 passed, 3 skipped
- [x] Ruff check and format checks pass
- [x] Mypy baseline gate passes
- [x] Bandit and `pip-audit --strict .` pass
- [x] MkDocs strict build and pre-commit hooks pass
- [x] Public API docstring updated
- [x] No breaking migration
- [x] Live-account validation of the guard fix and legacy TOTP regression