### PR TITLE
fix: complete current Android CAA login fallback

### DIFF
--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 
 from aiograpi.mixins.account import AccountMixin
 from aiograpi.mixins.album import DownloadAlbumMixin, UploadAlbumMixin
+from aiograpi.mixins.attestation import DeviceAttestationMixin
 from aiograpi.mixins.auth import LoginMixin
 from aiograpi.mixins.bloks import BloksMixin
 from aiograpi.mixins.challenge import ChallengeResolveMixin
@@ -47,7 +48,7 @@ from aiograpi.mixins.video import DownloadVideoMixin, UploadVideoMixin
 # Used as fallback logger if another is not provided.
 DEFAULT_LOGGER = logging.getLogger("aiograpi")
 
-__upstream_instagrapi_version__ = "2.18.13"
+__upstream_instagrapi_version__ = "2.18.14"
 
 
 class Client(
@@ -91,6 +92,7 @@ class Client(
     UploadClipMixin,
     ReelsMixin,
     ExploreMixin,
+    DeviceAttestationMixin,
     BloksMixin,
     TOTPMixin,
     FundraiserMixin,

--- a/aiograpi/mixins/attestation.py
+++ b/aiograpi/mixins/attestation.py
@@ -1,0 +1,203 @@
+import base64
+import time
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+from Cryptodome.Hash import SHA256
+from Cryptodome.PublicKey import ECC
+from Cryptodome.Random import get_random_bytes
+from Cryptodome.Signature import DSS
+
+from aiograpi.mixins.base import ClientMixin
+from aiograpi.utils.serialization import dumps
+
+# IGUSDIDRegistrationMutation in the Android 428 app profile emulated by aiograpi.
+USDID_REGISTRATION_CLIENT_DOC_ID = "124930351917786857261002920888"
+USDID_TOKEN_TTL = 3600
+USDID_REFRESH_MARGIN = 300
+ATTESTATION_KEYSTORE_ERROR = -1013
+
+
+def _b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+class DeviceAttestationMixin(ClientMixin):
+    """Device signals used by the current Android CAA login flow."""
+
+    usdid = ""
+    usdid_kid = ""
+    usdid_private_key = ""
+    usdid_registered = False
+    attestation_challenge_nonce = ""
+    attestation_key_nonce = ""
+    _usdid_header_cache = ""
+    _usdid_header_expires_at = 0
+
+    def get_usdid_settings(self) -> Dict[str, Any]:
+        """Return persisted USDID key material, if it has been generated."""
+        if not self.usdid_private_key:
+            return {}
+        return {
+            "usdid": self.usdid,
+            "kid": self.usdid_kid,
+            "private_key": self.usdid_private_key,
+            "registered": self.usdid_registered,
+        }
+
+    def set_usdid_settings(self, settings: Optional[Dict[str, Any]] = None) -> bool:
+        """Restore USDID key material and reset per-login attestation state."""
+        settings = settings or {}
+        self.usdid = str(settings.get("usdid") or "")
+        self.usdid_kid = str(settings.get("kid") or "")
+        self.usdid_private_key = str(settings.get("private_key") or "")
+        self.usdid_registered = bool(settings.get("registered"))
+        self.attestation_challenge_nonce = ""
+        self.attestation_key_nonce = ""
+        self._usdid_header_cache = ""
+        self._usdid_header_expires_at = 0
+        private = getattr(self, "private", None)
+        if private is not None:
+            private.headers.pop("X-Meta-Usdid", None)
+        return bool(self.usdid_private_key)
+
+    def usdid_generate(self, force: bool = False) -> str:
+        """Generate the local P-256 signing identity used by ``X-Meta-Usdid``."""
+        if self.usdid_private_key and not force:
+            return self.usdid
+        key = ECC.generate(curve="P-256")
+        self.usdid_private_key = key.export_key(format="PEM")
+        self.usdid = str(uuid4())
+        self.usdid_kid = _b64u(get_random_bytes(32))
+        self.usdid_registered = False
+        self._usdid_header_cache = ""
+        self._usdid_header_expires_at = 0
+        return self.usdid
+
+    def _usdid_key(self) -> ECC.EccKey:
+        if not self.usdid_private_key:
+            self.usdid_generate()
+        return ECC.import_key(self.usdid_private_key)
+
+    def _usdid_sign(self, message: str) -> bytes:
+        signer = DSS.new(self._usdid_key(), "fips-186-3", encoding="der")
+        return signer.sign(SHA256.new(message.encode()))
+
+    @property
+    def usdid_public_key_der(self) -> bytes:
+        """DER SubjectPublicKeyInfo for the USDID P-256 public key."""
+        return self._usdid_key().public_key().export_key(format="DER")
+
+    def usdid_header(self, ttl: int = USDID_TOKEN_TTL) -> str:
+        """Build the app's three-part ``X-Meta-Usdid`` signed value."""
+        now = int(time.time())
+        if self._usdid_header_cache and self._usdid_header_expires_at - now > USDID_REFRESH_MARGIN:
+            return self._usdid_header_cache
+        expires_at = now + ttl
+        signed_part = f"{self.usdid}.{expires_at}"
+        value = f"{signed_part}.{_b64u(self._usdid_sign(signed_part))}"
+        self._usdid_header_cache = value
+        self._usdid_header_expires_at = expires_at
+        return value
+
+    def usdid_registration_token(self, ttl: int = USDID_TOKEN_TTL) -> str:
+        """Build the ES256 registration token sent by the Android app."""
+        now = int(time.time())
+        payload = _b64u(
+            dumps(
+                {
+                    "sub": self.usdid,
+                    "iat": now,
+                    "aud": self.app_id,
+                    "exp": now + ttl,
+                    "pub": base64.b64encode(self.usdid_public_key_der).decode(),
+                    "alg": "ES256",
+                }
+            ).encode()
+        )
+        protected = _b64u(
+            dumps(
+                {
+                    "typ": "JWT",
+                    "alg": "ES256",
+                    "kid": self.usdid_kid,
+                    "aid": self.app_id,
+                    "ver": "1",
+                }
+            ).encode()
+        )
+        token = {
+            "payload": payload,
+            "signatures": [
+                {
+                    "protected": protected,
+                    "signature": _b64u(self._usdid_sign(f"{protected}.{payload}")),
+                }
+            ],
+        }
+        return _b64u(dumps(token).encode())
+
+    async def usdid_register(self, client_doc_id: str = USDID_REGISTRATION_CLIENT_DOC_ID) -> bool:
+        """Register the local USDID public key with Instagram."""
+        if not self.usdid_private_key:
+            self.usdid_generate()
+        variables = {
+            "input": {
+                "usdid_token": {"sensitive_string_value": self.usdid_registration_token()},
+                "fdid": {"sensitive_string_value": self.phone_id},
+            }
+        }
+        result = await self.private_graphql_www_request(
+            "IGUSDIDRegistrationMutation",
+            variables,
+            client_doc_id=client_doc_id,
+            extra_headers={
+                "X-Root-Field-Name": "usdid_registration",
+                "X-Graphql-Client-Library": "pando",
+            },
+        )
+        registration = next(
+            (
+                value
+                for key, value in (result.get("data") or {}).items()
+                if "usdid_registration" in key and isinstance(value, dict)
+            ),
+            {},
+        )
+        self.usdid_registered = bool(registration.get("success"))
+        return self.usdid_registered
+
+    async def attestation_create_android_keystore(self, key_hash: str = "", domain: Optional[str] = None) -> Dict:
+        """Request the server nonce used by the CAA login attestation header."""
+        kwargs = {
+            "data": {"app_scoped_device_id": self.uuid, "key_hash": key_hash},
+            "with_signature": False,
+            "headers": {"X-FB-Friendly-Name": "IgApi: attestation/create_android_keystore/"},
+            "login": True,
+        }
+        if domain:
+            kwargs["domain"] = domain
+        result = await self.private_request("attestation/create_android_keystore/", **kwargs)
+        self.attestation_challenge_nonce = str(result.get("challenge_nonce") or "")
+        self.attestation_key_nonce = str(result.get("key_nonce") or "")
+        return result
+
+    def attestation_params(self, challenge_nonce: str = "") -> str:
+        """Build the accepted keystore-unavailable ``X-IG-Attest-Params`` state."""
+        nonce = challenge_nonce or self.attestation_challenge_nonce
+        if not nonce:
+            return ""
+        return dumps(
+            {
+                "attestation": [
+                    {
+                        "version": 2,
+                        "type": "keystore",
+                        "errors": [ATTESTATION_KEYSTORE_ERROR],
+                        "challenge_nonce": nonce,
+                        "signed_nonce": "",
+                        "key_hash": "",
+                    }
+                ]
+            }
+        )

--- a/aiograpi/mixins/auth.py
+++ b/aiograpi/mixins/auth.py
@@ -19,6 +19,7 @@ from aiograpi import config
 from aiograpi.exceptions import (
     BadCredentials,
     BadPassword,
+    ChallengeError,
     ClientError,
     ClientThrottledError,
     LoginRequired,
@@ -572,22 +573,31 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             **self._exception_context(login_json),
         ) from exc
 
-    async def _login_with_caa_bloks_two_factor(self, verification_code: str, password: str, exc: Exception) -> bool:
-        caa_result = await self.bloks_caa_login_send_request(password, login_attempt_count=1)
-        context = self.bloks_extract_two_step_verification_context(caa_result)
-        login_json = deepcopy(self.last_json) if isinstance(self.last_json, dict) else {}
+    async def _try_caa_login(self, exc: Exception, verification_code: str = "") -> bool:
+        """Try current Android CAA login while preserving the legacy error on failure."""
+        try:
+            outcome = await self.bloks_caa_login(verification_code=verification_code)
+        except (ChallengeError, TwoFactorRequired):
+            raise
+        except ClientError as caa_exc:
+            self.logger.warning("CAA login fallback failed: %s", caa_exc)
+            return False
+        if outcome.get("logged_in"):
+            return True
+        context = str(outcome.get("two_step_verification_context") or "")
         if not context:
+            return False
+        if not verification_code.strip():
             raise TwoFactorRequired(
-                "Instagram rejected the legacy login endpoint and may require "
-                "a newer CAA/Bloks login flow, but the CAA response did not "
-                "include two_step_verification_context required for automatic "
-                "Bloks two-factor verification. Complete verification in the "
-                "Instagram app or inspect the current login response.",
+                f"{exc} (Instagram returned a Bloks two-factor context from the CAA login flow; "
+                "provide verification_code for login)",
                 response=getattr(exc, "response", None),
-                **self._exception_context(login_json),
             ) from exc
-        login_json["two_step_verification_context"] = context
-        return await self._login_with_bloks_two_factor(verification_code, login_json, exc)
+        return await self._login_with_bloks_two_factor(
+            verification_code,
+            {"two_step_verification_context": context},
+            exc,
+        )
 
     def init(self) -> bool:
         """
@@ -639,6 +649,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         self.mid = self.settings.get("mid", self.cookie_dict.get("mid"))
         self.set_ig_u_rur(self.settings.get("ig_u_rur"))
         self.set_ig_www_claim(self.settings.get("ig_www_claim"))
+        self.set_usdid_settings(self.settings.get("usdid"))
         # init headers
         headers = self.base_headers
         if self.authorization:
@@ -786,18 +797,18 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         except BadPassword as exc:
             login_json = deepcopy(self.last_json) if isinstance(self.last_json, dict) else {}
             context = self._extract_two_step_verification_context(login_json)
-            if not context and not verification_code.strip():
-                raise
-            if not verification_code.strip():
+            if not context:
+                logged = await self._try_caa_login(exc, verification_code=verification_code)
+                if not logged:
+                    raise
+            elif not verification_code.strip():
                 raise TwoFactorRequired(
                     f"{exc} (Instagram returned a Bloks two-factor context; provide verification_code for login)",
                     response=getattr(exc, "response", None),
                     **self._exception_context(login_json),
                 ) from exc
-            if context:
-                logged = await self._login_with_bloks_two_factor(verification_code, login_json, exc)
             else:
-                logged = await self._login_with_caa_bloks_two_factor(verification_code, self.password, exc)
+                logged = await self._login_with_bloks_two_factor(verification_code, login_json, exc)
         except TwoFactorRequired as e:
             if not verification_code.strip():
                 raise TwoFactorRequired(f"{e} (you did not provide verification_code for login method)")
@@ -929,7 +940,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         Dict
             Current session settings as a Dict
         """
-        return {
+        settings = {
             "uuids": {
                 "phone_id": self.phone_id,
                 "uuid": self.uuid,
@@ -964,6 +975,10 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             "public_transport_impersonate": self.public_transport_impersonate,
             "tls_verify": self.tls_verify,
         }
+        usdid_settings = self.get_usdid_settings()
+        if usdid_settings:
+            settings["usdid"] = usdid_settings
+        return settings
 
     def set_settings(self, settings: Dict) -> bool:
         """
@@ -1230,6 +1245,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         bool
             A boolean value
         """
+        previous_phone_id = self.phone_id
         self.phone_id = uuids.get("phone_id", self.generate_uuid())
         self.uuid = uuids.get("uuid", self.generate_uuid())
         self.client_session_id = uuids.get("client_session_id", self.generate_uuid())
@@ -1239,6 +1255,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         self.tray_session_id = uuids.get("tray_session_id", self.generate_uuid())
         # self.device_id = uuids.get("device_id", self.generate_uuid())
         self.settings["uuids"] = uuids
+        if previous_phone_id and previous_phone_id != self.phone_id:
+            self.set_usdid_settings({})
         return True
 
     def generate_uuid(self, prefix: str = "", suffix: str = "") -> str:

--- a/aiograpi/mixins/auth.py
+++ b/aiograpi/mixins/auth.py
@@ -536,6 +536,13 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             return "sms"
         return "totp"
 
+    def _is_unavailable_caa_login_error(self, exc: ClientError) -> bool:
+        response = getattr(exc, "response", None)
+        status_code = getattr(response, "status_code", None) or getattr(exc, "code", None)
+        error_type = str(getattr(exc, "error_type", "") or "").casefold()
+        message = str(getattr(exc, "message", "") or exc).casefold()
+        return status_code == 404 or (error_type == "field_exception" and "payload returned is null" in message)
+
     async def _login_with_bloks_two_factor(self, verification_code: str, login_json: Dict, exc: Exception) -> bool:
         context = self._extract_two_step_verification_context(login_json)
         if not context:
@@ -583,6 +590,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         except (ChallengeError, TwoFactorRequired):
             raise
         except ClientError as caa_exc:
+            if not self._is_unavailable_caa_login_error(caa_exc):
+                raise
             self.logger.warning("CAA login fallback failed: %s", caa_exc)
             return False
         if outcome.get("logged_in"):
@@ -799,10 +808,13 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             self.authorization_data = self.parse_authorization(self.last_response.headers.get("ig-set-authorization"))
         except BadPassword as exc:
             login_json = deepcopy(self.last_json) if isinstance(self.last_json, dict) else {}
+            login_response = self.last_response
             context = self._extract_two_step_verification_context(login_json)
             if not context:
                 logged = await self._try_caa_login(exc, verification_code=verification_code)
                 if not logged:
+                    self.last_json = login_json
+                    self.last_response = login_response
                     raise
             elif not verification_code.strip():
                 raise TwoFactorRequired(

--- a/aiograpi/mixins/auth.py
+++ b/aiograpi/mixins/auth.py
@@ -575,6 +575,9 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
 
     async def _try_caa_login(self, exc: Exception, verification_code: str = "") -> bool:
         """Try current Android CAA login while preserving the legacy error on failure."""
+        if not self.bloks_versioning_id:
+            self.logger.warning("CAA login fallback requires a complete app profile with a Bloks versioning id")
+            return False
         try:
             outcome = await self.bloks_caa_login(verification_code=verification_code)
         except (ChallengeError, TwoFactorRequired):

--- a/aiograpi/mixins/base.py
+++ b/aiograpi/mixins/base.py
@@ -13,8 +13,13 @@ if TYPE_CHECKING:
         """
 
         android_device_id: str
+        app_id: str
+        attestation_challenge_nonce: str
+        attestation_key_nonce: str
         authorization_data: Dict[str, Any]
         bloks_versioning_id: str
+        caa_aac: str
+        caa_waterfall_id: str
         challenge_code_handler: Any
         change_password_handler: Any
         client_session_id: str
@@ -56,6 +61,8 @@ if TYPE_CHECKING:
         user_agent: str
         username: str
         uuid: str
+        usdid_private_key: str
+        usdid_registered: bool
         with_challenge_flow: bool
 
         @property
@@ -129,6 +136,18 @@ if TYPE_CHECKING:
 
         async def bloks_caa_login_send_request(self, *args: Any, **kwargs: Any) -> Any: ...
 
+        async def bloks_caa_login(self, *args: Any, **kwargs: Any) -> Dict[str, Any]: ...
+
+        async def attestation_create_android_keystore(self, *args: Any, **kwargs: Any) -> Any: ...
+
+        def attestation_params(self, *args: Any, **kwargs: Any) -> str: ...
+
+        async def private_graphql_www_request(self, *args: Any, **kwargs: Any) -> Any: ...
+
+        async def usdid_register(self, *args: Any, **kwargs: Any) -> bool: ...
+
+        def usdid_header(self, *args: Any, **kwargs: Any) -> str: ...
+
         async def bloks_challenge_take_challenge(self, *args: Any, **kwargs: Any) -> Any: ...
 
         async def bloks_change_password(self, *args: Any, **kwargs: Any) -> Any: ...
@@ -147,9 +166,13 @@ if TYPE_CHECKING:
 
         async def challenge_resolve(self, *args: Any, **kwargs: Any) -> Any: ...
 
+        async def challenge_code_or_raised(self, *args: Any, **kwargs: Any) -> str: ...
+
         async def expose(self, *args: Any, **kwargs: Any) -> Any: ...
 
         def gen_user_breadcrumb(self, *args: Any, **kwargs: Any) -> str: ...
+
+        def get_usdid_settings(self, *args: Any, **kwargs: Any) -> Dict[str, Any]: ...
 
         def generate_android_device_id(self, *args: Any, **kwargs: Any) -> str: ...
 
@@ -236,6 +259,8 @@ if TYPE_CHECKING:
         def set_timezone_offset(self, *args: Any, **kwargs: Any) -> Any: ...
 
         def set_user_agent(self, *args: Any, **kwargs: Any) -> Any: ...
+
+        def set_usdid_settings(self, *args: Any, **kwargs: Any) -> bool: ...
 
         async def top_search(self, *args: Any, **kwargs: Any) -> Any: ...
 

--- a/aiograpi/mixins/bloks.py
+++ b/aiograpi/mixins/bloks.py
@@ -6,12 +6,21 @@ from json import JSONDecodeError
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
+from aiograpi.exceptions import ChallengeError, ClientError
 from aiograpi.mixins.base import ClientMixin
+from aiograpi.mixins.challenge import ChallengeChoice
 from aiograpi.utils.serialization import dumps
+
+CAA_API_DOMAIN = "b.i.instagram.com"
+AP_2SV_ENTRYPOINT = "com.bloks.www.ap.two_step_verification.entrypoint_async"
+AP_2SV_CODE_ENTRY = "com.bloks.www.ap.two_step_verification.code_entry"
+AP_2SV_CODE_ENTRY_ASYNC = "com.bloks.www.ap.two_step_verification.code_entry_async"
 
 
 class BloksMixin(ClientMixin):
     bloks_versioning_id = ""
+    caa_aac = ""
+    caa_waterfall_id = ""
 
     def _bloks_payload(self, params: Dict, bloks_versioning_id: str = "") -> Dict[str, str]:
         versioning_id = bloks_versioning_id or self.bloks_versioning_id
@@ -30,6 +39,7 @@ class BloksMixin(ClientMixin):
         bloks_versioning_id: str = "",
         domain: Optional[str] = None,
         login: bool = False,
+        extra_headers: Optional[Dict[str, str]] = None,
     ) -> Dict:
         """
         Perform a raw Bloks async action.
@@ -46,6 +56,8 @@ class BloksMixin(ClientMixin):
             API domain override. Uses the default private API domain when omitted.
         login: bool, optional
             Allow pre-login requests for registration/login flows.
+        extra_headers: Dict[str, str], optional
+            Per-request HTTP headers.
 
         Returns
         -------
@@ -53,10 +65,13 @@ class BloksMixin(ClientMixin):
             Raw Instagram response.
         """
         data = self._bloks_payload(params, bloks_versioning_id=bloks_versioning_id)
+        headers = {"X-FB-Friendly-Name": f"IgApi: bloks/async_action/{action}/"}
+        if extra_headers:
+            headers.update(extra_headers)
         kwargs = {
             "data": data,
             "with_signature": False,
-            "headers": {"X-FB-Friendly-Name": f"IgApi: bloks/async_action/{action}/"},
+            "headers": headers,
         }
         if domain:
             kwargs["domain"] = domain
@@ -70,6 +85,7 @@ class BloksMixin(ClientMixin):
         params: Dict,
         bloks_versioning_id: str = "",
         login: bool = False,
+        domain: Optional[str] = None,
     ) -> Dict:
         """
         Perform a raw Bloks app request.
@@ -84,6 +100,8 @@ class BloksMixin(ClientMixin):
             Bloks versioning id. Uses ``Client.bloks_versioning_id`` when omitted.
         login: bool, optional
             Allow pre-login requests for registration/login flows.
+        domain: str, optional
+            API domain override. Uses the default private API domain when omitted.
 
         Returns
         -------
@@ -92,6 +110,8 @@ class BloksMixin(ClientMixin):
         """
         data = self._bloks_payload(params, bloks_versioning_id=bloks_versioning_id)
         kwargs: Dict[str, Any] = {"data": data, "with_signature": False}
+        if domain:
+            kwargs["domain"] = domain
         if login:
             kwargs["login"] = True
         return await self.private_request(f"bloks/apps/{app}/", **kwargs)
@@ -455,6 +475,154 @@ class BloksMixin(ClientMixin):
             login=True,
         )
 
+    def _caa_device_network_info(self) -> Dict[str, Any]:
+        return {
+            "active_subscriptions_info": None,
+            "default_subscription_info": {
+                "network_type": None,
+                "is_data_roaming": 1,
+                "is_esim": None,
+                "is_gsm_roaming": 0,
+                "is_sim_sms_capable": None,
+                "is_mobile_data_enabled": 1,
+                "sim_carrier_id": 1,
+                "sim_carrier_id_name": None,
+                "sim_state": 5,
+                "sim_operator": "310260",
+                "sim_operator_name": "T-Mobile",
+                "signal_strength": None,
+                "group_id_level_1": None,
+                "network_operator": "310260",
+            },
+            "is_airplane_mode": 0,
+            "is_active_network_cellular": 0,
+            "is_device_sms_capable": 1,
+            "sim_count": 1,
+            "is_wifi": 1,
+        }
+
+    def bloks_extract_aac(self, result: Dict) -> str:
+        """Extract the server-issued CAA account access context."""
+        data = result.get("layout", {}).get("bloks_payload", {}).get("data", [])
+        if not isinstance(data, list):
+            return ""
+        for node in data:
+            payload = node.get("data") if isinstance(node, dict) else None
+            if not isinstance(payload, dict) or payload.get("key") != "CAA_ACCOUNT_ACCESS_CONTEXT:aac":
+                continue
+            initial = payload.get("initial")
+            if isinstance(initial, str) and initial.strip():
+                return initial
+            lispy = payload.get("initial_lispy")
+            if isinstance(lispy, str) and lispy:
+                value = self._extract_first_json_string(lispy, 0)
+                if value:
+                    return value
+        return ""
+
+    async def bloks_caa_login_process_client_data(
+        self,
+        waterfall_id: str = "",
+        offline_experiment_group: str = "caa_iteration_v3_perf_ig_4",
+        bloks_versioning_id: str = "",
+        domain: Optional[str] = None,
+    ) -> Dict:
+        """Open the CAA login homepage and retain its server-issued ``aac``."""
+        self.caa_waterfall_id = waterfall_id or str(uuid4())
+        self.caa_aac = ""
+        params = {
+            "is_from_logged_out": False,
+            "logged_out_user": "",
+            "qpl_join_id": None,
+            "family_device_id": self.phone_id,
+            "device_id": self.android_device_id,
+            "offline_experiment_group": offline_experiment_group,
+            "waterfall_id": self.caa_waterfall_id,
+            "logout_source": "",
+            "show_internal_settings": False,
+            "last_auto_login_time": 0,
+            "disable_auto_login": False,
+            "qe_device_id": self.uuid,
+            "use_auto_login_interstitial": True,
+            "disable_recursive_auto_login_interstitial": True,
+            "auto_login_interstitial_experiment_group_name": "",
+            "is_from_logged_in_switcher": False,
+            "switcher_logged_in_uid": "",
+            "account_list": [],
+            "blocked_uid": [],
+            "INTERNAL_INFRA_THEME": "THREE_NEUTRAL_GRAY",
+            "layered_homepage_experiment_group": "Deploy: Not in Experiment",
+            "launched_url": "",
+            "sim_phone_numbers": [],
+            "is_from_registration_reminder": False,
+        }
+        result = await self.bloks_async_action(
+            "com.bloks.www.bloks.caa.login.process_client_data_and_redirect",
+            params,
+            bloks_versioning_id=bloks_versioning_id,
+            domain=domain,
+            login=True,
+        )
+        self.caa_aac = self.bloks_extract_aac(result)
+        return result
+
+    async def bloks_caa_login_oauth_token_fetch(
+        self,
+        username: str = "",
+        waterfall_id: str = "",
+        offline_experiment_group: str = "caa_iteration_v3_perf_ig_4",
+        bloks_versioning_id: str = "",
+        domain: Optional[str] = None,
+    ) -> Dict:
+        """Perform the CAA OAuth token preflight sent before credentials."""
+        self.caa_waterfall_id = waterfall_id or self.caa_waterfall_id or str(uuid4())
+        params = {
+            "client_input_params": {
+                "username_input": username or self.username,
+                "si_device_param_network_info": self._caa_device_network_info(),
+                "aac": self.caa_aac,
+                "lois_settings": {"lois_token": ""},  # nosec B105
+                "cloud_trust_token": None,  # nosec B105
+                "zero_balance_state": "",
+                "network_bssid": None,
+            },
+            "server_params": {
+                "is_from_logged_out": 0,
+                "layered_homepage_experiment_group": "Deploy: Not in Experiment",
+                "device_id": self.android_device_id,
+                "login_surface": "login_home",
+                "waterfall_id": self.caa_waterfall_id,
+                "INTERNAL__latency_qpl_instance_id": int(time.time() * 1000),
+                "is_platform_login": 0,
+                "login_entry_point": "logged_out",
+                "INTERNAL__latency_qpl_marker_id": 36707139,
+                "family_device_id": self.phone_id,
+                "offline_experiment_group": offline_experiment_group,
+                "access_flow_version": "pre_mt_behavior",
+                "is_from_logged_in_switcher": 0,
+                "qe_device_id": self.uuid,
+            },
+        }
+        return await self.bloks_async_action(
+            "com.bloks.www.caa.login.oauth.token.fetch.async",
+            params,
+            bloks_versioning_id=bloks_versioning_id,
+            domain=domain,
+            login=True,
+        )
+
+    async def bloks_caa_login_prepare(self, username: str = "", domain: Optional[str] = None) -> bool:
+        """Run the ordered device and CAA preflight needed before login."""
+        if not self.usdid_registered and not (await self.usdid_register()):
+            return False
+        await self.bloks_caa_login_process_client_data(domain=domain)
+        self.attestation_challenge_nonce = ""
+        self.attestation_key_nonce = ""
+        await self.attestation_create_android_keystore(domain=domain)
+        if self.caa_aac:
+            await self.bloks_caa_login_oauth_token_fetch(username=username, domain=domain)
+        return bool(self.caa_aac and self.attestation_challenge_nonce)
+
     async def bloks_caa_login_send_request(
         self,
         password: str,
@@ -464,13 +632,14 @@ class BloksMixin(ClientMixin):
         waterfall_id: str = "",
         offline_experiment_group: str = "caa_iteration_v3_perf_ig_4",
         bloks_versioning_id: str = "",
+        domain: Optional[str] = None,
     ) -> Dict:
         """
         Send the current CAA/Bloks login request used before Bloks 2FA.
 
-        This low-level helper is intentionally conservative: it uses ordinary
-        device/session identifiers already available on the client and leaves
-        attestation-like fields empty instead of inventing fake values.
+        This low-level helper requires the server-issued account access context
+        and uses the attestation state populated by
+        :meth:`bloks_caa_login_prepare`.
 
         Returns
         -------
@@ -478,19 +647,23 @@ class BloksMixin(ClientMixin):
             Raw Instagram response.
         """
         contact_point = username or self.username
-        encrypted_password = password if password.startswith("#PWD_") else await self.password_encrypt(password)
-        flow_id = waterfall_id or str(uuid4())
-        text_input_id = flow_id[:8]
+        if password.startswith("#PWD_"):
+            encrypted_password = password
+        else:
+            encrypted_password = await self.password_encrypt(password)
+        flow_id = waterfall_id or self.caa_waterfall_id or str(uuid4())
+        self.caa_waterfall_id = flow_id
+        if not self.caa_aac:
+            raise ClientError(
+                "CAA login requires a server-issued aac; call bloks_caa_login_prepare() before send_login_request"
+            )
+        # Recent CAA login screens emit short base36-like input ids. Hex-only
+        # UUID prefixes are accepted by the VM but can return a null-payload 404.
+        text_input_id = f"{uuid4().hex[:4]}ig"
         params = {
             "client_input_params": {
                 "blocked_uids": [],
-                "aac": dumps(
-                    {
-                        "aac_init_timestamp": int(time.time()),
-                        "aaccs": "",
-                        "aacjid": str(uuid4()),
-                    }
-                ),
+                "aac": self.caa_aac,
                 "sim_phones": [],
                 "aymh_accounts": [],
                 "network_bssid": None,
@@ -498,30 +671,7 @@ class BloksMixin(ClientMixin):
                 "has_granted_read_contacts_permissions": 0,
                 "auth_secure_device_id": "",
                 "has_whatsapp_installed": 0,
-                "si_device_param_network_info": {
-                    "active_subscriptions_info": None,
-                    "default_subscription_info": {
-                        "network_type": None,
-                        "is_data_roaming": 1,
-                        "is_esim": None,
-                        "is_gsm_roaming": 0,
-                        "is_sim_sms_capable": None,
-                        "is_mobile_data_enabled": 1,
-                        "sim_carrier_id": 1,
-                        "sim_carrier_id_name": None,
-                        "sim_state": 5,
-                        "sim_operator": "310260",
-                        "sim_operator_name": "T-Mobile",
-                        "signal_strength": None,
-                        "group_id_level_1": None,
-                        "network_operator": "310260",
-                    },
-                    "is_airplane_mode": 0,
-                    "is_active_network_cellular": 0,
-                    "is_device_sms_capable": 1,
-                    "sim_count": 1,
-                    "is_wifi": 1,
-                },
+                "si_device_param_network_info": self._caa_device_network_info(),
                 "password": encrypted_password,
                 "sso_token_map_json_string": "",  # nosec B105
                 "block_store_machine_id": "",
@@ -545,7 +695,7 @@ class BloksMixin(ClientMixin):
                     "ANSWER_PHONE_CALLS": "DENIED",
                 },
                 "accounts_list": [],
-                "gms_incoming_call_retriever_eligibility": "not_eligible",
+                "gms_incoming_call_retriever_eligibility": "eligible",
                 "family_device_id": self.phone_id,
                 "fb_ig_device_id": [],
                 "device_emails": [],
@@ -572,12 +722,12 @@ class BloksMixin(ClientMixin):
                 "offline_experiment_group": offline_experiment_group,
                 "is_from_landing_page": 0,
                 "left_nav_button_action": "NONE",
-                "password_text_input_id": f"{text_input_id}:105",
+                "password_text_input_id": f"{text_input_id}:82",
                 "is_from_empty_password": 0,  # nosec B105
                 "is_from_msplit_fallback": 0,
                 "ar_event_source": "login_home_page",
                 "qe_device_id": self.uuid,
-                "username_text_input_id": f"{text_input_id}:104",
+                "username_text_input_id": f"{text_input_id}:81",
                 "layered_homepage_experiment_group": "Deploy: Not in Experiment",
                 "device_id": self.android_device_id,
                 "login_surface": "login_home",
@@ -593,12 +743,282 @@ class BloksMixin(ClientMixin):
                 "is_from_logged_in_switcher": 0,
             },
         }
+        attest_params = self.attestation_params()
         return await self.bloks_async_action(
             "com.bloks.www.bloks.caa.login.async.send_login_request",
             params,
             bloks_versioning_id=bloks_versioning_id,
+            domain=domain,
+            extra_headers={"X-IG-Attest-Params": attest_params} if attest_params else None,
             login=True,
         )
+
+    async def bloks_caa_login(
+        self,
+        username: str = "",
+        password: Optional[str] = None,
+        prepare: bool = True,
+        domain: str = CAA_API_DOMAIN,
+        verification_code: str = "",
+    ) -> Dict[str, Any]:
+        """Run current Android CAA login, including its profile-code challenge."""
+        username = username or self.username
+        password = password or self.password
+        if prepare and not (await self.bloks_caa_login_prepare(username=username, domain=domain)):
+            return {
+                "logged_in": False,
+                "two_step_verification_context": "",
+                "result": {},
+                "two_step": {},
+                "reason": "CAA preflight did not return account access and attestation data",
+            }
+        result = await self.bloks_caa_login_send_request(password, username=username, domain=domain)
+        logged_in = self.bloks_apply_login_response(result)
+        two_step = {}
+        if not logged_in and self.bloks_caa_login_needs_two_step(result):
+            two_step = await self.bloks_caa_resolve_two_step_verification(
+                result,
+                verification_code=verification_code,
+                domain=domain,
+            )
+            logged_in = bool(two_step.get("logged_in"))
+        context = "" if logged_in else self.bloks_extract_two_step_verification_context(result)
+        return {
+            "logged_in": logged_in,
+            "two_step_verification_context": context,
+            "result": result,
+            "two_step": two_step,
+            "reason": "" if logged_in else str(two_step.get("reason") or "CAA login did not return a session"),
+        }
+
+    def _bloks_collect_strings(self, value: Any, output: List[str]) -> None:
+        if isinstance(value, str):
+            output.append(value)
+        elif isinstance(value, dict):
+            for child in value.values():
+                self._bloks_collect_strings(child, output)
+        elif isinstance(value, list):
+            for child in value:
+                self._bloks_collect_strings(child, output)
+
+    def _bloks_all_text(self, result: Dict) -> str:
+        strings: List[str] = []
+        self._bloks_collect_strings(result, strings)
+        return "\n".join(strings)
+
+    def bloks_caa_login_needs_two_step(self, result: Dict) -> bool:
+        """Return whether CAA routed login to the profile-code challenge."""
+        return AP_2SV_ENTRYPOINT in self._bloks_all_text(result)
+
+    @staticmethod
+    def _bloks_parenthesized_expression(value: str, start: int) -> str:
+        """Return one balanced Bloks expression while respecting quoted strings."""
+        depth = 0
+        in_string = False
+        escaped = False
+        for index in range(start, len(value)):
+            character = value[index]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == '"':
+                    in_string = False
+                continue
+            if character == '"':
+                in_string = True
+            elif character == "(":
+                depth += 1
+            elif character == ")":
+                depth -= 1
+                if depth == 0:
+                    return value[start : index + 1]
+        return ""
+
+    @staticmethod
+    def _bloks_string_literals(value: str) -> List[str]:
+        """Decode JSON-style string literals from a Bloks expression."""
+        strings: List[str] = []
+        decoder = json.JSONDecoder()
+        index = 0
+        while True:
+            index = value.find('"', index)
+            if index < 0:
+                return strings
+            try:
+                decoded, consumed = decoder.raw_decode(value[index:])
+            except JSONDecodeError:
+                index += 1
+                continue
+            if isinstance(decoded, str):
+                strings.append(decoded)
+            index += consumed
+
+    def bloks_extract_context_data(self, result: Dict, app_id: str) -> str:
+        """Extract the context token chained to an exact Bloks app id."""
+        strings: List[str] = []
+        self._bloks_collect_strings(result, strings)
+        anchor = re.compile(re.escape(app_id) + r"(?![_a-zA-Z])")
+        app_reference = re.compile(r"(?<![_a-zA-Z0-9])com\.bloks\.[_a-zA-Z0-9.]+")
+        for text in strings:
+            for found in anchor.finditer(text):
+                map_start = text.find("(f4i", found.end())
+                if map_start < 0:
+                    continue
+                next_app = app_reference.search(text, found.end())
+                if next_app and next_app.start() < map_start:
+                    continue
+                expression = self._bloks_parenthesized_expression(text, map_start)
+                if not expression:
+                    continue
+                groups: List[List[str]] = []
+                cursor = 0
+                while True:
+                    group_start = expression.find("(dkc", cursor)
+                    if group_start < 0:
+                        break
+                    group = self._bloks_parenthesized_expression(expression, group_start)
+                    if not group:
+                        break
+                    groups.append(self._bloks_string_literals(group))
+                    cursor = group_start + len(group)
+                for keys, values in zip(groups, groups[1:]):
+                    if "context_data" not in keys:
+                        continue
+                    context_index = keys.index("context_data")
+                    if context_index < len(values):
+                        return values[context_index]
+        return ""
+
+    async def bloks_ap_two_step_verification_entrypoint(
+        self,
+        context_data: str,
+        bloks_versioning_id: str = "",
+        domain: Optional[str] = None,
+    ) -> Dict:
+        """Open the CAA profile-code challenge entrypoint."""
+        params = {
+            "client_input_params": {
+                "auth_secure_device_id": "",
+                "accounts_list": [],
+                "has_whatsapp_installed": 0,
+                "family_device_id": self.phone_id,
+                "machine_id": self.mid,
+            },
+            "server_params": {
+                "use_open_instead_of_push": 0,
+                "context_data": context_data,
+                "INTERNAL__latency_qpl_marker_id": 36707139,
+                "INTERNAL__latency_qpl_instance_id": int(time.time() * 1000),
+                "device_id": self.uuid,
+                "use_close_instead_of_back": 0,
+            },
+        }
+        return await self.bloks_async_action(
+            AP_2SV_ENTRYPOINT,
+            params,
+            bloks_versioning_id=bloks_versioning_id,
+            domain=domain,
+            login=True,
+        )
+
+    async def bloks_ap_two_step_verification_code_entry(
+        self,
+        context_data: str,
+        bloks_versioning_id: str = "",
+        domain: Optional[str] = None,
+    ) -> Dict:
+        """Open the profile-code input screen and obtain its submit context."""
+        params = {
+            "client_input_params": {"aac": self.caa_aac},
+            "server_params": {
+                "context_data": context_data,
+                "show_close_button": 0,
+                "device_id": self.uuid,
+                "INTERNAL_INFRA_screen_id": "generic_code_entry",
+                "is_dismissable": 1,
+            },
+        }
+        return await self.bloks_app(
+            AP_2SV_CODE_ENTRY,
+            params,
+            bloks_versioning_id=bloks_versioning_id,
+            domain=domain,
+            login=True,
+        )
+
+    async def bloks_ap_two_step_verification_submit_code(
+        self,
+        context_data: str,
+        code: str,
+        bloks_versioning_id: str = "",
+        domain: Optional[str] = None,
+    ) -> Dict:
+        """Submit the one-time code and return the terminal login response."""
+        params = {
+            "client_input_params": {
+                "auth_secure_device_id": "",
+                "aac": self.caa_aac,
+                "code": str(code),
+                "family_device_id": self.phone_id,
+                "device_id": self.android_device_id,
+                "machine_id": self.mid,
+            },
+            "server_params": {
+                "context_data": context_data,
+                "INTERNAL__latency_qpl_marker_id": 36707139,
+                "INTERNAL__latency_qpl_instance_id": int(time.time() * 1000),
+                "device_id": self.uuid,
+            },
+        }
+        return await self.bloks_async_action(
+            AP_2SV_CODE_ENTRY_ASYNC,
+            params,
+            bloks_versioning_id=bloks_versioning_id,
+            domain=domain,
+            login=True,
+        )
+
+    async def bloks_caa_resolve_two_step_verification(
+        self,
+        send_result: Dict,
+        verification_code: str = "",
+        domain: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Drive the CAA profile-code challenge through its terminal step."""
+        entry_context = self.bloks_extract_context_data(send_result, AP_2SV_ENTRYPOINT)
+        if not entry_context:
+            return {"logged_in": False, "reason": "missing entrypoint context_data"}
+        entry_result = await self.bloks_ap_two_step_verification_entrypoint(entry_context, domain=domain)
+
+        code_context = self.bloks_extract_context_data(entry_result, AP_2SV_CODE_ENTRY)
+        if not code_context:
+            return {"logged_in": False, "reason": "missing code_entry context_data"}
+        code_result = await self.bloks_ap_two_step_verification_code_entry(code_context, domain=domain)
+
+        submit_context = self.bloks_extract_context_data(code_result, AP_2SV_CODE_ENTRY_ASYNC)
+        if not submit_context:
+            return {"logged_in": False, "reason": "missing code_entry_async context_data"}
+        code = verification_code or (await self.challenge_code_or_raised(ChallengeChoice.EMAIL))
+        try:
+            submit_result = await self.bloks_ap_two_step_verification_submit_code(
+                submit_context,
+                code,
+                domain=domain,
+            )
+        except ChallengeError:
+            raise
+        except ClientError as exc:
+            raise ChallengeError(
+                f"CAA profile-code submission failed: {exc}",
+                response=getattr(exc, "response", None),
+            ) from exc
+        return {
+            "logged_in": self.bloks_apply_login_response(submit_result),
+            "reason": "",
+            "result": submit_result,
+        }
 
     def _find_bloks_value(self, data: Any, key: str) -> Any:
         if isinstance(data, dict):

--- a/aiograpi/mixins/private.py
+++ b/aiograpi/mixins/private.py
@@ -287,6 +287,8 @@ class PrivateRequestMixin(ClientMixin):
             headers.update({"IG-U-RUR": '"%s"' % self.ig_u_rur})
         if self.ig_www_claim:
             headers.update({"X-IG-WWW-Claim": self.ig_www_claim})
+        if self.usdid_private_key:
+            headers.update({"X-Meta-Usdid": self.usdid_header()})
         return headers
 
     def private_headers(self, headers=None):

--- a/docs/usage-guide/totp.md
+++ b/docs/usage-guide/totp.md
@@ -40,7 +40,7 @@ Notes:
 
 Some accounts are moved by Instagram to a newer CAA/Bloks two-factor flow. In that case the legacy `accounts/two_factor_login/` endpoint can reject a valid code with `Invalid Parameters`.
 
-`Client.login(..., verification_code="123456")` still uses the legacy mobile endpoint first. If Instagram returns a `two_step_verification_context`, aiograpi automatically retries through the Bloks two-factor flow. If the legacy login response does not expose that context, aiograpi can make a current CAA/Bloks login request to recover the context and continue the same Bloks verification path. When Instagram still does not return enough state, the exception explains that the account needs manual app verification or a fresh current-app login response.
+`await Client.login(..., verification_code="123456")` still uses the legacy mobile endpoint first. If Instagram returns a `two_step_verification_context`, aiograpi automatically retries through the Bloks two-factor flow. If the legacy endpoint instead returns `BadPassword` without that context, aiograpi retries the current Android CAA login sequence, including its device registration and server-issued preflight state. A successful embedded session is applied automatically. When Instagram opens the CAA profile-code screen, aiograpi uses the supplied `verification_code` or `challenge_code_handler` and applies the terminal session response.
 
 8-digit backup codes can be passed through the same `verification_code` parameter:
 
@@ -85,8 +85,8 @@ await cl.bloks_two_step_verification_enter_backup_code(context)
 result = await cl.bloks_two_step_verification_verify_code(context, "12345678", challenge="backup_codes")
 ```
 
-`bloks_caa_login_send_request(...)` is also available as a low-level helper for inspecting the CAA/Bloks login response manually. `bloks_extract_two_step_verification_context(...)` extracts the context from that response when Instagram returns the current Bloks redirect action.
+`await bloks_caa_login(...)` runs the complete current CAA sequence. For low-level inspection, call `await bloks_caa_login_prepare(...)` before `await bloks_caa_login_send_request(...)`; the send helper requires the account access context returned by Instagram during that preflight. `bloks_extract_two_step_verification_context(...)` extracts a legacy Bloks two-factor context when the login response exposes one.
 
 `bloks_extract_login_response(...)` returns decoded `login_response`, response `headers`, cookie values, raw cookie header text, and the raw embedded object when Instagram returns a successful Bloks login payload. It returns `{}` when the response is an intermediate UI state or an error. `bloks_apply_login_response(...)` can then copy the returned authorization data and cookies into the current client session.
 
-Automatic fallback can only run after Instagram exposes `two_step_verification_context` to the client or to the CAA/Bloks login response. A `BadPassword` response with a known-good password can still be account-risk handling before Instagram exposes that context, so treat it as a signal to inspect proxy/IP, device consistency, and the raw login response.
+The separate account-recovery UI used by some accounts is not automated. If current CAA login does not return a session or a supported profile-code challenge, `login()` preserves the original `BadPassword`. That response can still mean a wrong password or Instagram account-risk handling, so inspect proxy/IP and device consistency before retrying repeatedly.

--- a/tests/regression/test_attestation.py
+++ b/tests/regression/test_attestation.py
@@ -1,0 +1,798 @@
+import base64
+import json
+import unittest
+from unittest import mock
+from unittest.mock import AsyncMock, Mock
+
+from Cryptodome.Hash import SHA256
+from Cryptodome.PublicKey import ECC
+from Cryptodome.Signature import DSS
+
+from aiograpi import Client
+from aiograpi.exceptions import ChallengeError, ChallengeRequired, ClientError, UnknownError
+from aiograpi.mixins.attestation import USDID_REFRESH_MARGIN, USDID_REGISTRATION_CLIENT_DOC_ID
+from aiograpi.mixins.bloks import AP_2SV_ENTRYPOINT
+
+
+def _b64u_decode(value):
+    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+
+
+class DeviceAttestationRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    def build_client(self):
+        client = Client()
+        client.uuid = "00000000-0000-4000-8000-000000000000"
+        client.phone_id = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+        client.bloks_versioning_id = "bloks-version"
+        return client
+
+    async def test_usdid_header_is_three_segments_signed_over_uuid_and_expiry(self):
+        client = self.build_client()
+        client.usdid_generate()
+
+        value = client.usdid_header()
+
+        parts = value.split(".")
+        self.assertEqual(len(parts), 3)
+        usdid, expires_at, signature = parts
+        self.assertEqual(usdid, client.usdid)
+        self.assertTrue(expires_at.isdigit())
+        verifier = DSS.new(ECC.import_key(client.usdid_public_key_der), "fips-186-3", encoding="der")
+        verifier.verify(SHA256.new(f"{usdid}.{expires_at}".encode()), _b64u_decode(signature))
+
+    async def test_usdid_header_absent_until_key_is_generated_and_then_cached(self):
+        client = self.build_client()
+        self.assertNotIn("X-Meta-Usdid", client.base_headers)
+
+        client.usdid_generate()
+
+        self.assertEqual(client.base_headers["X-Meta-Usdid"], client.usdid_header())
+        self.assertEqual(client.usdid_header(), client.usdid_header())
+
+    async def test_usdid_identity_reuse_force_rotation_and_header_refresh(self):
+        client = self.build_client()
+        client.usdid_generate()
+        original_identity = (client.usdid, client.usdid_kid, client.usdid_private_key)
+
+        self.assertEqual(client.usdid_generate(), original_identity[0])
+        self.assertEqual((client.usdid, client.usdid_kid, client.usdid_private_key), original_identity)
+
+        with mock.patch("aiograpi.mixins.attestation.time.time", return_value=1000):
+            original_header = client.usdid_header()
+            client._usdid_header_expires_at = 1000 + USDID_REFRESH_MARGIN
+            refreshed_header = client.usdid_header()
+
+        self.assertNotEqual(refreshed_header, original_header)
+        client.usdid_generate(force=True)
+        self.assertNotEqual((client.usdid, client.usdid_kid, client.usdid_private_key), original_identity)
+        self.assertFalse(client.usdid_registered)
+
+    async def test_usdid_registration_token_is_valid_es256_jws(self):
+        client = self.build_client()
+        client.usdid_generate()
+
+        token = json.loads(_b64u_decode(client.usdid_registration_token()))
+        payload = json.loads(_b64u_decode(token["payload"]))
+        protected = json.loads(_b64u_decode(token["signatures"][0]["protected"]))
+
+        self.assertEqual(payload["sub"], client.usdid)
+        self.assertEqual(payload["aud"], client.app_id)
+        self.assertEqual(payload["exp"] - payload["iat"], 3600)
+        self.assertEqual(protected["alg"], "ES256")
+        self.assertEqual(protected["kid"], client.usdid_kid)
+        public_key = ECC.import_key(base64.b64decode(payload["pub"]))
+        verifier = DSS.new(public_key, "fips-186-3", encoding="der")
+        signing_input = f"{token['signatures'][0]['protected']}.{token['payload']}"
+        verifier.verify(SHA256.new(signing_input.encode()), _b64u_decode(token["signatures"][0]["signature"]))
+
+    async def test_usdid_register_uses_app_428_document_and_family_device_id(self):
+        client = self.build_client()
+        response = {"data": {"1$usdid_registration(data:$input)": {"success": True}}}
+
+        with mock.patch.object(client, "private_graphql_www_request", return_value=response) as graphql_request:
+            result = await client.usdid_register()
+
+        self.assertTrue(result)
+        self.assertEqual(USDID_REGISTRATION_CLIENT_DOC_ID, "124930351917786857261002920888")
+        graphql_request.assert_called_once()
+        friendly_name, variables = graphql_request.call_args.args[:2]
+        self.assertEqual(friendly_name, "IGUSDIDRegistrationMutation")
+        self.assertEqual(
+            variables["input"]["fdid"]["sensitive_string_value"],
+            client.phone_id,
+        )
+        self.assertTrue(variables["input"]["usdid_token"]["sensitive_string_value"])
+        self.assertEqual(graphql_request.call_args.kwargs["client_doc_id"], USDID_REGISTRATION_CLIENT_DOC_ID)
+        self.assertNotIn("domain", graphql_request.call_args.kwargs)
+
+    async def test_usdid_register_returns_false_for_rejection_or_missing_payload(self):
+        client = self.build_client()
+        responses = [
+            {"data": {"1$usdid_registration(data:$input)": {"success": False}}},
+            {"data": None},
+        ]
+
+        with mock.patch.object(client, "private_graphql_www_request", side_effect=responses):
+            self.assertFalse(await client.usdid_register())
+            self.assertFalse(await client.usdid_register())
+
+        self.assertFalse(client.usdid_registered)
+
+    async def test_attestation_create_stores_nonce_and_uses_app_scoped_device_id(self):
+        client = self.build_client()
+        response = {"challenge_nonce": "challenge", "key_nonce": "key", "status": "ok"}
+
+        with mock.patch.object(client, "private_request", return_value=response) as private_request:
+            result = await client.attestation_create_android_keystore(domain="b.i.instagram.com")
+
+        self.assertEqual(result, response)
+        self.assertEqual(client.attestation_challenge_nonce, "challenge")
+        self.assertEqual(client.attestation_key_nonce, "key")
+        private_request.assert_called_once_with(
+            "attestation/create_android_keystore/",
+            data={"app_scoped_device_id": client.uuid, "key_hash": ""},
+            with_signature=False,
+            headers={"X-FB-Friendly-Name": "IgApi: attestation/create_android_keystore/"},
+            login=True,
+            domain="b.i.instagram.com",
+        )
+
+    async def test_attestation_create_uses_default_domain_and_clears_missing_nonces(self):
+        client = self.build_client()
+        client.attestation_challenge_nonce = "stale"
+        client.attestation_key_nonce = "stale"
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            await client.attestation_create_android_keystore()
+
+        self.assertEqual(client.attestation_challenge_nonce, "")
+        self.assertEqual(client.attestation_key_nonce, "")
+        self.assertNotIn("domain", private_request.call_args.kwargs)
+
+    async def test_attestation_params_match_accepted_keystore_error_state(self):
+        client = self.build_client()
+
+        params = json.loads(client.attestation_params("challenge"))
+
+        self.assertEqual(
+            params,
+            {
+                "attestation": [
+                    {
+                        "version": 2,
+                        "type": "keystore",
+                        "errors": [-1013],
+                        "challenge_nonce": "challenge",
+                        "signed_nonce": "",
+                        "key_hash": "",
+                    }
+                ]
+            },
+        )
+        self.assertEqual(client.attestation_params(""), "")
+
+    async def test_usdid_settings_roundtrip_does_not_leak_between_clients(self):
+        client = self.build_client()
+        other = self.build_client()
+        client.usdid_generate()
+        client.usdid_registered = True
+
+        self.assertFalse(other.usdid_private_key)
+        settings = client.get_settings()
+        self.assertIn("usdid", settings)
+
+        restored = Client(settings=settings)
+        self.assertEqual(restored.usdid, client.usdid)
+        self.assertEqual(restored.usdid_public_key_der, client.usdid_public_key_der)
+        self.assertTrue(restored.usdid_registered)
+
+    async def test_clearing_usdid_settings_removes_stale_session_header(self):
+        client = self.build_client()
+        client.usdid_generate()
+        client.private.headers.update(client.base_headers)
+        self.assertIn("X-Meta-Usdid", client.private.headers)
+
+        client.set_usdid_settings({})
+
+        self.assertNotIn("X-Meta-Usdid", client.private.headers)
+
+    async def test_resetting_device_rotates_family_id_and_clears_bound_usdid(self):
+        client = self.build_client()
+        client.usdid_generate()
+        client.usdid_registered = True
+        client.private.headers.update(client.base_headers)
+        old_phone_id = client.phone_id
+
+        client.set_device(reset=True)
+
+        self.assertNotEqual(client.phone_id, old_phone_id)
+        self.assertEqual(client.get_usdid_settings(), {})
+        self.assertFalse(client.usdid_registered)
+        self.assertNotIn("X-Meta-Usdid", client.private.headers)
+        self.assertNotIn("usdid", client.get_settings())
+
+
+class CaaLoginRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    def build_client(self):
+        client = Client()
+        client.uuid = "00000000-0000-4000-8000-000000000000"
+        client.phone_id = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+        client.android_device_id = "android-123"
+        client.mid = "mid-123"
+        client.bloks_versioning_id = "bloks-version"
+        client.username = "example_user"
+        client.password = "dummy_password"
+        return client
+
+    @staticmethod
+    def aac_response(aac):
+        return {
+            "layout": {
+                "bloks_payload": {
+                    "data": [
+                        {
+                            "data": {
+                                "key": "CAA_ACCOUNT_ACCESS_CONTEXT:aac",
+                                "initial_lispy": f"(fhy {json.dumps(aac)})",
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+    async def test_process_client_data_extracts_server_issued_aac(self):
+        client = self.build_client()
+        aac = '{"aac_init_timestamp":1,"aacjid":"j","aaccs":"server"}'
+
+        with mock.patch.object(client, "bloks_async_action", return_value=self.aac_response(aac)) as action:
+            result = await client.bloks_caa_login_process_client_data(domain="b.i.instagram.com")
+
+        self.assertEqual(result, self.aac_response(aac))
+        self.assertEqual(client.caa_aac, aac)
+        called_action, params = action.call_args.args[:2]
+        self.assertEqual(called_action, "com.bloks.www.bloks.caa.login.process_client_data_and_redirect")
+        self.assertEqual(params["family_device_id"], client.phone_id)
+        self.assertEqual(params["device_id"], client.android_device_id)
+        self.assertEqual(params["qe_device_id"], client.uuid)
+        self.assertEqual(action.call_args.kwargs["domain"], "b.i.instagram.com")
+        self.assertTrue(action.call_args.kwargs["login"])
+
+    async def test_extract_aac_supports_initial_and_rejects_malformed_payloads(self):
+        client = self.build_client()
+        direct = {
+            "layout": {
+                "bloks_payload": {
+                    "data": [{"data": {"key": "CAA_ACCOUNT_ACCESS_CONTEXT:aac", "initial": "server-aac"}}]
+                }
+            }
+        }
+
+        self.assertEqual(client.bloks_extract_aac(direct), "server-aac")
+        self.assertEqual(client.bloks_extract_aac({"layout": {"bloks_payload": {"data": {}}}}), "")
+        self.assertEqual(
+            client.bloks_extract_aac(
+                {
+                    "layout": {
+                        "bloks_payload": {
+                            "data": [
+                                {
+                                    "data": {
+                                        "key": "CAA_ACCOUNT_ACCESS_CONTEXT:aac",
+                                        "initial_lispy": "not-json",
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ),
+            "",
+        )
+
+    async def test_bloks_transport_forwards_login_domain_and_extra_headers(self):
+        client = self.build_client()
+
+        with mock.patch.object(client, "private_request", side_effect=[{"kind": "action"}, {"kind": "app"}]) as request:
+            action_result = await client.bloks_async_action(
+                "com.example.action",
+                {"value": 1},
+                domain="b.i.instagram.com",
+                extra_headers={"X-Test": "yes"},
+                login=True,
+            )
+            app_result = await client.bloks_app(
+                "com.example.app",
+                {"value": 2},
+                domain="b.i.instagram.com",
+                login=True,
+            )
+
+        self.assertEqual(action_result, {"kind": "action"})
+        self.assertEqual(app_result, {"kind": "app"})
+        action_call, app_call = request.call_args_list
+        self.assertEqual(action_call.args[0], "bloks/async_action/com.example.action/")
+        self.assertEqual(action_call.kwargs["headers"]["X-Test"], "yes")
+        self.assertEqual(action_call.kwargs["domain"], "b.i.instagram.com")
+        self.assertTrue(action_call.kwargs["login"])
+        self.assertEqual(app_call.args[0], "bloks/apps/com.example.app/")
+        self.assertEqual(app_call.kwargs["domain"], "b.i.instagram.com")
+        self.assertTrue(app_call.kwargs["login"])
+
+    async def test_oauth_preflight_uses_username_aac_and_waterfall(self):
+        client = self.build_client()
+        client.caa_aac = "server-aac"
+
+        with mock.patch.object(client, "bloks_async_action", return_value={"status": "ok"}) as action:
+            await client.bloks_caa_login_oauth_token_fetch(
+                username="override_user",
+                waterfall_id="waterfall-1",
+                domain="b.i.instagram.com",
+            )
+
+        called_action, params = action.call_args.args[:2]
+        self.assertEqual(called_action, "com.bloks.www.caa.login.oauth.token.fetch.async")
+        self.assertEqual(params["client_input_params"]["username_input"], "override_user")
+        self.assertEqual(params["client_input_params"]["aac"], "server-aac")
+        self.assertEqual(params["server_params"]["waterfall_id"], "waterfall-1")
+        self.assertEqual(action.call_args.kwargs["domain"], "b.i.instagram.com")
+        self.assertTrue(action.call_args.kwargs["login"])
+
+    async def test_prepare_runs_current_preflight_sequence(self):
+        client = self.build_client()
+        order = []
+
+        def register():
+            order.append("register")
+            client.usdid_registered = True
+            return True
+
+        def process(**kwargs):
+            order.append("process")
+            client.caa_aac = '{"aaccs":"server"}'
+            return {}
+
+        def attest(**kwargs):
+            order.append("attestation")
+            client.attestation_challenge_nonce = "challenge"
+            return {"challenge_nonce": "challenge"}
+
+        def oauth(**kwargs):
+            order.append("oauth")
+            return {}
+
+        with (
+            mock.patch.object(client, "usdid_register", side_effect=register),
+            mock.patch.object(client, "bloks_caa_login_process_client_data", side_effect=process),
+            mock.patch.object(client, "attestation_create_android_keystore", side_effect=attest),
+            mock.patch.object(client, "bloks_caa_login_oauth_token_fetch", side_effect=oauth),
+        ):
+            result = await client.bloks_caa_login_prepare(domain="b.i.instagram.com")
+
+        self.assertTrue(result)
+        self.assertEqual(order, ["register", "process", "attestation", "oauth"])
+
+    async def test_prepare_stops_when_usdid_registration_is_rejected(self):
+        client = self.build_client()
+
+        with (
+            mock.patch.object(client, "usdid_register", return_value=False),
+            mock.patch.object(client, "bloks_caa_login_process_client_data") as process,
+            mock.patch.object(client, "attestation_create_android_keystore") as attest,
+            mock.patch.object(client, "bloks_caa_login_oauth_token_fetch") as oauth,
+        ):
+            result = await client.bloks_caa_login_prepare()
+
+        self.assertFalse(result)
+        process.assert_not_called()
+        attest.assert_not_called()
+        oauth.assert_not_called()
+
+    async def test_prepare_skips_registration_and_oauth_without_aac(self):
+        client = self.build_client()
+        client.usdid_registered = True
+
+        def process(**kwargs):
+            client.caa_aac = ""
+            return {}
+
+        def attest(**kwargs):
+            client.attestation_challenge_nonce = "challenge"
+            return {"challenge_nonce": "challenge"}
+
+        with (
+            mock.patch.object(client, "usdid_register") as register,
+            mock.patch.object(client, "bloks_caa_login_process_client_data", side_effect=process),
+            mock.patch.object(client, "attestation_create_android_keystore", side_effect=attest),
+            mock.patch.object(client, "bloks_caa_login_oauth_token_fetch") as oauth,
+        ):
+            result = await client.bloks_caa_login_prepare()
+
+        self.assertFalse(result)
+        register.assert_not_called()
+        oauth.assert_not_called()
+
+    async def test_prepare_returns_false_when_attestation_nonce_is_missing(self):
+        client = self.build_client()
+        client.usdid_registered = True
+
+        def process(**kwargs):
+            client.caa_aac = "server-aac"
+            return {}
+
+        with (
+            mock.patch.object(client, "bloks_caa_login_process_client_data", side_effect=process),
+            mock.patch.object(client, "attestation_create_android_keystore", return_value={}),
+            mock.patch.object(client, "bloks_caa_login_oauth_token_fetch", return_value={}) as oauth,
+        ):
+            result = await client.bloks_caa_login_prepare(username="override_user")
+
+        self.assertFalse(result)
+        oauth.assert_called_once_with(username="override_user", domain=None)
+
+    async def test_send_login_requires_server_issued_aac(self):
+        client = self.build_client()
+
+        with mock.patch.object(client, "bloks_async_action") as action, self.assertRaises(ClientError) as cm:
+            await client.bloks_caa_login_send_request("dummy_password")
+
+        self.assertIn("server-issued aac", str(cm.exception))
+        action.assert_not_called()
+
+    async def test_send_login_uses_server_aac_and_attestation_only_on_final_request(self):
+        client = self.build_client()
+        client.caa_aac = '{"aac_init_timestamp":1,"aacjid":"j","aaccs":"server"}'
+        client.attestation_challenge_nonce = "challenge"
+        client.password_encrypt = AsyncMock(return_value="#PWD_INSTAGRAM:4:1:encrypted")
+
+        with mock.patch.object(client, "bloks_async_action", return_value={"status": "ok"}) as action:
+            await client.bloks_caa_login_send_request("dummy_password", domain="b.i.instagram.com")
+
+        called_action, params = action.call_args.args[:2]
+        self.assertEqual(called_action, "com.bloks.www.bloks.caa.login.async.send_login_request")
+        self.assertEqual(params["client_input_params"]["aac"], client.caa_aac)
+        self.assertEqual(params["client_input_params"]["password"], "#PWD_INSTAGRAM:4:1:encrypted")
+        self.assertEqual(params["client_input_params"]["gms_incoming_call_retriever_eligibility"], "eligible")
+        self.assertEqual(params["server_params"]["waterfall_id"], client.caa_waterfall_id)
+        self.assertEqual(action.call_args.kwargs["domain"], "b.i.instagram.com")
+        self.assertTrue(action.call_args.kwargs["login"])
+        attest = json.loads(action.call_args.kwargs["extra_headers"]["X-IG-Attest-Params"])
+        self.assertEqual(attest["attestation"][0]["challenge_nonce"], "challenge")
+
+    async def test_send_login_accepts_encrypted_password_and_explicit_overrides_without_attestation(self):
+        client = self.build_client()
+        client.caa_aac = "server-aac"
+        client.password_encrypt = AsyncMock(
+            side_effect=AssertionError("encrypted passwords must not be encrypted twice")
+        )
+
+        with mock.patch.object(client, "bloks_async_action", return_value={"status": "ok"}) as action:
+            await client.bloks_caa_login_send_request(
+                "#PWD_INSTAGRAM:4:1:encrypted",
+                username="override_user",
+                waterfall_id="waterfall-1",
+            )
+
+        params = action.call_args.args[1]
+        self.assertEqual(params["client_input_params"]["password"], "#PWD_INSTAGRAM:4:1:encrypted")
+        self.assertEqual(params["client_input_params"]["contact_point"], "override_user")
+        self.assertEqual(params["server_params"]["waterfall_id"], "waterfall-1")
+        self.assertIsNone(action.call_args.kwargs["extra_headers"])
+        client.password_encrypt.assert_not_called()
+
+    async def test_full_caa_login_applies_direct_embedded_login_response(self):
+        client = self.build_client()
+        authorization = "Bearer IGT:2:token"
+        embedded = json.dumps(
+            {
+                "login_response": json.dumps({"status": "ok", "logged_in_user": {"pk": 123}}),
+                "headers": json.dumps({"IG-Set-Authorization": authorization}),
+            }
+        )
+        send_result = {"layout": {"bloks_payload": {"action": f"(x {json.dumps(embedded)})"}}}
+
+        with (
+            mock.patch.object(client, "bloks_caa_login_prepare", return_value=True),
+            mock.patch.object(client, "bloks_caa_login_send_request", return_value=send_result),
+            mock.patch.object(client, "parse_authorization", return_value={"ds_user_id": "123"}) as parse_auth,
+        ):
+            outcome = await client.bloks_caa_login()
+
+        self.assertTrue(outcome["logged_in"])
+        self.assertEqual(outcome["result"], send_result)
+        parse_auth.assert_called_once_with(authorization)
+
+    async def test_full_caa_login_returns_reason_when_preflight_is_incomplete(self):
+        client = self.build_client()
+
+        with (
+            mock.patch.object(client, "bloks_caa_login_prepare", return_value=False),
+            mock.patch.object(client, "bloks_caa_login_send_request") as send,
+        ):
+            outcome = await client.bloks_caa_login()
+
+        self.assertFalse(outcome["logged_in"])
+        self.assertIn("preflight", outcome["reason"])
+        send.assert_not_called()
+
+    async def test_full_caa_login_can_skip_preflight_for_prepared_client(self):
+        client = self.build_client()
+
+        with (
+            mock.patch.object(client, "bloks_caa_login_prepare") as prepare,
+            mock.patch.object(client, "bloks_caa_login_send_request", return_value={}) as send,
+            mock.patch.object(client, "bloks_apply_login_response", return_value=False),
+        ):
+            outcome = await client.bloks_caa_login(prepare=False)
+
+        self.assertFalse(outcome["logged_in"])
+        prepare.assert_not_called()
+        send.assert_called_once_with(
+            client.password,
+            username=client.username,
+            domain="b.i.instagram.com",
+        )
+
+    async def test_full_caa_login_dispatches_profile_code_challenge(self):
+        client = self.build_client()
+        send_result = {"layout": {"bloks_payload": {"action": AP_2SV_ENTRYPOINT}}}
+
+        with (
+            mock.patch.object(client, "bloks_caa_login_prepare", return_value=True),
+            mock.patch.object(client, "bloks_caa_login_send_request", return_value=send_result),
+            mock.patch.object(client, "bloks_apply_login_response", return_value=False),
+            mock.patch.object(
+                client,
+                "bloks_caa_resolve_two_step_verification",
+                return_value={"logged_in": True, "reason": "", "result": {}},
+            ) as resolve,
+        ):
+            outcome = await client.bloks_caa_login(verification_code="654321")
+
+        self.assertTrue(outcome["logged_in"])
+        resolve.assert_called_once_with(
+            send_result,
+            verification_code="654321",
+            domain="b.i.instagram.com",
+        )
+
+    async def test_full_caa_login_returns_legacy_context_when_no_session_is_applied(self):
+        client = self.build_client()
+
+        with (
+            mock.patch.object(client, "bloks_caa_login_prepare", return_value=True),
+            mock.patch.object(client, "bloks_caa_login_send_request", return_value={}),
+            mock.patch.object(client, "bloks_apply_login_response", return_value=False),
+            mock.patch.object(client, "bloks_extract_two_step_verification_context", return_value="legacy-context"),
+        ):
+            outcome = await client.bloks_caa_login()
+
+        self.assertFalse(outcome["logged_in"])
+        self.assertEqual(outcome["two_step_verification_context"], "legacy-context")
+        self.assertIn("did not return a session", outcome["reason"])
+
+
+class CaaVerifyProfileRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    ENTRYPOINT = "com.bloks.www.ap.two_step_verification.entrypoint_async"
+    CODE_ENTRY = "com.bloks.www.ap.two_step_verification.code_entry"
+    CODE_ENTRY_ASYNC = "com.bloks.www.ap.two_step_verification.code_entry_async"
+
+    def build_client(self):
+        client = Client()
+        client.uuid = "00000000-0000-4000-8000-000000000000"
+        client.phone_id = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+        client.android_device_id = "android-123"
+        client.mid = "mid-123"
+        client.bloks_versioning_id = "bloks-version"
+        client.username = "example_user"
+        client.caa_aac = '{"aaccs":"server"}'
+        return client
+
+    @staticmethod
+    def action(app_id, context_data, container="action"):
+        payload = {container: (f'"{app_id}" (f4i (dkc "context_data" "device_id") (dkc "{context_data}" "device"))')}
+        return {"layout": {"bloks_payload": payload}}
+
+    async def test_context_extraction_matches_exact_app_and_reads_template_map(self):
+        client = self.build_client()
+        result = {
+            "layout": {
+                "bloks_payload": {
+                    "action": (
+                        f'"{self.CODE_ENTRY}_help" (f4i (dkc "context_data") (dkc "wrong")) '
+                        f'"{self.CODE_ENTRY}" (f4i (dkc "context_data") (dkc "entry-context"))'
+                    ),
+                    "ft": {
+                        "template": (f'"{self.CODE_ENTRY_ASYNC}" (f4i (dkc "context_data") (dkc "submit-context"))')
+                    },
+                }
+            }
+        }
+
+        self.assertEqual(client.bloks_extract_context_data(result, self.CODE_ENTRY), "entry-context")
+        self.assertEqual(client.bloks_extract_context_data(result, self.CODE_ENTRY_ASYNC), "submit-context")
+
+    async def test_context_extraction_pairs_context_key_with_value_at_same_index(self):
+        client = self.build_client()
+        result = {
+            "layout": {
+                "bloks_payload": {
+                    "action": (
+                        f'"{self.CODE_ENTRY}" (f4i (dkc "device_id" "context_data") (dkc "device" "expected-context"))'
+                    )
+                }
+            }
+        }
+
+        self.assertEqual(client.bloks_extract_context_data(result, self.CODE_ENTRY), "expected-context")
+
+    async def test_context_extraction_stays_in_target_string_and_decodes_escapes(self):
+        client = self.build_client()
+        expected = 'context-with-"quotes"'
+        result = {
+            "layout": {
+                "bloks_payload": {
+                    "unrelated": f'"{self.CODE_ENTRY}" without-a-map',
+                    "target": (
+                        f'"{self.CODE_ENTRY}" '
+                        f'(f4i (dkc "device_id" "context_data") (dkc "device" {json.dumps(expected)}))'
+                    ),
+                }
+            }
+        }
+
+        self.assertEqual(client.bloks_extract_context_data(result, self.CODE_ENTRY), expected)
+
+    async def test_context_extraction_does_not_use_a_later_apps_map(self):
+        client = self.build_client()
+        result = {
+            "layout": {
+                "bloks_payload": {
+                    "action": (
+                        f'"{self.CODE_ENTRY}" (noop) '
+                        '"com.bloks.www.unrelated.action" '
+                        '(f4i (dkc "context_data") (dkc "wrong-context"))'
+                    )
+                }
+            }
+        }
+
+        self.assertEqual(client.bloks_extract_context_data(result, self.CODE_ENTRY), "")
+
+    async def test_context_extraction_returns_empty_for_missing_anchor_or_context(self):
+        client = self.build_client()
+
+        self.assertEqual(client.bloks_extract_context_data({}, self.CODE_ENTRY), "")
+        self.assertEqual(
+            client.bloks_extract_context_data(
+                {"layout": {"bloks_payload": {"action": f'"{self.CODE_ENTRY}" (dkc "other" "value")'}}},
+                self.CODE_ENTRY,
+            ),
+            "",
+        )
+
+    async def test_verify_profile_chains_contexts_and_applies_terminal_login(self):
+        client = self.build_client()
+        send_result = self.action(self.ENTRYPOINT, "entry-context")
+        entry_result = self.action(self.CODE_ENTRY, "code-context")
+        code_result = self.action(self.CODE_ENTRY_ASYNC, "submit-context", container="ft")
+        submit_result = {"layout": {"bloks_payload": {"action": "embedded-login"}}}
+        calls = []
+
+        with (
+            mock.patch.object(
+                client,
+                "bloks_ap_two_step_verification_entrypoint",
+                side_effect=lambda context, **kwargs: calls.append(("entry", context)) or entry_result,
+            ),
+            mock.patch.object(
+                client,
+                "bloks_ap_two_step_verification_code_entry",
+                side_effect=lambda context, **kwargs: calls.append(("code", context)) or code_result,
+            ),
+            mock.patch.object(
+                client,
+                "bloks_ap_two_step_verification_submit_code",
+                side_effect=lambda context, code, **kwargs: calls.append(("submit", context, code)) or submit_result,
+            ),
+            mock.patch.object(client, "bloks_apply_login_response", return_value=True),
+        ):
+            outcome = await client.bloks_caa_resolve_two_step_verification(send_result, verification_code="654321")
+
+        self.assertTrue(outcome["logged_in"])
+        self.assertEqual(
+            calls,
+            [("entry", "entry-context"), ("code", "code-context"), ("submit", "submit-context", "654321")],
+        )
+
+    async def test_verify_profile_uses_existing_challenge_code_handler(self):
+        client = self.build_client()
+        send_result = self.action(self.ENTRYPOINT, "entry-context")
+        entry_result = self.action(self.CODE_ENTRY, "code-context")
+        code_result = self.action(self.CODE_ENTRY_ASYNC, "submit-context", container="ft")
+        client.challenge_code_handler = AsyncMock(return_value="123456")
+
+        with (
+            mock.patch.object(client, "bloks_ap_two_step_verification_entrypoint", return_value=entry_result),
+            mock.patch.object(client, "bloks_ap_two_step_verification_code_entry", return_value=code_result),
+            mock.patch.object(client, "bloks_ap_two_step_verification_submit_code", return_value={}) as submit,
+            mock.patch.object(client, "bloks_apply_login_response", return_value=False),
+        ):
+            await client.bloks_caa_resolve_two_step_verification(send_result)
+
+        client.challenge_code_handler.assert_called_once()
+        self.assertEqual(submit.call_args.args[:2], ("submit-context", "123456"))
+
+    async def test_verify_profile_reports_each_missing_context(self):
+        client = self.build_client()
+        send_result = self.action(self.ENTRYPOINT, "entry-context")
+        entry_result = self.action(self.CODE_ENTRY, "code-context")
+
+        self.assertEqual(
+            (await client.bloks_caa_resolve_two_step_verification({}))["reason"],
+            "missing entrypoint context_data",
+        )
+        with mock.patch.object(client, "bloks_ap_two_step_verification_entrypoint", return_value={}):
+            self.assertEqual(
+                (await client.bloks_caa_resolve_two_step_verification(send_result))["reason"],
+                "missing code_entry context_data",
+            )
+        with (
+            mock.patch.object(client, "bloks_ap_two_step_verification_entrypoint", return_value=entry_result),
+            mock.patch.object(client, "bloks_ap_two_step_verification_code_entry", return_value={}),
+        ):
+            self.assertEqual(
+                (await client.bloks_caa_resolve_two_step_verification(send_result))["reason"],
+                "missing code_entry_async context_data",
+            )
+
+    async def test_verify_profile_raises_when_code_handler_returns_no_code(self):
+        client = self.build_client()
+        send_result = self.action(self.ENTRYPOINT, "entry-context")
+        entry_result = self.action(self.CODE_ENTRY, "code-context")
+        code_result = self.action(self.CODE_ENTRY_ASYNC, "submit-context", container="ft")
+        client.challenge_code_handler = AsyncMock(return_value=None)
+
+        with (
+            mock.patch.object(client, "bloks_ap_two_step_verification_entrypoint", return_value=entry_result),
+            mock.patch.object(client, "bloks_ap_two_step_verification_code_entry", return_value=code_result),
+            self.assertRaises(ChallengeRequired),
+        ):
+            await client.bloks_caa_resolve_two_step_verification(send_result)
+
+    async def test_verify_profile_surfaces_submit_code_rejection_as_challenge_error(self):
+        client = self.build_client()
+        send_result = self.action(self.ENTRYPOINT, "entry-context")
+        entry_result = self.action(self.CODE_ENTRY, "code-context")
+        code_result = self.action(self.CODE_ENTRY_ASYNC, "submit-context", container="ft")
+        rejection = UnknownError("The security code is invalid")
+
+        with (
+            mock.patch.object(client, "bloks_ap_two_step_verification_entrypoint", return_value=entry_result),
+            mock.patch.object(client, "bloks_ap_two_step_verification_code_entry", return_value=code_result),
+            mock.patch.object(client, "bloks_ap_two_step_verification_submit_code", side_effect=rejection),
+            self.assertRaises(ChallengeError) as raised,
+        ):
+            await client.bloks_caa_resolve_two_step_verification(send_result, verification_code="654321")
+
+        self.assertIn("profile-code submission failed", str(raised.exception))
+        self.assertIs(raised.exception.__cause__, rejection)
+
+    async def test_verify_profile_requests_are_prelogin_and_use_caa_domain(self):
+        client = self.build_client()
+
+        with mock.patch.object(client, "bloks_async_action", return_value={}) as action:
+            await client.bloks_ap_two_step_verification_entrypoint("entry-context", domain="b.i.instagram.com")
+            await client.bloks_ap_two_step_verification_submit_code(
+                "submit-context", "123456", domain="b.i.instagram.com"
+            )
+
+        for call in action.call_args_list:
+            self.assertTrue(call.kwargs["login"])
+            self.assertEqual(call.kwargs["domain"], "b.i.instagram.com")
+
+        with mock.patch.object(client, "bloks_app", return_value={}) as app:
+            await client.bloks_ap_two_step_verification_code_entry("code-context", domain="b.i.instagram.com")
+
+        self.assertTrue(app.call_args.kwargs["login"])
+        self.assertEqual(app.call_args.kwargs["domain"], "b.i.instagram.com")

--- a/tests/regression/test_auth.py
+++ b/tests/regression/test_auth.py
@@ -5,12 +5,14 @@ from pydantic import ValidationError
 
 from aiograpi import Client
 from aiograpi.exceptions import (
+    AccountSuspended,
     BadPassword,
     ChallengeError,
     ClientNotFoundError,
     LoginRequired,
     PleaseWaitFewMinutes,
     PrivateError,
+    RateLimitError,
     TwoFactorRequired,
 )
 from aiograpi.types import UserShort
@@ -246,40 +248,65 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.username = "example"
         client.password = "password"
         client.authorization_data = {}
-        client.last_json = {"message": "The password you entered is incorrect.", "error_type": "bad_password"}
+        legacy_json = {"message": "The password you entered is incorrect.", "error_type": "bad_password"}
+        legacy_response = Mock(status_code=400)
+        client.last_json = legacy_json
+        client.last_response = legacy_response
         client.pre_login_flow = AsyncMock(return_value=True)
         client.password_encrypt = AsyncMock(return_value="enc-password")
-        client.private_request = AsyncMock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
-        client.bloks_caa_login = AsyncMock(
-            return_value={"logged_in": False, "two_step_verification_context": "", "reason": "no session"}
-        )
+        original = BadPassword("Bad Password", response=legacy_response)
+        client.private_request = AsyncMock(side_effect=original)
 
-        with self.assertRaises(BadPassword):
+        async def caa_without_session(**kwargs):
+            client.last_json = {"status": "ok", "step": "caa"}
+            client.last_response = Mock(status_code=200)
+            return {"logged_in": False, "two_step_verification_context": "", "reason": "no session"}
+
+        client.bloks_caa_login = AsyncMock(side_effect=caa_without_session)
+
+        with self.assertRaises(BadPassword) as raised:
             await client.login(verification_code="654321")
 
+        self.assertIs(raised.exception, original)
         client.bloks_caa_login.assert_awaited_once_with(verification_code="654321")
+        self.assertEqual(client.last_json, legacy_json)
+        self.assertIs(client.last_response, legacy_response)
 
     async def test_login_bad_password_without_context_preserves_original_error_when_caa_is_unavailable(self):
         client = Client()
         client.username = "example"
         client.password = "password"
         client.authorization_data = {}
-        client.last_json = {"message": "Bad Password", "error_type": "bad_password"}
+        legacy_json = {"message": "Bad Password", "error_type": "bad_password"}
+        legacy_response = Mock(status_code=400)
+        client.last_json = legacy_json
+        client.last_response = legacy_response
         client.pre_login_flow = AsyncMock(return_value=True)
         client.password_encrypt = AsyncMock(return_value="enc-password")
-        client.private_request = AsyncMock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
+        original = BadPassword("Bad Password", response=legacy_response)
+        client.private_request = AsyncMock(side_effect=original)
+        caa_response = Mock(status_code=404)
         caa_error = ClientNotFoundError(
             "Payload returned is null",
-            response=Mock(status_code=404),
+            response=caa_response,
             error_type="field_exception",
             status="fail",
         )
-        client.bloks_caa_login = AsyncMock(side_effect=caa_error)
 
-        with self.assertRaises(BadPassword):
+        async def unavailable_caa(**kwargs):
+            client.last_json = {"status": "fail", "error_type": "field_exception"}
+            client.last_response = caa_response
+            raise caa_error
+
+        client.bloks_caa_login = AsyncMock(side_effect=unavailable_caa)
+
+        with self.assertRaises(BadPassword) as raised:
             await client.login(verification_code="654321")
 
+        self.assertIs(raised.exception, original)
         client.bloks_caa_login.assert_awaited_once_with(verification_code="654321")
+        self.assertEqual(client.last_json, legacy_json)
+        self.assertIs(client.last_response, legacy_response)
 
     async def test_login_bad_password_without_bloks_hash_preserves_original_error(self):
         client = Client()
@@ -305,6 +332,45 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.bloks_caa_login = AsyncMock(side_effect=rejection)
 
         with self.assertRaises(ChallengeError) as raised:
+            await client._try_caa_login(original, verification_code="654321")
+
+        self.assertIs(raised.exception, rejection)
+
+    async def test_login_caa_rate_limit_error_is_not_replaced_and_retains_caa_state(self):
+        client = Client()
+        client.username = "example"
+        client.password = "password"
+        client.authorization_data = {}
+        client.last_json = {"message": "Bad Password", "error_type": "bad_password"}
+        client.last_response = Mock(status_code=400)
+        client.pre_login_flow = AsyncMock(return_value=True)
+        client.password_encrypt = AsyncMock(return_value="enc-password")
+        client.private_request = AsyncMock(side_effect=BadPassword("Bad Password", response=client.last_response))
+        caa_json = {"status": "fail", "error_type": "rate_limit_error"}
+        caa_response = Mock(status_code=429)
+        rejection = RateLimitError("CAA login is rate limited", response=caa_response)
+
+        async def rate_limited_caa(**kwargs):
+            client.last_json = caa_json
+            client.last_response = caa_response
+            raise rejection
+
+        client.bloks_caa_login = AsyncMock(side_effect=rate_limited_caa)
+
+        with self.assertRaises(RateLimitError) as raised:
+            await client.login(verification_code="654321")
+
+        self.assertIs(raised.exception, rejection)
+        self.assertEqual(client.last_json, caa_json)
+        self.assertIs(client.last_response, caa_response)
+
+    async def test_caa_account_suspension_is_not_replaced_with_legacy_bad_password(self):
+        client = Client()
+        original = BadPassword("Bad Password", response=Mock(status_code=400))
+        rejection = AccountSuspended("CAA account suspension")
+        client.bloks_caa_login = AsyncMock(side_effect=rejection)
+
+        with self.assertRaises(AccountSuspended) as raised:
             await client._try_caa_login(original, verification_code="654321")
 
         self.assertIs(raised.exception, rejection)

--- a/tests/regression/test_auth.py
+++ b/tests/regression/test_auth.py
@@ -6,6 +6,8 @@ from pydantic import ValidationError
 from aiograpi import Client
 from aiograpi.exceptions import (
     BadPassword,
+    ChallengeError,
+    ClientNotFoundError,
     LoginRequired,
     PleaseWaitFewMinutes,
     PrivateError,
@@ -119,7 +121,7 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.user_short_gql.assert_not_awaited()
         self.assertEqual(client.username, "example")
 
-    async def test_login_bad_password_without_context_tries_caa_bloks_context_when_code_provided(self):
+    async def test_login_bad_password_without_context_tries_current_caa_flow(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -129,26 +131,34 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.password_encrypt = AsyncMock(return_value="enc-password")
         client.login_flow = AsyncMock()
         client.private_request = AsyncMock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
-        caa_result = {"layout": {"bloks_payload": {"action": "action-with-context"}}}
-        client.bloks_caa_login_send_request = AsyncMock(return_value=caa_result)
-        client.bloks_extract_two_step_verification_context = Mock(return_value="context-1")
-        client.bloks_two_step_verification_entrypoint = AsyncMock(return_value={"status": "ok"})
-        client.bloks_two_step_verification_method_picker = AsyncMock(return_value={"status": "ok"})
-        client.bloks_two_step_verification_select_method = AsyncMock(return_value={"status": "ok"})
-        client.bloks_two_step_verification_verify_code = AsyncMock(return_value={"layout": {}})
-        client.bloks_apply_login_response = Mock(return_value=True)
+        client.bloks_caa_login = AsyncMock(return_value={"logged_in": True})
 
         result = await client.login(verification_code="654321")
 
         self.assertTrue(result)
-        client.bloks_caa_login_send_request.assert_awaited_once_with("password", login_attempt_count=1)
-        client.bloks_extract_two_step_verification_context.assert_called_once_with(caa_result)
-        client.bloks_two_step_verification_select_method.assert_awaited_once_with("context-1", selected_method="totp")
-        client.bloks_two_step_verification_verify_code.assert_awaited_once_with(
-            "context-1",
-            "654321",
-            challenge="totp",
-        )
+        client.bloks_caa_login.assert_awaited_once_with(verification_code="654321")
+        client.login_flow.assert_awaited_once_with()
+
+    async def test_login_bad_password_recovery_response_tries_current_caa_flow_without_code(self):
+        client = Client()
+        client.username = "example"
+        client.password = "password"
+        client.authorization_data = {}
+        client.last_json = {
+            "message": "Get back into your account",
+            "error_title": "Forgotten password?",
+            "error_type": "bad_password",
+        }
+        client.pre_login_flow = AsyncMock(return_value=True)
+        client.password_encrypt = AsyncMock(return_value="enc-password")
+        client.login_flow = AsyncMock()
+        client.private_request = AsyncMock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
+        client.bloks_caa_login = AsyncMock(return_value={"logged_in": True})
+
+        result = await client.login()
+
+        self.assertTrue(result)
+        client.bloks_caa_login.assert_awaited_once_with(verification_code="")
         client.login_flow.assert_awaited_once_with()
 
     async def test_login_with_eight_digit_backup_code_selects_backup_code_bloks_challenge(self):
@@ -231,7 +241,7 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         )
         client.login_flow.assert_awaited_once_with()
 
-    async def test_login_bad_password_without_context_raises_clear_error_when_caa_has_no_context(self):
+    async def test_login_bad_password_without_context_preserves_original_error_when_caa_has_no_session(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -240,13 +250,73 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.pre_login_flow = AsyncMock(return_value=True)
         client.password_encrypt = AsyncMock(return_value="enc-password")
         client.private_request = AsyncMock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
-        client.bloks_caa_login_send_request = AsyncMock(return_value={"layout": {"bloks_payload": {"action": ""}}})
-        client.bloks_extract_two_step_verification_context = Mock(return_value="")
-        client.bloks_two_step_verification_verify_code = AsyncMock()
+        client.bloks_caa_login = AsyncMock(
+            return_value={"logged_in": False, "two_step_verification_context": "", "reason": "no session"}
+        )
 
-        with self.assertRaises(TwoFactorRequired) as cm:
+        with self.assertRaises(BadPassword):
             await client.login(verification_code="654321")
 
-        self.assertIn("CAA response did not include two_step_verification_context", str(cm.exception))
-        client.bloks_caa_login_send_request.assert_awaited_once_with("password", login_attempt_count=1)
-        client.bloks_two_step_verification_verify_code.assert_not_awaited()
+        client.bloks_caa_login.assert_awaited_once_with(verification_code="654321")
+
+    async def test_login_bad_password_without_context_preserves_original_error_when_caa_is_unavailable(self):
+        client = Client()
+        client.username = "example"
+        client.password = "password"
+        client.authorization_data = {}
+        client.last_json = {"message": "Bad Password", "error_type": "bad_password"}
+        client.pre_login_flow = AsyncMock(return_value=True)
+        client.password_encrypt = AsyncMock(return_value="enc-password")
+        client.private_request = AsyncMock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
+        caa_error = ClientNotFoundError(
+            "Payload returned is null",
+            response=Mock(status_code=404),
+            error_type="field_exception",
+            status="fail",
+        )
+        client.bloks_caa_login = AsyncMock(side_effect=caa_error)
+
+        with self.assertRaises(BadPassword):
+            await client.login(verification_code="654321")
+
+        client.bloks_caa_login.assert_awaited_once_with(verification_code="654321")
+
+    async def test_caa_profile_code_error_is_not_replaced_with_legacy_bad_password(self):
+        client = Client()
+        original = BadPassword("Bad Password", response=Mock(status_code=400))
+        rejection = ChallengeError("CAA profile-code submission failed")
+        client.bloks_caa_login = AsyncMock(side_effect=rejection)
+
+        with self.assertRaises(ChallengeError) as raised:
+            await client._try_caa_login(original, verification_code="654321")
+
+        self.assertIs(raised.exception, rejection)
+
+    async def test_caa_legacy_two_step_context_requires_a_verification_code(self):
+        client = Client()
+        original = BadPassword("Bad Password", response=Mock(status_code=400))
+        client.bloks_caa_login = AsyncMock(
+            return_value={"logged_in": False, "two_step_verification_context": "legacy-context"}
+        )
+
+        with self.assertRaises(TwoFactorRequired) as raised:
+            await client._try_caa_login(original)
+
+        self.assertIn("provide verification_code", str(raised.exception))
+
+    async def test_caa_legacy_two_step_context_delegates_supplied_code(self):
+        client = Client()
+        original = BadPassword("Bad Password", response=Mock(status_code=400))
+        client.bloks_caa_login = AsyncMock(
+            return_value={"logged_in": False, "two_step_verification_context": "legacy-context"}
+        )
+        client._login_with_bloks_two_factor = AsyncMock(return_value=True)
+
+        result = await client._try_caa_login(original, verification_code="654321")
+
+        self.assertTrue(result)
+        client._login_with_bloks_two_factor.assert_awaited_once_with(
+            "654321",
+            {"two_step_verification_context": "legacy-context"},
+            original,
+        )

--- a/tests/regression/test_auth.py
+++ b/tests/regression/test_auth.py
@@ -281,6 +281,23 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         client.bloks_caa_login.assert_awaited_once_with(verification_code="654321")
 
+    async def test_login_bad_password_without_bloks_hash_preserves_original_error(self):
+        client = Client()
+        client.username = "example"
+        client.password = "password"
+        client.authorization_data = {}
+        client.bloks_versioning_id = None
+        client.last_json = {"message": "Bad Password", "error_type": "bad_password"}
+        client.pre_login_flow = AsyncMock(return_value=True)
+        client.password_encrypt = AsyncMock(return_value="enc-password")
+        client.private_request = AsyncMock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
+        client.bloks_caa_login = AsyncMock(side_effect=AssertionError("Bloks hash is required"))
+
+        with self.assertRaises(BadPassword):
+            await client.login(verification_code="654321")
+
+        client.bloks_caa_login.assert_not_awaited()
+
     async def test_caa_profile_code_error_is_not_replaced_with_legacy_bad_password(self):
         client = Client()
         original = BadPassword("Bad Password", response=Mock(status_code=400))

--- a/tests/regression/test_bloks.py
+++ b/tests/regression/test_bloks.py
@@ -175,6 +175,16 @@ class BloksRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             login=True,
         )
 
+    async def test_bloks_async_action_preserves_positional_login_argument(self):
+        client = self.build_client()
+        params = {"server_params": {"flow": "example_flow"}}
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        await client.bloks_async_action("com.example.action", params, "", None, True)
+
+        self.assertTrue(client.private_request.await_args.kwargs["login"])
+        self.assertNotIn("domain", client.private_request.await_args.kwargs)
+
     async def test_bloks_async_action_does_not_leak_friendly_name_onto_session(self):
         client = self.build_client()
         client._user_id = "123"
@@ -235,12 +245,23 @@ class BloksRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             login=True,
         )
 
+    async def test_bloks_app_preserves_positional_login_argument(self):
+        client = self.build_client()
+        params = {"server_params": {"flow": "example_flow"}}
+        client.private_request = AsyncMock(return_value={"status": "ok"})
+
+        await client.bloks_app("com.example.app", params, "", True)
+
+        self.assertTrue(client.private_request.await_args.kwargs["login"])
+        self.assertNotIn("domain", client.private_request.await_args.kwargs)
+
     async def test_bloks_login_helpers_allow_prelogin_private_requests(self):
         client = self.build_client()
         client.username = "example"
         client.android_device_id = "android-1"
         client.phone_id = "family-device-1"
         client.mid = "machine-1"
+        client.caa_aac = "server-aac"
         client.password_encrypt = AsyncMock(return_value="#PWD_INSTAGRAM:4:1:encrypted")
         client._send_private_request = AsyncMock()
 
@@ -552,6 +573,7 @@ class BloksRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.phone_id = "family-device-1"
         client.uuid = "uuid-1"
         client.mid = "machine-1"
+        client.caa_aac = "server-aac"
         client.password_encrypt = AsyncMock(return_value="#PWD_INSTAGRAM:4:1:encrypted")
         expected = {"status": "ok"}
 
@@ -563,16 +585,18 @@ class BloksRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         action, params = bloks_async_action.call_args.args[:2]
         self.assertEqual(
             bloks_async_action.call_args.kwargs,
-            {"bloks_versioning_id": "", "login": True},
+            {"bloks_versioning_id": "", "domain": None, "extra_headers": None, "login": True},
         )
         self.assertEqual(action, "com.bloks.www.bloks.caa.login.async.send_login_request")
         self.assertEqual(params["client_input_params"]["contact_point"], "example")
         self.assertEqual(params["client_input_params"]["password"], "#PWD_INSTAGRAM:4:1:encrypted")
+        self.assertEqual(params["client_input_params"]["aac"], "server-aac")
         self.assertEqual(params["client_input_params"]["device_id"], "android-1")
         self.assertEqual(params["client_input_params"]["family_device_id"], "family-device-1")
         self.assertEqual(params["client_input_params"]["machine_id"], "machine-1")
         self.assertEqual(params["client_input_params"]["login_attempt_count"], 1)
         self.assertEqual(params["client_input_params"]["try_num"], 1)
+        self.assertEqual(params["client_input_params"]["gms_incoming_call_retriever_eligibility"], "eligible")
         network_info = params["client_input_params"]["si_device_param_network_info"]
         self.assertEqual(network_info["active_subscriptions_info"], None)
         self.assertEqual(network_info["is_airplane_mode"], 0)

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -2,4 +2,4 @@ import aiograpi
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.18.13"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.18.14"


### PR DESCRIPTION
## Summary

- retry the current Android CAA login flow when the legacy endpoint returns `BadPassword` without a legacy two-factor context
- register and persist the signed USDID device identity, obtain server-issued CAA and attestation state, and run the required OAuth preflight asynchronously
- apply embedded login sessions and resolve the supported Verify Profile code challenge through `verification_code` or `challenge_code_handler`
- preserve the original login error when the fallback cannot safely start or cannot produce a supported terminal state
- sync the recorded upstream baseline to `instagrapi` 2.18.14

Thanks @KnifeLemon for documenting the sanitized flow shapes and publishing a reference implementation.

## Scope

This is the native async mirror of subzeroid/instagrapi#2766, which fixed subzeroid/instagrapi#2732.

The separate account-recovery UI remains unsupported because its entry component-query contract is not available. This PR handles direct CAA success and the Verify Profile challenge without guessing that missing contract.

## Verification

- `765 passed, 13 skipped, 35 subtests passed` in the canonical regression suite
- `85 passed` in focused CAA/auth/Bloks/upstream regressions
- Ruff check and format, pre-commit, mypy baseline, Bandit, strict MkDocs build, dependency audit, package build, and diff check passed
- the real-network CAA preflight reached USDID registration, server AAC, attestation, OAuth preflight, and credential submission; terminal async authentication was not re-verified because the available server routes did not return a usable terminal session
- the synchronous `instagrapi` 2.18.14 control produced the same terminal behavior for those routes
