### PR TITLE
fix: require TLS 1.2 for realtime transport

### DIFF
--- a/aiograpi/realtime/mqttot.py
+++ b/aiograpi/realtime/mqttot.py
@@ -243,7 +243,13 @@ class SocketMQTToTTransport:
         self.host = host
         self.port = port
         self.timeout = timeout
-        self.tls_context = tls_context or ssl.create_default_context()
+        if tls_context is None:
+            tls_context = ssl.create_default_context()
+            default_minimum_version = tls_context.minimum_version
+            tls_context.minimum_version = ssl.TLSVersion.TLSv1_2
+            if default_minimum_version > tls_context.minimum_version:
+                tls_context.minimum_version = default_minimum_version
+        self.tls_context = tls_context
         self.proxy = proxy
         self.sock: Optional[socket.socket] = None
 

--- a/tests/regression/test_realtime.py
+++ b/tests/regression/test_realtime.py
@@ -1,5 +1,6 @@
 import json
 import socket
+import ssl
 import threading
 import unittest
 import zlib
@@ -118,6 +119,43 @@ class RealtimeClientRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsInstance(realtime.transport, SocketMQTToTTransport)
         self.assertEqual(realtime.transport.proxy, "socks5://127.0.0.1:8888")
+
+    def test_transport_default_context_requires_tls_1_2(self):
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+
+        with mock.patch(
+            "aiograpi.realtime.mqttot.ssl.create_default_context",
+            return_value=context,
+        ):
+            transport = SocketMQTToTTransport("example.com")
+
+        self.assertIs(transport.tls_context, context)
+        self.assertEqual(context.minimum_version, ssl.TLSVersion.TLSv1_2)
+
+    def test_transport_default_context_preserves_stricter_tls_minimum(self):
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.minimum_version = ssl.TLSVersion.TLSv1_3
+
+        with mock.patch(
+            "aiograpi.realtime.mqttot.ssl.create_default_context",
+            return_value=context,
+        ):
+            transport = SocketMQTToTTransport("example.com")
+
+        self.assertIs(transport.tls_context, context)
+        self.assertEqual(context.minimum_version, ssl.TLSVersion.TLSv1_3)
+
+    def test_transport_does_not_modify_caller_supplied_weak_tls_context(self):
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+
+        with mock.patch("aiograpi.realtime.mqttot.ssl.create_default_context") as create_context:
+            transport = SocketMQTToTTransport("example.com", tls_context=context)
+
+        self.assertIs(transport.tls_context, context)
+        self.assertEqual(context.minimum_version, ssl.TLSVersion.MINIMUM_SUPPORTED)
+        create_context.assert_not_called()
 
     def test_transport_disconnect_shuts_down_socket_to_unblock_active_recv(self):
         class BlockingRecvSocket:


### PR DESCRIPTION
## Summary

- require TLS 1.2 or newer for library-created Realtime MQTT SSL contexts
- preserve stricter platform defaults and caller-provided SSL context policies
- mirror the security hardening and regression coverage from [instagrapi #2770](https://github.com/subzeroid/instagrapi/pull/2770)

## Security

Mirrors the fix for [instagrapi code scanning alert #18](https://github.com/subzeroid/instagrapi/security/code-scanning/18).

## Verification

- `596 passed, 3 skipped, 35 subtests passed` in the full regression suite
- `24 passed` in the focused Realtime regression suite
- Ruff check and format passed
- Bandit reported no issues
- strict MkDocs build passed
- all pre-commit hooks passed
- mypy output is unchanged from the same untouched base environment
