### PR TITLE
test: mirror exhausted 429 contract

### DIFF
--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -48,7 +48,7 @@ from aiograpi.mixins.video import DownloadVideoMixin, UploadVideoMixin
 # Used as fallback logger if another is not provided.
 DEFAULT_LOGGER = logging.getLogger("aiograpi")
 
-__upstream_instagrapi_version__ = "2.18.16"
+__upstream_instagrapi_version__ = "2.18.18"
 
 
 class Client(

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -5,7 +5,7 @@
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.18.16
+instagrapi 2.18.18
 ```
 
 `aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback
@@ -30,6 +30,8 @@ challenge context handling, and clearer Reel/clip upload failure details.
 `aiograpi 1.5.0` continues the baseline through `instagrapi 2.11.0` and ports the `user_follow(...)` action-count/cache semantics fix so duplicate follow attempts return `False` when the relationship already exists or is pending.
 
 `aiograpi 1.6.0` continues the baseline through `instagrapi 2.12.0` and ports typed preservation for v2-only `UserShort` fields in private GraphQL follow-list payloads, including `friendship_status` and normalized `latest_reel_media`.
+
+`aiograpi 1.12.14` continues the baseline through `instagrapi 2.18.18`. Its HTTPX transport already exposes the final HTTP response directly, so exhausted `429` responses map to `ClientThrottledError` or `PleaseWaitFewMinutes` without leaking urllib3 retry errors or adding a second transport retry layer.
 
 ## Release policy
 

--- a/docs/usage-guide/troubleshooting.md
+++ b/docs/usage-guide/troubleshooting.md
@@ -108,9 +108,7 @@ Open the proxy's management URL (often the redirect target) to confirm.
 
 ### `PleaseWaitFewMinutes`
 
-Self-explanatory. Wait, don't retry-loop. aiograpi already retries with
-backoff on 429, so this means you've exhausted that and Instagram wants
-you to actually pause.
+Instagram is asking the account to pause. Private requests surface this response immediately; unlike the configurable outer retry loop in `public_request()`, they do not automatically retry HTTP 429. Wait instead of starting another retry loop.
 
 ### `ClientThrottledError` (HTTP 429)
 

--- a/tests/regression/test_private.py
+++ b/tests/regression/test_private.py
@@ -10,7 +10,9 @@ from aiograpi.exceptions import (
     BadPassword,
     ClientConnectionError,
     ClientNotFoundError,
+    ClientThrottledError,
     DirectMessageRequestsDisabled,
+    PleaseWaitFewMinutes,
 )
 
 
@@ -159,6 +161,35 @@ class PrivateRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             await client._send_private_request("users/999/info/")
 
         self.assertEqual(client.last_json, {})
+
+    async def test_send_private_request_maps_429_to_typed_throttling_error_without_transport_retries(self):
+        client = self._build_client()
+        client.session_retry_total = 9
+        response = self._response({"message": "rate limited", "status": "fail"}, status_code=429)
+        client.private.get = AsyncMock(return_value=response)
+
+        with self.assertRaises(ClientThrottledError) as cm:
+            await client._send_private_request("users/999/info/")
+
+        self.assertIs(cm.exception.response, response)
+        client.private.get.assert_awaited_once()
+
+    async def test_send_private_request_maps_429_wait_message_to_please_wait(self):
+        client = self._build_client()
+        response = self._response(
+            {
+                "message": "Please wait a few minutes before you try again",
+                "status": "fail",
+            },
+            status_code=429,
+        )
+        client.private.get = AsyncMock(return_value=response)
+
+        with self.assertRaises(PleaseWaitFewMinutes) as cm:
+            await client._send_private_request("users/999/info/")
+
+        self.assertIs(cm.exception.response, response)
+        client.private.get.assert_awaited_once()
 
     async def test_private_request_retries_remote_protocol_error_once(self):
         client = self._build_client()

--- a/tests/regression/test_private.py
+++ b/tests/regression/test_private.py
@@ -2,6 +2,8 @@ import json
 import unittest
 from unittest.mock import AsyncMock, Mock
 
+import httpx
+
 from aiograpi import Client, httpx_ext
 from aiograpi.exceptions import (
     AccountContactPointRequired,
@@ -165,31 +167,48 @@ class PrivateRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_send_private_request_maps_429_to_typed_throttling_error_without_transport_retries(self):
         client = self._build_client()
         client.session_retry_total = 9
-        response = self._response({"message": "rate limited", "status": "fail"}, status_code=429)
-        client.private.get = AsyncMock(return_value=response)
+        requests = []
 
-        with self.assertRaises(ClientThrottledError) as cm:
-            await client._send_private_request("users/999/info/")
+        def handle_request(request):
+            requests.append(request)
+            return httpx.Response(429, json={"message": "rate limited", "status": "fail"})
 
-        self.assertIs(cm.exception.response, response)
-        client.private.get.assert_awaited_once()
+        client.private._client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        try:
+            with self.assertRaises(ClientThrottledError) as cm:
+                await client._send_private_request("users/999/info/")
+        finally:
+            await client.private._close()
+
+        self.assertEqual(cm.exception.response.status_code, 429)
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0].method, "GET")
 
     async def test_send_private_request_maps_429_wait_message_to_please_wait(self):
         client = self._build_client()
