### PR TITLE
fix: sync pinned media and Direct photo flows

### DIFF
--- a/aiograpi/mixins/direct.py
+++ b/aiograpi/mixins/direct.py
@@ -20,6 +20,7 @@ from aiograpi.extractors import (
     extract_direct_thread,
     extract_user_short,
 )
+from aiograpi.image_util import prepare_image
 from aiograpi.mixins.base import ClientMixin
 from aiograpi.types import (
     DirectMessage,
@@ -787,23 +788,73 @@ class DirectMixin(ClientMixin):
         self, path: Path, user_ids: List[int] = [], thread_ids: List[int] = []
     ) -> DirectMessage:
         """
-        Send a direct photo to list of users or threads
+        Send a direct photo to a list of users or threads.
+
+        Instagram retired ``direct_v2/threads/broadcast/configure_photo/``.
+        Direct photos now use the messenger image attachment flow:
+
+        1. Normalize the image to JPEG and upload it to
+           ``rupload.facebook.com/messenger_image/``.
+        2. Send the returned ``media_id`` through
+           ``direct_v2/threads/broadcast/photo_attachment/``.
+
+        When ``user_ids`` is used, an existing Direct thread is required.
 
         Parameters
         ----------
         path: Path
-            Path to photo that will be posted on the thread
+            Path to a JPG, JPEG, PNG, or WebP image.
         user_ids: List[int]
-            List of unique identifier of Users id
+            List of unique identifiers of Users id.
         thread_ids: List[int]
-            List of unique identifier of Direct Message thread id
+            List of unique identifiers of Direct Message thread id.
 
         Returns
         -------
         DirectMessage
-            An object of DirectMessage
+            An object of DirectMessage.
         """
-        return await self.direct_send_file(path, user_ids, thread_ids, content_type="photo")
+        assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
+        assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
+            "Specify user_ids or thread_ids, but not both"
+        )
+        if user_ids:
+            thread_ids = [await self._direct_thread_id_from_user_ids(user_ids, "photo")]
+
+        path = Path(path)
+        valid_extensions = {".jpg", ".jpeg", ".png", ".webp"}
+        if path.suffix.lower() not in valid_extensions:
+            raise ValueError("Invalid file format. Only JPG/JPEG/PNG/WEBP files are supported.")
+        photo_bytes, _ = prepare_image(str(path), max_side=1080)
+
+        entity_name = f"fb_uploader_{int(time.time() * 1000)}"
+        media_id = await self._photo_rupload(photo_bytes, entity_name)
+
+        token = self.generate_mutation_token()
+        data = {
+            "action": "send_item",
+            "is_x_transport_forward": "false",
+            "is_shh_mode": "0",
+            "thread_ids": dumps([int(tid) for tid in thread_ids]),
+            "send_attribution": "inbox",
+            "client_context": token,
+            "attachment_fbid": str(media_id),
+            "device_id": self.android_device_id,
+            "mutation_token": token,
+            "_uuid": self.uuid,
+            "allow_full_aspect_ratio": "true",
+            "btt_dual_send": "false",
+            "is_ae_dual_send": "false",
+            "offline_threading_id": token,
+        }
+        result = await self.private_request(
+            "direct_v2/threads/broadcast/photo_attachment/",
+            data=self.with_default_data(data),
+            with_signature=False,
+        )
+        return extract_direct_message(result["payload"])
 
     def _direct_video_metadata(self, path: Path) -> Tuple[int, int, float]:
         width, height, duration_sec = 720, 1280, 1.0
@@ -981,6 +1032,35 @@ class DirectMixin(ClientMixin):
             headers.update(extra_headers)
         return headers
 
+    async def _photo_rupload(self, photo_bytes: bytes, entity_name: str) -> int:
+        """Upload JPEG bytes to messenger_image and return its media_id."""
+        url = f"https://rupload.facebook.com/messenger_image/{entity_name}"
+        headers = self._messenger_rupload_headers({"image_type": "FILE_ATTACHMENT"})
+        headers.update(
+            {
+                "content-type": "application/octet-stream",
+                "offset": "0",
+                "x-entity-length": str(len(photo_bytes)),
+                "x-entity-name": entity_name,
+                "x-entity-type": "image/jpeg",
+            }
+        )
+        response = await httpx_ext.request(
+            "POST",
+            url,
+            data=photo_bytes,
+            headers=headers,
+            proxy=getattr(self, "proxy", None),
+            verify=self.tls_verify,
+            timeout=120,
+        )
+        if response.status_code != 200:
+            raise ClientError(f"messenger_image upload POST failed: {response.status_code} {response.text[:300]}")
+        try:
+            return int(response.json()["media_id"])
+        except Exception as exc:
+            raise ClientError(f"messenger_image response missing media_id: {response.text[:300]}") from exc
+
     async def _video_rupload(self, video_bytes: bytes, entity_name: str, waterfall_id: str) -> int:
         """Upload mp4 bytes to ``rupload.facebook.com/messenger_video/...``."""
         url = f"https://rupload.facebook.com/messenger_video/{entity_name}"