-        response = self._response(
-            {
-                "message": "Please wait a few minutes before you try again",
-                "status": "fail",
-            },
-            status_code=429,
-        )
-        client.private.get = AsyncMock(return_value=response)
+        requests = []
 
-        with self.assertRaises(PleaseWaitFewMinutes) as cm:
-            await client._send_private_request("users/999/info/")
+        def handle_request(request):
+            requests.append(request)
+            return httpx.Response(
+                429,
+                json={
+                    "message": "Please wait a few minutes before you try again",
+                    "status": "fail",
+                },
+            )
 
-        self.assertIs(cm.exception.response, response)
-        client.private.get.assert_awaited_once()
+        client.private._client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        try:
+            with self.assertRaises(PleaseWaitFewMinutes) as cm:
+                await client._send_private_request("users/999/info/")
+        finally:
+            await client.private._close()
+
+        self.assertEqual(cm.exception.response.status_code, 429)
+        self.assertEqual(len(requests), 1)
 
     async def test_private_request_retries_remote_protocol_error_once(self):
         client = self._build_client()

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import AsyncMock, Mock
 
+import httpx
 import orjson
 
 from aiograpi import Client, httpx_ext
@@ -40,18 +41,28 @@ class PublicRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_public_request_retries_typed_429_only_at_the_outer_layer(self):
         client = Client()
         client.last_response_ts = 0
-        client.public.get = AsyncMock(return_value=self._response(status_code=429))
+        requests = []
 
-        with unittest.mock.patch("aiograpi.mixins.public.asyncio.sleep", new_callable=AsyncMock) as sleep:
-            with self.assertRaises(ClientThrottledError) as cm:
-                await client.public_request(
-                    "https://www.instagram.com/graphql/query/",
-                    retries_count=3,
-                    retries_timeout=0,
-                )
+        def handle_request(request):
+            requests.append(request)
+            return httpx.Response(429, text="rate limited")
+
+        client.public._client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        try:
+            with unittest.mock.patch("aiograpi.mixins.public.asyncio.sleep", new_callable=AsyncMock) as sleep:
+                with self.assertRaises(ClientThrottledError) as cm:
+                    await client.public_request(
+                        "https://www.instagram.com/graphql/query/",
+                        retries_count=3,
+                        retries_timeout=0,
+                    )
+        finally:
+            await client.public._close()
 
         self.assertEqual(cm.exception.response.status_code, 429)
-        self.assertEqual(client.public.get.await_count, 3)
+        self.assertEqual(len(requests), 3)
+        self.assertTrue(all(request.method == "GET" for request in requests))
         self.assertEqual(sleep.await_args_list.count(unittest.mock.call(0)), 2)
         self.assertEqual(sleep.await_args_list.count(unittest.mock.call(1.0)), 2)
 

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -4,26 +4,11 @@ from unittest.mock import AsyncMock, Mock
 import httpx
 import orjson
 