@@ -1155,59 +1235,11 @@ class DirectMixin(ClientMixin):
         DirectMessage
             An object of DirectMessage
         """
-        assert self.user_id, "Login required"
-        user_ids = _direct_id_list(user_ids)
-        thread_ids = _direct_id_list(thread_ids)
-        assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
-            "Specify user_ids or thread_ids, but not both"
-        )
-        method = f"configure_{content_type}"
-        token = self.generate_mutation_token()
-        nav_chains = [
-            (
-                "6xQ:direct_media_picker_photos_fragment:1,5rG:direct_thread:2,"
-                "5ME:direct_quick_camera_fragment:3,5ME:direct_quick_camera_fragment:4,"
-                "4ju:reel_composer_preview:5,5rG:direct_thread:6,5rG:direct_thread:7,"
-                "6xQ:direct_media_picker_photos_fragment:8,5rG:direct_thread:9"
-            ),
-            (
-                "1qT:feed_timeline:1,7Az:direct_inbox:2,7Az:direct_inbox:3,"
-                "5rG:direct_thread:4,6xQ:direct_media_picker_photos_fragment:5,"
-                "5rG:direct_thread:6,5rG:direct_thread:7,"
-                "6xQ:direct_media_picker_photos_fragment:8,5rG:direct_thread:9"
-            ),
-        ]
-        kwargs = {}
-        data = {
-            "action": "send_item",
-            "is_shh_mode": "0",
-            "send_attribution": "direct_thread",
-            "client_context": token,
-            "mutation_token": token,
-            "nav_chain": random.choices(nav_chains),
-            "offline_threading_id": token,
-        }
-        if content_type == "video":
-            data["video_result"] = ""
-            kwargs["to_direct"] = True
         if content_type == "photo":
-            data["send_attribution"] = "inbox"
-            data["allow_full_aspect_ratio"] = "true"
-        if user_ids:
-            data["recipient_users"] = dumps([[int(uid) for uid in user_ids]])
-        if thread_ids:
-            data["thread_ids"] = dumps([int(tid) for tid in thread_ids])
-        path = Path(path)
-        upload_id = str(int(time.time() * 1000))
-        upload_id, width, height = (await getattr(self, f"{content_type}_rupload")(path, upload_id, **kwargs))[:3]
-        data["upload_id"] = upload_id
-        # data['content_type'] = content_type
-        result = await self.private_request(
-            f"direct_v2/threads/broadcast/{method}/",
-            data=self.with_default_data(data),
-            with_signature=False,
-        )
-        return extract_direct_message(result["payload"])
+            return await self.direct_send_photo(path, user_ids, thread_ids)
+        if content_type == "video":
+            return await self.direct_send_video(path, user_ids, thread_ids)
+        raise ValueError('content_type must be "photo" or "video"')
 
     async def direct_send_cutout_sticker(
         self,

--- a/aiograpi/mixins/direct.py
+++ b/aiograpi/mixins/direct.py
@@ -1074,7 +1074,7 @@ class DirectMixin(ClientMixin):
                 "x_fb_video_waterfall_id": waterfall_id,
             }
         )
-        proxy = getattr(self, "proxy", None)
+        proxy = self.private.proxy
         response = await httpx_ext.request(
             "GET",
             url,
@@ -1170,7 +1170,7 @@ class DirectMixin(ClientMixin):
         entity = f"{upload_id}_0_{rand_key}"
         url = f"https://rupload.facebook.com/messenger_audio/{entity}"
         headers = self._messenger_rupload_headers({"audio_type": "FILE_ATTACHMENT"})
-        proxy = getattr(self, "proxy", None)
+        proxy = self.private.proxy
         response = await httpx_ext.request(
             "GET",
             url,

--- a/aiograpi/mixins/direct.py
+++ b/aiograpi/mixins/direct.py
@@ -1048,7 +1048,7 @@ class DirectMixin(ClientMixin):
         response = await httpx_ext.request(
             "POST",
             url,
-            data=photo_bytes,
+            content=photo_bytes,
             headers=headers,
             proxy=self.private.proxy,
             verify=self.tls_verify,

--- a/aiograpi/mixins/direct.py
+++ b/aiograpi/mixins/direct.py
@@ -1050,7 +1050,7 @@ class DirectMixin(ClientMixin):
             url,
             data=photo_bytes,
             headers=headers,
-            proxy=getattr(self, "proxy", None),
+            proxy=self.private.proxy,
             verify=self.tls_verify,
             timeout=120,
         )

--- a/aiograpi/mixins/media.py
+++ b/aiograpi/mixins/media.py
@@ -1375,22 +1375,21 @@ class MediaMixin(ClientMixin):
         List[Media]
             A list of objects of Media
         """
-        default_nav = self.base_headers["X-IG-Nav-Chain"]
-        self.base_headers["X-IG-Nav-Chain"] = (
-            "MainFeedFragment:feed_timeline:12:main_home::,UserDetailFragment:profile:13:button::"
-        )
+        user_id = str(user_id)
+        nav_chain = "MainFeedFragment:feed_timeline:12:main_home::,UserDetailFragment:profile:13:button::"
         medias = await self.private_request(
             f"feed/user/{user_id}/",
             params={
                 "exclude_comment": "true",
                 "only_fetch_first_carousel_media": "false",
             },
+            headers={"X-IG-Nav-Chain": nav_chain},
         )
         pinned_medias = []
         for media in medias.get("items") or []:
-            if media.get("timeline_pinned_user_ids") is not None:
+            pinned_user_ids = media.get("timeline_pinned_user_ids") or ()
+            if user_id in map(str, pinned_user_ids):
                 pinned_medias.append(extract_media_v1(media))