-from aiograpi import Client, httpx_ext
+from aiograpi import Client
 from aiograpi.exceptions import ClientLoginRequired, ClientThrottledError
 
 
 class PublicRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
-    def _response(self, status_code=200):
-        response = Mock()
-        response.status_code = status_code
-        response.url = "https://www.instagram.com/graphql/query/"
-        response.text = "rate limited"
-        response.headers = {}
-        response.raise_for_status.return_value = None
-        if status_code >= 400:
-            response.raise_for_status.side_effect = httpx_ext.HTTPStatusError(
-                f"{status_code} response",
-                request=Mock(),
-                response=response,
-            )
-        return response
-
     async def test_public_request_maps_challenge_redirect_html_to_login_required(self):
         client = Client()
         client.last_response_ts = 0

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -3,11 +3,26 @@ from unittest.mock import AsyncMock, Mock
 
 import orjson
 
-from aiograpi import Client
-from aiograpi.exceptions import ClientLoginRequired
+from aiograpi import Client, httpx_ext
+from aiograpi.exceptions import ClientLoginRequired, ClientThrottledError
 
 
 class PublicRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    def _response(self, status_code=200):
+        response = Mock()
+        response.status_code = status_code
+        response.url = "https://www.instagram.com/graphql/query/"
+        response.text = "rate limited"
+        response.headers = {}
+        response.raise_for_status.return_value = None
+        if status_code >= 400:
+            response.raise_for_status.side_effect = httpx_ext.HTTPStatusError(
+                f"{status_code} response",
+                request=Mock(),
+                response=response,
+            )
+        return response
+
     async def test_public_request_maps_challenge_redirect_html_to_login_required(self):
         client = Client()
         client.last_response_ts = 0
@@ -21,6 +36,24 @@ class PublicRequestRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         with self.assertRaises(ClientLoginRequired):
             await client._send_public_request("https://www.instagram.com/graphql/query/", return_json=True)
+
+    async def test_public_request_retries_typed_429_only_at_the_outer_layer(self):
+        client = Client()
+        client.last_response_ts = 0
+        client.public.get = AsyncMock(return_value=self._response(status_code=429))
+
+        with unittest.mock.patch("aiograpi.mixins.public.asyncio.sleep", new_callable=AsyncMock) as sleep:
+            with self.assertRaises(ClientThrottledError) as cm:
+                await client.public_request(
+                    "https://www.instagram.com/graphql/query/",
+                    retries_count=3,
+                    retries_timeout=0,
+                )
+
+        self.assertEqual(cm.exception.response.status_code, 429)
+        self.assertEqual(client.public.get.await_count, 3)
+        self.assertEqual(sleep.await_args_list.count(unittest.mock.call(0)), 2)
+        self.assertEqual(sleep.await_args_list.count(unittest.mock.call(1.0)), 2)
 
     async def test_public_doc_id_graphql_request_injects_logged_in_public_cookies(self):
         client = Client()

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -4,7 +4,7 @@ import aiograpi
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.18.16"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.18.18"
 
 
 def test_upstream_sync_doc_matches_recorded_baseline():


### PR DESCRIPTION
## Summary

- Record compatibility through `instagrapi 2.18.18`.
- Verify through the real HTTPX session and `MockTransport` that private HTTP 429 responses map to `ClientThrottledError` or `PleaseWaitFewMinutes` without a hidden transport retry layer.
- Verify that public HTTP 429 handling performs exactly the configured outer retries and still raises the typed throttling exception with the final response attached.
- Clarify the private versus public retry behavior in the troubleshooting and upstream-sync documentation.

## Architecture

`aiograpi` uses HTTPX rather than urllib3 adapters, so the upstream Requests implementation does not need to be copied. This PR preserves the existing async transport and adds contract coverage instead of introducing a second retry package or changing production request behavior.

## Test plan

- `813 passed, 13 skipped, 35 subtests passed` on the repository regression target.
- `mkdocs build --strict`
- `ruff check .`
- `ruff format --check .`
- `bandit -q -c pyproject.toml -r aiograpi`
- `python -m build`

## Review

Independent pre-landing review completed with no unresolved findings and a ready-to-merge verdict.