-        self.base_headers["X-IG-Nav-Chain"] = default_nav
         return pinned_medias
 
     async def user_medias(self, user_id: int, amount: int = 0, sleep: int = 0) -> List[Media]:

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -38,7 +38,7 @@
 | direct_thread_unmute(thread_id: int)                                      | bool                    | Unmute the thread
 | direct_thread_mute_video_call(thread_id: int, revert: bool = False)       | bool                    | Mute video call for the thread
 | direct_thread_unmute_video_call(thread_id: int)                           | bool                    | Unmute video call for the thread
-| direct_send_photo(path: Path, user_ids: List[int], thread_ids: List[int]) | DirectMessage           | Send a direct photo to list of users or threads
+| direct_send_photo(path: Path, user_ids: List[int], thread_ids: List[int]) | DirectMessage           | Send a direct photo to users in an existing thread or directly to thread ids
 | direct_send_video(path: Path, user_ids: List[int], thread_ids: List[int]) | DirectMessage           | Send a direct video to list of users or threads
 | direct_send_voice(path: Path, user_ids: List[int], thread_ids: List[int], waveform: Optional[List[float]] = None) | DirectMessage | Send an m4a/AAC voice message to list of users or threads
 | video_upload_to_direct(path: Path, caption: str, thumbnail: Path, mentions: List[StoryMention], thread_ids: List[int] = [], extra_data: Dict[str, str] = {}) | DirectMessage | Upload video to direct thread as a story and configure it
@@ -55,6 +55,7 @@ Notes:
 
 * Direct recipient arguments accept either one id (`user_ids=123`) or a list of ids (`user_ids=[123]`).
 * For `direct_send()`, `direct_media_share()`, `direct_send_photo()`, `direct_send_video()`, and `direct_send_voice()`, pass exactly one of `user_ids` or `thread_ids`.
+* Direct photo, video, and voice attachments sent with `user_ids` require an existing Direct thread. Use `direct_send()` to start the conversation first, or prefer `thread_ids` when the thread id is already known.
 * `direct_send_video()` uses the current direct video attachment flow. `video_upload_to_direct()` remains available for the older story-to-direct flow.
 * Direct message requests / invitations are exposed as `direct_requests()`; `direct_pending_inbox()` remains as the older name.
 * `direct_pending_requests_preview()` is the lightweight Android-app preview for request counters; use `direct_requests()` when you need the actual threads.

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -198,7 +198,6 @@ class ClientPrivateTestCase(BaseClientMixin, unittest.IsolatedAsyncioTestCase):
         login_kwargs = {
             "username": acc["username"],
             "password": acc["password"],
-            "relogin": True,
         }
         if totp_seed:
             totp_code = cl.totp_generate_code(totp_seed)

--- a/tests/live/test_direct.py
+++ b/tests/live/test_direct.py
@@ -190,8 +190,29 @@ class ClientDirectLiveTestCase(RealtimeLiveHelpers, _legacy.ClientPrivateTestCas
         photo_path = self.make_photo_png()
         sent_messages = []
         thread_id = None
+        recipient_follow_added = False
 
         try:
+            relationship = await recipient.user_friendship_v1(sender.user_id)
+            if not relationship or not relationship.following:
+                followed = await recipient.user_follow(sender.user_id)
+                if not followed:
+                    self.skipTest("Recipient could not follow sender before Direct delivery test")
+                recipient_follow_added = True
+                relationship = await recipient.user_friendship_v1(sender.user_id)
+                if relationship and relationship.outgoing_request:
+                    approved = await sender.user_follow_request_approve(recipient.user_id)
+                    if not approved:
+                        self.skipTest("Sender could not approve recipient follow request")
+
+                for _ in range(6):
+                    relationship = await recipient.user_friendship_v1(sender.user_id)
+                    if relationship and relationship.following:
+                        break
+                    await asyncio.sleep(2)
+                if not relationship or not relationship.following:
+                    self.skipTest("Recipient follow was not active before Direct delivery test")
+
             seed_message = await sender.direct_send(
                 f"aiograpi direct photo live warm {int(time.time())}",
                 user_ids=[recipient.user_id],
@@ -249,3 +270,8 @@ class ClientDirectLiveTestCase(RealtimeLiveHelpers, _legacy.ClientPrivateTestCas
                         await client.direct_thread_hide(thread_id)
                     except Exception as exc:
                         logger.warning("Direct photo thread cleanup failed: %s", exc)
+            if recipient_follow_added:
+                try:
+                    await recipient.user_unfollow(sender.user_id)
+                except Exception as exc:
+                    logger.warning("Direct photo follow cleanup failed: %s", exc)

--- a/tests/live/test_direct.py
+++ b/tests/live/test_direct.py
@@ -1,7 +1,11 @@
 import asyncio
 import logging
+import tempfile
 import time
 from contextlib import asynccontextmanager
+from pathlib import Path
+
+from PIL import Image
 
 from aiograpi.exceptions import DirectMessageNotFound
 from aiograpi.types import DirectMessage
@@ -12,6 +16,13 @@ logger = logging.getLogger("aiograpi.tests")
 
 
 class ClientDirectLiveTestCase(RealtimeLiveHelpers, _legacy.ClientPrivateTestCase):
+    def make_photo_png(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as tmp:
+            path = Path(tmp.name)
+        Image.new("RGBA", (64, 48), (37, 99, 235, 128)).save(path)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+        return path
+
     @asynccontextmanager
     async def direct_pagination_thread(self, sender, test_name):
         try:
@@ -168,3 +179,73 @@ class ClientDirectLiveTestCase(RealtimeLiveHelpers, _legacy.ClientPrivateTestCas
                         await client.direct_thread_hide(thread_id)
                     except Exception as exc:
                         logger.warning("Direct media share thread cleanup failed: %s", exc)
+
+    async def test_direct_send_photo_with_thread_and_user_ids_live(self):
+        sender = self.cl
+        try:
+            recipient = await self.fresh_account_excluding({sender.user_id})
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+        photo_path = self.make_photo_png()
+        sent_messages = []
+        thread_id = None
+
+        try:
+            seed_message = await sender.direct_send(
+                f"aiograpi direct photo live warm {int(time.time())}",
+                user_ids=[recipient.user_id],
+            )
+            self.assertIsInstance(seed_message, DirectMessage)
+            sent_messages.append((sender, seed_message))
+
+            thread_id = seed_message.thread_id
+            if not thread_id:
+                thread = await sender.direct_thread_by_participants([recipient.user_id])
+                thread_id = thread.get("thread_v2_id") or thread.get("thread_id")
+            self.assertTrue(thread_id)
+
+            reply_message = await recipient.direct_answer(
+                thread_id,
+                f"aiograpi direct photo live reply {int(time.time())}",
+            )
+            self.assertIsInstance(reply_message, DirectMessage)
+            sent_messages.append((recipient, reply_message))
+
+            thread_photo = await sender.direct_send_photo(photo_path, thread_ids=[thread_id])
+            self.assertIsInstance(thread_photo, DirectMessage)
+            self.assertTrue(thread_photo.id)
+            sent_messages.append((sender, thread_photo))
+
+            user_photo = await sender.direct_send_photo(photo_path, user_ids=[recipient.user_id])
+            self.assertIsInstance(user_photo, DirectMessage)
+            self.assertTrue(user_photo.id)
+            sent_messages.append((sender, user_photo))
+
+            for sent_photo in (thread_photo, user_photo):
+                received_photo = None
+                for _ in range(8):
+                    try:
+                        received_photo = await recipient.direct_message(thread_id, sent_photo.id, amount=20)
+                    except DirectMessageNotFound:
+                        await asyncio.sleep(2)
+                        continue
+                    if received_photo.item_type == "media" and received_photo.media:
+                        break
+                    await asyncio.sleep(2)
+
+                self.assertIsNotNone(received_photo)
+                self.assertEqual(received_photo.item_type, "media")
+                self.assertIsNotNone(received_photo.media)
+        finally:
+            if thread_id:
+                for client, message in reversed(sent_messages):
+                    try:
+                        await client.direct_message_unsend(thread_id, message.id)
+                    except Exception as exc:
+                        logger.warning("Direct photo message cleanup failed: %s", exc)
+                for client in (sender, recipient):
+                    try:
+                        await client.direct_thread_hide(thread_id)
+                    except Exception as exc:
+                        logger.warning("Direct photo thread cleanup failed: %s", exc)

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -1,6 +1,12 @@
+import asyncio
 import os
+import tempfile
+import time
 import unittest
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
+
+from PIL import Image
 
 from aiograpi.exceptions import (
     ClientBadRequestError,
@@ -10,6 +16,8 @@ from aiograpi.exceptions import (
     ClientThrottledError,
     ClientUnauthorizedError,
 )
+from aiograpi.types import Media
+from tests import legacy as _legacy
 from tests.live.smoke import _fetch_accounts, _login_first_usable
 
 PUBLIC_MEDIA_FETCH_ERRORS = (
@@ -20,6 +28,79 @@ PUBLIC_MEDIA_FETCH_ERRORS = (
     ClientThrottledError,
     ClientUnauthorizedError,
 )
+
+
+class ClientPinnedMediaLiveTestCase(_legacy.ClientPrivateTestCase):
+    def make_photo_png(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as tmp:
+            path = Path(tmp.name)
+        Image.new("RGB", (640, 800), (37, 99, 235)).save(path)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+        return path
+
+    async def expected_pinned_media_pks(self, client):
+        user_id = str(client.user_id)
+        nav_chain = "MainFeedFragment:feed_timeline:12:main_home::,UserDetailFragment:profile:13:button::"
+        response = await client.private_request(
+            f"feed/user/{user_id}/",
+            params={
+                "exclude_comment": "true",
+                "only_fetch_first_carousel_media": "false",
+            },
+            headers={"X-IG-Nav-Chain": nav_chain},
+        )
+        return [
+            str(item["pk"])
+            for item in response.get("items") or []
+            if user_id in map(str, item.get("timeline_pinned_user_ids") or ())
+        ]
+
+    async def test_user_pinned_medias_upload_pin_readback_unpin_delete_live(self):
+        client = self.cl
+        photo_path = self.make_photo_png()
+        media = None
+        pinned = False
+
+        try:
+            media = await client.photo_upload(
+                photo_path,
+                f"aiograpi pinned media live {int(time.time())}",
+            )
+            self.assertIsInstance(media, Media)
+            self.assertTrue(await client.media_pin(media.pk))
+            pinned = True
+
+            expected_pks = []
+            actual_pks = []
+            for _ in range(8):
+                expected_pks = await self.expected_pinned_media_pks(client)
+                actual_pks = [str(item.pk) for item in await client.user_pinned_medias(client.user_id)]
+                if str(media.pk) in expected_pks and actual_pks == expected_pks:
+                    break
+                await asyncio.sleep(3)
+
+            self.assertIn(str(media.pk), expected_pks)
+            self.assertEqual(actual_pks, expected_pks)
+
+            self.assertTrue(await client.media_unpin(media.pk))
+            pinned = False
+            for _ in range(8):
+                actual_pks = [str(item.pk) for item in await client.user_pinned_medias(client.user_id)]
+                if str(media.pk) not in actual_pks:
+                    break
+                await asyncio.sleep(3)
+            self.assertNotIn(str(media.pk), actual_pks)
+        finally:
+            if media is not None:
+                if pinned:
+                    try:
+                        await client.media_unpin(media.pk)
+                    except Exception:
+                        pass
+                try:
+                    await client.media_delete(media.id)
+                except Exception:
+                    pass
 
 
 class ClientMediaCountAliasLiveTestCase(unittest.IsolatedAsyncioTestCase):

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import tempfile
 import time
@@ -19,6 +20,8 @@ from aiograpi.exceptions import (
 from aiograpi.types import Media
 from tests import legacy as _legacy
 from tests.live.smoke import _fetch_accounts, _login_first_usable
+
+logger = logging.getLogger("aiograpi.tests")
 
 PUBLIC_MEDIA_FETCH_ERRORS = (
     ClientBadRequestError,
@@ -95,12 +98,12 @@ class ClientPinnedMediaLiveTestCase(_legacy.ClientPrivateTestCase):
                 if pinned:
                     try:
                         await client.media_unpin(media.pk)
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        logger.warning("Pinned media unpin cleanup failed: %s", exc)
                 try:
                     await client.media_delete(media.id)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.warning("Pinned media delete cleanup failed: %s", exc)
 
 
 class ClientMediaCountAliasLiveTestCase(unittest.IsolatedAsyncioTestCase):

--- a/tests/live/test_realtime.py
+++ b/tests/live/test_realtime.py
@@ -13,9 +13,11 @@ class RealtimeLiveHelpers:
         return os.getenv("IG_REALTIME_PROXY") or client.proxy
 
     async def fresh_account_excluding(self, exclude_user_ids):
-        data = await self.fetch_test_accounts(count=5 + len(exclude_user_ids))
+        # Multi-account live tests must be able to move past a temporarily
+        # throttled batch instead of repeatedly retrying the same first five.
+        data = await self.fetch_test_accounts(count=max(20, 5 + len(exclude_user_ids)))
         last_exc = None
-        for acc in data[:5]:
+        for acc in data:
             if str(acc.get("user_id")) in {str(user_id) for user_id in exclude_user_ids}:
                 continue
             try:

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -5,8 +5,10 @@ from pathlib import Path
 from unittest import mock
 from unittest.mock import AsyncMock, Mock
 
+from PIL import Image
+
 from aiograpi import Client
-from aiograpi.exceptions import DirectMessageNotFound, DirectThreadNotFound
+from aiograpi.exceptions import ClientError, DirectMessageNotFound, DirectThreadNotFound
 from aiograpi.extractors import extract_direct_thread
 from aiograpi.types import DirectMessage, DirectThread
 
@@ -104,6 +106,13 @@ def _temp_file(suffix, data):
     tmp.write(data)
     tmp.close()
     return Path(tmp.name)
+
+
+def _temp_image(suffix=".png"):
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        path = Path(tmp.name)
+    Image.new("RGB", (48, 64), (37, 99, 235)).save(path)
+    return path
 
 
 class DirectMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
@@ -680,6 +689,261 @@ class DirectMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         client.direct_thread_by_participants.assert_awaited_once_with([42])
         client._voice_rupload.assert_not_called()
+
+    async def test_direct_send_photo_uploads_and_broadcasts_attachment_for_thread_ids(self):
+        client = _build_client()
+        path = _temp_file(".png", b"png-bytes")
+        expected = Mock(spec=DirectMessage)
+
+        try:
+            with (
+                mock.patch("aiograpi.mixins.direct.time.time", return_value=1234.567),
+                mock.patch("aiograpi.mixins.direct.prepare_image", return_value=(b"jpeg-bytes", (64, 48)), create=True),
+                mock.patch.object(
+                    client,
+                    "_photo_rupload",
+                    new=AsyncMock(return_value=987654321),
+                    create=True,
+                ) as rupload,
+                mock.patch.object(
+                    client,
+                    "photo_rupload",
+                    new=AsyncMock(return_value=("legacy-upload", 64, 48)),
+                ),
+                mock.patch.object(client, "generate_mutation_token", return_value="mutation-token"),
+                mock.patch("aiograpi.mixins.direct.extract_direct_message", return_value=expected),
+            ):
+                client.private_request = AsyncMock(return_value=_direct_payload())
+                result = await client.direct_send_photo(path, thread_ids=[123])
+        finally:
+            path.unlink(missing_ok=True)
+
+        assert result is expected
+        rupload.assert_awaited_once_with(b"jpeg-bytes", "fb_uploader_1234567")
+        client.private_request.assert_awaited_once_with(
+            "direct_v2/threads/broadcast/photo_attachment/",
+            data=mock.ANY,
+            with_signature=False,
+        )
+        data = client.private_request.call_args.kwargs["data"]
+        assert json.loads(data["thread_ids"]) == [123]
+        assert data["attachment_fbid"] == "987654321"
+        assert data["action"] == "send_item"
+        assert data["is_x_transport_forward"] == "false"
+        assert data["is_shh_mode"] == "0"
+        assert data["send_attribution"] == "inbox"
+        assert data["client_context"] == "mutation-token"
+        assert data["mutation_token"] == "mutation-token"
+        assert data["offline_threading_id"] == "mutation-token"
+        assert data["device_id"] == "android-device"
+        assert data["_uuid"] == "uuid-1"
+        assert data["allow_full_aspect_ratio"] == "true"
+        assert data["btt_dual_send"] == "false"
+        assert data["is_ae_dual_send"] == "false"
+
+    async def test_direct_send_photo_accepts_jpeg_and_webp_inputs(self):
+        client = _build_client()
+
+        for suffix in (".jpeg", ".webp"):
+            with self.subTest(suffix=suffix):
+                path = _temp_image(suffix)
+                try:
+                    with (
+                        mock.patch.object(
+                            client,
+                            "_photo_rupload",
+                            new=AsyncMock(return_value=123),
+                        ) as rupload,
+                        mock.patch.object(client, "generate_mutation_token", return_value="token"),
+                        mock.patch(
+                            "aiograpi.mixins.direct.extract_direct_message",
+                            return_value=Mock(spec=DirectMessage),
+                        ),
+                    ):
+                        client.private_request = AsyncMock(return_value=_direct_payload())
+                        await client.direct_send_photo(path, thread_ids=[123])
+                finally:
+                    path.unlink(missing_ok=True)
+
+                photo_bytes, _ = rupload.await_args.args
+                assert photo_bytes.startswith(b"\xff\xd8")
+
+    async def test_direct_send_photo_requires_login(self):
+        client = Client()
+
+        with self.assertRaisesRegex(AssertionError, "Login required"):
+            await client.direct_send_photo("missing.png", thread_ids=[123])
+
+    async def test_direct_send_photo_requires_exactly_one_recipient_mode(self):
+        client = _build_client()
+
+        for user_ids, thread_ids in (([], []), ([42], [123])):
+            with self.subTest(user_ids=user_ids, thread_ids=thread_ids):
+                with self.assertRaisesRegex(AssertionError, "Specify user_ids or thread_ids, but not both"):
+                    await client.direct_send_photo(
+                        "missing.png",
+                        user_ids=user_ids,
+                        thread_ids=thread_ids,
+                    )
+
+    async def test_direct_send_photo_resolves_existing_thread_for_user_ids(self):
+        client = _build_client()
+        path = _temp_file(".jpg", b"jpg-bytes")
+        thread_id = "340282366841710300949128149448121770626"
+        client.direct_thread_by_participants = AsyncMock(return_value={"thread_v2_id": thread_id})
+
+        try:
+            with (
+                mock.patch("aiograpi.mixins.direct.prepare_image", return_value=(b"jpeg-bytes", (64, 48)), create=True),
+                mock.patch.object(
+                    client,
+                    "_photo_rupload",
+                    new=AsyncMock(return_value=123),
+                    create=True,
+                ),
+                mock.patch.object(
+                    client,
+                    "photo_rupload",
+                    new=AsyncMock(return_value=("legacy-upload", 64, 48)),
+                ),
+                mock.patch.object(client, "generate_mutation_token", return_value="mutation-token"),
+            ):
+                client.private_request = AsyncMock(return_value=_direct_payload())
+                await client.direct_send_photo(path, user_ids=[42])
+        finally:
+            path.unlink(missing_ok=True)
+
+        client.direct_thread_by_participants.assert_awaited_once_with([42])
+        data = client.private_request.call_args.kwargs["data"]
+        assert json.loads(data["thread_ids"]) == [int(thread_id)]
+        assert "recipient_users" not in data
+
+    async def test_direct_send_photo_raises_before_upload_when_existing_thread_is_missing(self):
+        client = _build_client()
+        client.direct_thread_by_participants = AsyncMock(return_value={})
+
+        with mock.patch.object(
+            client,
+            "_photo_rupload",
+            new=AsyncMock(),
+            create=True,
+        ) as rupload:
+            with self.assertRaises(DirectThreadNotFound):
+                await client.direct_send_photo("missing.png", user_ids=[42])
+
+        client.direct_thread_by_participants.assert_awaited_once_with([42])
+        rupload.assert_not_awaited()
+
+    async def test_direct_send_photo_rejects_unsupported_extension(self):
+        client = _build_client()
+        path = _temp_file(".gif", b"not-an-image")
+
+        try:
+            with self.assertRaisesRegex(ValueError, "JPG/JPEG/PNG/WEBP"):
+                await client.direct_send_photo(path, thread_ids=[123])
+        finally:
+            path.unlink(missing_ok=True)
+
+    async def test_direct_send_file_delegates_to_current_photo_and_video_flows(self):
+        client = _build_client()
+        photo_result = Mock(spec=DirectMessage)
+        video_result = Mock(spec=DirectMessage)
+
+        with (
+            mock.patch.object(client, "direct_send_photo", new=AsyncMock(return_value=photo_result)) as send_photo,
+            mock.patch.object(client, "direct_send_video", new=AsyncMock(return_value=video_result)) as send_video,
+            mock.patch.object(
+                client,
+                "photo_rupload",
+                new=AsyncMock(return_value=("legacy-photo", 1, 1)),
+            ),
+            mock.patch.object(
+                client,
+                "video_rupload",
+                new=AsyncMock(return_value=("legacy-video", 1, 1)),
+            ),
+        ):
+            client.private_request = AsyncMock(return_value=_direct_payload())
+            photo = await client.direct_send_file("photo.jpg", thread_ids=[123], content_type="photo")
+            video = await client.direct_send_file("video.mp4", user_ids=[42], content_type="video")
+
+        assert photo is photo_result
+        assert video is video_result
+        send_photo.assert_awaited_once_with("photo.jpg", [], [123])
+        send_video.assert_awaited_once_with("video.mp4", [42], [])
+
+    async def test_direct_send_file_rejects_unsupported_content_type(self):
+        client = _build_client()
+
+        with self.assertRaisesRegex(ValueError, 'content_type must be "photo" or "video"'):
+            await client.direct_send_file("voice.m4a", thread_ids=[123], content_type="audio")
+
+    async def test_photo_rupload_posts_jpeg_with_messenger_headers(self):
+        client = _build_client()
+        client.proxy = "http://proxy.example:8080"
+
+        class FakeResponse:
+            status_code = 200
+            text = '{"media_id":"987654321"}'
+
+            def json(self):
+                return {"media_id": "987654321"}
+
+        with (
+            mock.patch.object(
+                client,
+                "_messenger_rupload_headers",
+                return_value={"authorization": "Bearer token", "image_type": "FILE_ATTACHMENT"},
+            ) as headers,
+            mock.patch(
+                "aiograpi.mixins.direct.httpx_ext.request",
+                new=AsyncMock(return_value=FakeResponse()),
+            ) as request,
+        ):
+            media_id = await client._photo_rupload(b"photo-bytes", "fb_uploader_123")
+
+        assert media_id == 987654321
+        headers.assert_called_once_with({"image_type": "FILE_ATTACHMENT"})
+        request.assert_awaited_once_with(
+            "POST",
+            "https://rupload.facebook.com/messenger_image/fb_uploader_123",
+            data=b"photo-bytes",
+            headers={
+                "authorization": "Bearer token",
+                "image_type": "FILE_ATTACHMENT",
+                "content-type": "application/octet-stream",
+                "offset": "0",
+                "x-entity-length": "11",
+                "x-entity-name": "fb_uploader_123",
+                "x-entity-type": "image/jpeg",
+            },
+            proxy=client.proxy,
+            verify=client.tls_verify,
+            timeout=120,
+        )
+
+    async def test_photo_rupload_raises_for_failed_upload(self):
+        client = _build_client()
+        response = Mock(status_code=500, text="server error")
+
+        with mock.patch(
+            "aiograpi.mixins.direct.httpx_ext.request",
+            new=AsyncMock(return_value=response),
+        ):
+            with self.assertRaisesRegex(ClientError, "messenger_image upload POST failed: 500"):
+                await client._photo_rupload(b"photo-bytes", "fb_uploader_123")
+
+    async def test_photo_rupload_raises_when_media_id_is_missing(self):
+        client = _build_client()
+        response = Mock(status_code=200, text='{"status":"ok"}')
+        response.json.return_value = {"status": "ok"}
+
+        with mock.patch(
+            "aiograpi.mixins.direct.httpx_ext.request",
+            new=AsyncMock(return_value=response),
+        ):
+            with self.assertRaisesRegex(ClientError, "messenger_image response missing media_id"):
+                await client._photo_rupload(b"photo-bytes", "fb_uploader_123")
 
     async def test_messenger_rupload_headers_merges_common_optional_and_extra_headers(self):
         client = _build_client()

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -880,7 +880,7 @@ class DirectMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
     async def test_photo_rupload_posts_jpeg_with_messenger_headers(self):
         client = _build_client()
-        client.proxy = "http://proxy.example:8080"
+        client.set_proxy("http://proxy.example:8080")
 
         class FakeResponse:
             status_code = 200
@@ -917,10 +917,26 @@ class DirectMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
                 "x-entity-name": "fb_uploader_123",
                 "x-entity-type": "image/jpeg",
             },
-            proxy=client.proxy,
+            proxy=client.private.proxy,
             verify=client.tls_verify,
             timeout=120,
         )
+
+    async def test_photo_rupload_uses_active_private_session_proxy_after_clear(self):
+        client = _build_client()
+        client.set_proxy("http://proxy.example:8080")
+        client.set_proxy("")
+
+        response = Mock(status_code=200, text='{"media_id":"987654321"}')
+        response.json.return_value = {"media_id": "987654321"}
+        with mock.patch(
+            "aiograpi.mixins.direct.httpx_ext.request",
+            new=AsyncMock(return_value=response),
+        ) as request:
+            await client._photo_rupload(b"photo-bytes", "fb_uploader_123")
+
+        assert client.private.proxy is None
+        assert request.await_args.kwargs["proxy"] is None
 
     async def test_photo_rupload_raises_for_failed_upload(self):
         client = _build_client()

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -1018,6 +1018,24 @@ class DirectMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             }
         )
 
+    async def test_video_rupload_uses_active_private_session_proxy_after_clear(self):
+        client = _build_client()
+        client.set_proxy("http://proxy.example:8080")
+        client.set_proxy("")
+
+        offset_response = Mock(status_code=200, text='{"offset":0}')
+        offset_response.json.return_value = {"offset": 0}
+        upload_response = Mock(status_code=200, text='{"media_id":"987654321"}')
+        upload_response.json.return_value = {"media_id": "987654321"}
+        with mock.patch(
+            "aiograpi.mixins.direct.httpx_ext.request",
+            new=AsyncMock(side_effect=[offset_response, upload_response]),
+        ) as request:
+            await client._video_rupload(b"video-bytes", "entity-name", "waterfall-id")
+
+        assert client.private.proxy is None
+        assert [call.kwargs["proxy"] for call in request.await_args_list] == [None, None]
+
     async def test_voice_rupload_delegates_base_headers_to_helper(self):
         client = _build_client()
 
@@ -1044,3 +1062,21 @@ class DirectMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         assert media_id == 987654321
         headers.assert_called_once_with({"audio_type": "FILE_ATTACHMENT"})
+
+    async def test_voice_rupload_uses_active_private_session_proxy_after_clear(self):
+        client = _build_client()
+        client.set_proxy("http://proxy.example:8080")
+        client.set_proxy("")
+
+        offset_response = Mock(status_code=200, text='{"offset":0}')
+        offset_response.json.return_value = {"offset": 0}
+        upload_response = Mock(status_code=200, text='{"media_id":"987654321"}')
+        upload_response.json.return_value = {"media_id": "987654321"}
+        with mock.patch(
+            "aiograpi.mixins.direct.httpx_ext.request",
+            new=AsyncMock(side_effect=[offset_response, upload_response]),
+        ) as request:
+            await client._voice_rupload(b"voice-bytes", "1234567", -99)
+
+        assert client.private.proxy is None
+        assert [call.kwargs["proxy"] for call in request.await_args_list] == [None, None]

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -907,7 +907,7 @@ class DirectMixinRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         request.assert_awaited_once_with(
             "POST",
             "https://rupload.facebook.com/messenger_image/fb_uploader_123",
-            data=b"photo-bytes",
+            content=b"photo-bytes",
             headers={
                 "authorization": "Bearer token",
                 "image_type": "FILE_ATTACHMENT",

--- a/tests/regression/test_live_smoke.py
+++ b/tests/regression/test_live_smoke.py
@@ -144,6 +144,32 @@ class _LoginClient:
 
 
 class LiveSmokeRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_legacy_live_account_helper_reuses_saved_session_before_relogin(self):
+        from tests import legacy
+
+        client = _LoginClient()
+        account = {
+            "username": "example",
+            "password": "password",
+            "client_settings": {"totp_seed": "seed", "authorization_data": {"ds_user_id": "1"}},
+            "proxy": "",
+            "user_id": "1",
+        }
+
+        with (
+            patch.object(legacy, "Client", return_value=client),
+            patch.object(legacy, "login_with_timeout", new=AsyncMock()) as login,
+        ):
+            result = await legacy.ClientPrivateTestCase.client_from_test_account(None, account)
+
+        self.assertIs(result, client)
+        login.assert_awaited_once_with(
+            client,
+            username="example",
+            password="password",
+            verification_code="123456",
+        )
+
     async def test_fetch_accounts_overrides_existing_default_count(self):
         smoke = _load_live_smoke_module()
         captured = {}

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -564,3 +564,48 @@ class MediaActionPayloadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(cursor, "next")
         client.usertag_medias_paginated_v1.assert_awaited_once_with(123, 1, end_cursor="")
         client.usertag_medias_paginated_gql.assert_not_awaited()
+
+
+class UserPinnedMediasRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_user_pinned_medias_filters_by_requested_user_id(self):
+        client = Client()
+        response = {
+            "items": [
+                {"code": "target-int", "timeline_pinned_user_ids": [1349651722]},
+                {"code": "target-str", "timeline_pinned_user_ids": ["1349651722"]},
+                {"code": "other-user", "timeline_pinned_user_ids": [999]},
+                {"code": "ordinary", "timeline_pinned_user_ids": []},
+                {"code": "missing"},
+            ]
+        }
+        client.private_request = AsyncMock(return_value=response)
+
+        with unittest.mock.patch(
+            "aiograpi.mixins.media.extract_media_v1",
+            side_effect=lambda media: media,
+        ):
+            medias = await client.user_pinned_medias("1349651722")
+
+        self.assertEqual(
+            [media["code"] for media in medias],
+            ["target-int", "target-str"],
+        )
+
+    async def test_user_pinned_medias_sends_request_local_profile_nav_chain(self):
+        client = Client()
+        original_nav_chain = client.base_headers["X-IG-Nav-Chain"]
+        client.private_request = AsyncMock(return_value={"items": []})
+
+        await client.user_pinned_medias("1349651722")
+
+        client.private_request.assert_awaited_once_with(
+            "feed/user/1349651722/",
+            params={
+                "exclude_comment": "true",
+                "only_fetch_first_carousel_media": "false",
+            },
+            headers={
+                "X-IG-Nav-Chain": "MainFeedFragment:feed_timeline:12:main_home::,UserDetailFragment:profile:13:button::"
+            },
+        )
+        self.assertEqual(client.base_headers["X-IG-Nav-Chain"], original_nav_chain)


### PR DESCRIPTION
## Summary

- filter pinned-media reads by the requested profile and keep navigation headers request-local
- send Direct photos through the Messenger attachment upload/broadcast flow, including active proxy and TLS handling
- add regression and live coverage for pin roundtrips, photo delivery, proxy clearing, and reusable live-account sessions

Mirrors the fixes shipped in instagrapi PRs #2764 and #2765.

## Verification

- local regression: 503 passed, 3 skipped, 35 subtests passed
- pre-commit: all hooks passed
- fresh Linux clone: regression, Ruff, format, mypy baseline, and Bandit passed
- live pinned-media roundtrip: passed (upload, pin, exact readback, unpin, absence check, delete)
- live Direct photo delivery: passed for both thread_ids and user_ids with recipient readback
- independent review: no Critical or Important findings