### PR TITLE
feat: add native async private HTTP/2 transport

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -167,6 +167,28 @@ jobs:
             tests/legacy.py::ChapiPortedRegressionTestCase \
             tests/regression
 
+  private-curl-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.14"]
+        curl-version: [minimum, current]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install private transport test dependencies
+        env:
+          CURL_VERSION: ${{ matrix.curl-version }}
+        run: |
+          python -m pip install -e ".[test,curl]"
+          if [ "$CURL_VERSION" = minimum ]; then
+            python -m pip install "curl_cffi==0.15.0"
+          fi
+      - name: Check private transport and real TLS/HTTP2 behavior
+        run: python -m pytest -q tests/regression/test_private_transport.py tests/regression/test_private_transport_wire.py
+
   live-test:
     # Live IG tests via pooled accounts. Only on canonical-repo pushes
     # — PRs from forks don't have access to the TEST_ACCOUNTS_URL secret.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [Unreleased]
+
+### Added
+
+- Optional native asynchronous private HTTP/2 transport with `Client(private_transport="curl")`, ported from `instagrapi` 2.18.19. It preserves mobile headers, device settings and scoped cookies and advertises only `h2` for HTTPS; the default transport and login routing are unchanged.
+- Real TLS/HTTP2 regression coverage for ALPN, connection reuse, CONNECT proxies, redirects, cookies, errors, timeouts and cancellation; CI checks minimum and current curl_cffi on Python 3.10 and 3.14.
+- Explicitly guarded CAA and saved-session live tests. Private curl requires `aiograpi[curl]`, curl_cffi >= 0.15.0 and libcurl >= 8.10.0.
+
 ## [1.12.14] - 2026-08-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ See the [Migration Guide](https://subzeroid.github.io/aiograpi/latest/migration/
 pip install aiograpi
 ```
 
-Optional public web TLS impersonation support is available as an extra:
+Optional public web TLS impersonation and private HTTP/2 transports are available as an extra:
 
 ```bash
 pip install "aiograpi[curl]"
 ```
 
-Use it only for public web endpoints that are sensitive to browser TLS fingerprints:
+For public web endpoints that are sensitive to browser TLS fingerprints:
 
 ```python
 cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
@@ -158,8 +158,7 @@ cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 
 See the [public transport guide](docs/usage-guide/public-transport.md) for live comparison results and caveats.
 
-Private mobile API requests can separately use native async HTTP/2 with `Client(private_transport="curl")`.
-See the [private HTTP/2 transport guide](docs/usage-guide/interactions.md#private-http2-transport) for saved-session setup and requirements.
+Private mobile API requests can separately use native async HTTP/2 with `Client(private_transport="curl")`. See the [private HTTP/2 transport guide](docs/usage-guide/interactions.md#private-http2-transport) for saved-session setup, requirements and limitations.
 
 TLS certificate verification is enabled by default. For a trusted debugging MITM proxy, prefer `Client(tls_verify="/path/to/proxy-ca.pem")`; use `Client(tls_verify=False)` only for temporary local debugging because it allows session interception.
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 
 See the [public transport guide](docs/usage-guide/public-transport.md) for live comparison results and caveats.
 
+Private mobile API requests can separately use native async HTTP/2 with `Client(private_transport="curl")`.
+See the [private HTTP/2 transport guide](docs/usage-guide/interactions.md#private-http2-transport) for saved-session setup and requirements.
+
 TLS certificate verification is enabled by default. For a trusted debugging MITM proxy, prefer `Client(tls_verify="/path/to/proxy-ca.pem")`; use `Client(tls_verify=False)` only for temporary local debugging because it allows session interception.
 
 ### Realtime MQTT and Direct

--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -48,7 +48,7 @@ from aiograpi.mixins.video import DownloadVideoMixin, UploadVideoMixin
 # Used as fallback logger if another is not provided.
 DEFAULT_LOGGER = logging.getLogger("aiograpi")
 
-__upstream_instagrapi_version__ = "2.18.18"
+__upstream_instagrapi_version__ = "2.18.19"
 
 
 class Client(

--- a/aiograpi/httpx_ext.py
+++ b/aiograpi/httpx_ext.py
@@ -89,6 +89,7 @@ class Session:
         self.verify = verify
         self._client = None
         self._proxy = None
+        self._retired_clients = []
 
     @property
     def cookies(self):
@@ -129,10 +130,16 @@ class Session:
         await self._close()
 
     async def _close(self):
+        await self._close_retired_clients()
         if self._client and self._client._state is ClientState.OPENED:
             await self._client.__aexit__()
 
+    async def _close_retired_clients(self):
+        while self._retired_clients:
+            await self._retired_clients.pop().aclose()
+
     async def request(self, *args, headers=None, proxy=None, **kwargs):
+        await self._close_retired_clients()
         if "timeout" not in kwargs:
             kwargs["timeout"] = DEFAULT_TIMEOUT
         if self._client._state is ClientState.UNOPENED:
@@ -147,6 +154,36 @@ class Session:
 
     async def post(self, *args, **kwargs):
         return await self.request("post", *args, **kwargs)
+
+
+class CurlPrivateSession(Session):
+    """Private HTTPX session using native asynchronous curl I/O."""
+
+    def _set_client(self):
+        from aiograpi.transports import CurlH2Transport
+
+        old = self._client
+        replacement = httpx.AsyncClient(
+            transport=CurlH2Transport(proxy=self._proxy, verify=self.verify),
+            follow_redirects=True,
+            trust_env=False,
+            cookies=old.cookies if old is not None else None,
+        )
+        self._client = replacement
+        if old is not None:
+            self._retired_clients.append(old)
+
+    async def _close(self):
+        await self._close_retired_clients()
+        if self._client is not None:
+            await self._client.aclose()
+
+    async def request(self, *args, headers=None, proxy=None, **kwargs):
+        await self._close_retired_clients()
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = DEFAULT_TIMEOUT
+        headers = {key: value for key, value in (self.headers | (headers or {})).items() if value is not None}
+        return await self._client.request(*args, headers=headers, **kwargs)
 
 
 class CurlResponse:
@@ -299,4 +336,5 @@ __all__ = [
     "request",
     "Session",
     "CurlSession",
+    "CurlPrivateSession",
 ]

--- a/aiograpi/mixins/auth.py
+++ b/aiograpi/mixins/auth.py
@@ -620,6 +620,10 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         bool
             A boolean value
         """
+        # Select the saved transport before applying cookies and TLS settings.
+        # Rebuilding the curl client for TLS configuration preserves its jar.
+        if "private_transport" in self.settings:
+            self._configure_private_transport(self.settings["private_transport"])
         if "cookies" in self.settings:
             self.private.set_cookies(self.settings["cookies"])
         else:
@@ -648,6 +652,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             session_retry_statuses=self.settings.get("session_retry_statuses", self.session_retry_statuses),
             public_transport=self.settings.get("public_transport"),
             public_transport_impersonate=self.settings.get("public_transport_impersonate"),
+            private_transport=self.settings.get("private_transport"),
         )
 
         self.set_timezone_offset(timezone_offset, timezone_name=timezone_name or None)
@@ -988,6 +993,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             "session_retry_statuses": self.session_retry_statuses,
             "public_transport": self.public_transport,
             "public_transport_impersonate": self.public_transport_impersonate,
+            "private_transport": self.private_transport,
             "tls_verify": self.tls_verify,
         }
         usdid_settings = self.get_usdid_settings()
@@ -1072,9 +1078,12 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         session_retry_statuses: list = None,
         public_transport: Optional[Literal["requests", "curl"]] = None,
         public_transport_impersonate: Optional[str] = None,
+        private_transport: Optional[Literal["requests", "curl"]] = None,
     ) -> bool:
         if request_timeout is not None:
             self.request_timeout = request_timeout
+        if private_transport is not None:
+            self._configure_private_transport(private_transport)
         if public_request_retries_count is not None:
             self.public_request_retries_count = public_request_retries_count
         if public_request_retries_timeout is not None:
@@ -1111,6 +1120,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
                     "session_retry_statuses": self.session_retry_statuses,
                     "public_transport": self.public_transport,
                     "public_transport_impersonate": self.public_transport_impersonate,
+                    "private_transport": self.private_transport,
                 }
             )
         return True

--- a/aiograpi/mixins/base.py
+++ b/aiograpi/mixins/base.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
         phone_id: str
         phone_number: Optional[str]
         private: Any
+        private_transport: str
         private_requests_count: int
         public: Any
         public_accept_language: str
@@ -211,6 +212,8 @@ if TYPE_CHECKING:
         def parse_authorization(self, *args: Any, **kwargs: Any) -> Dict[str, Any]: ...
 
         def _configure_public_transport(self, *args: Any, **kwargs: Any) -> Any: ...
+
+        def _configure_private_transport(self, private_transport: str) -> Any: ...
 
         def _default_public_user_agent(self, *args: Any, **kwargs: Any) -> str: ...
 

--- a/aiograpi/mixins/private.py
+++ b/aiograpi/mixins/private.py
@@ -4,6 +4,7 @@ import logging
 import random
 import time
 
+import httpx
 import orjson
 
 from aiograpi import config, httpx_ext
@@ -146,12 +147,17 @@ class PrivateRequestMixin(ClientMixin):
     session_retry_total = 3
     session_retry_backoff_factor = 2
     session_retry_statuses = [429, 500, 502, 503, 504]
+    private_transport = "requests"
     domain = config.API_DOMAIN
     last_response = None
     last_json = {}
 
     def __init__(self, *args, **kwargs):
-        self.private = httpx_ext.Session(verify=getattr(self, "tls_verify", True))
+        self.private_transport = self._normalize_private_transport(
+            kwargs.pop("private_transport", self.private_transport)
+        )
+        session = httpx_ext.CurlPrivateSession if self.private_transport == "curl" else httpx_ext.Session
+        self.private = session(verify=getattr(self, "tls_verify", True))
         self.email = kwargs.pop("email", None)
         self.phone_number = kwargs.pop("phone_number", None)
         self.request_timeout = kwargs.pop("request_timeout", getattr(self, "request_timeout", self.request_timeout))
@@ -179,6 +185,28 @@ class PrivateRequestMixin(ClientMixin):
             )
         )
         super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def _normalize_private_transport(private_transport):
+        if private_transport not in {"requests", "curl"}:
+            raise ValueError("private_transport must be 'requests' or 'curl'")
+        return private_transport
+
+    def _configure_private_transport(self, private_transport):
+        selected = self._normalize_private_transport(private_transport)
+        if selected == self.private_transport:
+            return
+        old = self.private
+        session = httpx_ext.CurlPrivateSession if selected == "curl" else httpx_ext.Session
+        replacement = session(verify=old.verify)
+        replacement.proxy = old.proxy
+        replacement.headers.update(old.headers)
+        replacement._client.cookies = httpx.Cookies(old.cookies)
+        replacement._retired_clients.extend(old._retired_clients)
+        if old._client is not None:
+            replacement._retired_clients.append(old._client)
+        self.private = replacement
+        self.private_transport = selected
 
     async def small_delay(self):
         """
@@ -417,7 +445,7 @@ class PrivateRequestMixin(ClientMixin):
         with_signature=True,
         headers=None,
         extra_sig=None,
-        domain: str = None,
+        domain: str | None = None,
     ):
         self.last_response = None
         self.last_json = last_json = {}  # for Sentry context in traceback
@@ -737,7 +765,7 @@ class PrivateRequestMixin(ClientMixin):
         with_signature=True,
         headers=None,
         extra_sig=None,
-        domain: str = None,
+        domain: str | None = None,
     ):
         # Hard guard: every private endpoint requires a logged-in
         # session (cookie + user_id). Without this, IG returns

--- a/aiograpi/transports.py
+++ b/aiograpi/transports.py
@@ -1,0 +1,103 @@
+"""Optional asynchronous transports for private mobile API requests."""
+
+import os
+import re
+
+import httpx
+
+
+class CurlH2Transport(httpx.AsyncBaseTransport):
+    """Buffered native-async curl transport with h2-only HTTPS ALPN.
+
+    HTTPX owns request preparation, redirects, cookies and decompression.
+    Curl owns the persistent connections and does not retry requests.
+    """
+
+    def __init__(self, proxy=None, verify=True):
+        try:
+            import curl_cffi
+            from curl_cffi import CurlHttpVersion, CurlOpt, ffi
+            from curl_cffi import requests as curl_requests
+        except ImportError as exc:
+            raise RuntimeError(
+                "curl private transport requires the optional curl extra: pip install aiograpi[curl]"
+            ) from exc
+
+        version = re.search(r"libcurl/(\d+)\.(\d+)\.(\d+)", curl_cffi.__curl_version__)
+        if not version or tuple(map(int, version.groups())) < (8, 10, 0):
+            raise RuntimeError("curl private transport requires libcurl >= 8.10.0 for h2-only ALPN")
+        self._curl_requests = curl_requests
+        self._http_version = CurlHttpVersion.V2_PRIOR_KNOWLEDGE
+        self._http2 = CurlHttpVersion.V2_0
+        self._proxy = proxy
+        self._verify = verify
+        self._client = None
+        self._closed = False
+        self._curl_options = {CurlOpt.HTTP_CONTENT_DECODING: 0, CurlOpt.NOPROXY: ""}
+        if isinstance(verify, str) and os.path.isdir(verify):
+            self._curl_options.update({CurlOpt.CAPATH: verify, CurlOpt.CAINFO: ffi.NULL})
+            self._verify = True
+
+    @property
+    def client(self):
+        if self._closed:
+            raise RuntimeError("curl private transport is closed")
+        if self._client is None:
+            self._client = self._curl_requests.AsyncSession(
+                trust_env=False,
+                default_headers=False,
+                discard_cookies=True,
+                http_version=self._http_version,
+                curl_options=self._curl_options,
+            )
+            # curl_cffi reads CA environment variables even with trust_env=False.
+            self._client.verify = True
+        return self._client
+
+    @staticmethod
+    def _timeout(request):
+        budgets = request.extensions.get("timeout", {})
+        connect, read = budgets.get("connect"), budgets.get("read")
+        if connect is None and read is None:
+            return None
+        if not all(isinstance(value, (int, float)) for value in (connect, read)):
+            raise ValueError("curl connect/read timeouts must both be numeric or both None")
+        return connect, read
+
+    async def handle_async_request(self, request):
+        timeout = self._timeout(request)
+        body = await request.aread()
+        try:
+            upstream = await self.client.request(
+                request.method,
+                str(request.url),
+                data=body,
+                headers=list(request.headers.raw),
+                proxies={"all": self._proxy or ""},
+                timeout=timeout,
+                verify=self._verify,
+                allow_redirects=False,
+                default_headers=False,
+                accept_encoding=None,
+                discard_cookies=True,
+                quote=False,
+            )
+        except self._curl_requests.exceptions.RequestException as exc:
+            # In particular, partial transfers must not reach the legacy
+            # incomplete-read retry and resubmit a credential-bearing POST.
+            raise httpx.ConnectError(f"curl private transport failed ({type(exc).__name__})", request=request) from exc
+
+        if request.url.scheme == "https" and upstream.http_version != self._http2:
+            raise httpx.ConnectError("curl private transport did not negotiate HTTP/2", request=request)
+        return httpx.Response(
+            upstream.status_code,
+            headers=upstream.headers.multi_items(),
+            stream=httpx.ByteStream(upstream.content),
+            extensions={"http_version": b"HTTP/2" if upstream.http_version == self._http2 else b"HTTP/1.1"},
+        )
+
+    async def aclose(self):
+        if not self._closed:
+            self._closed = True
+            if self._client is not None:
+                await self._client.close()

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -68,6 +68,8 @@ coverage rather than decreasing it.
 
 We use [pytest][pytest-docs] as our testing framework.
 
+To include the optional private curl transport tests, install both extras with `python -m pip install -e ".[test,curl]"`, then run `python -m pytest -q tests/regression/test_private_transport.py tests/regression/test_private_transport_wire.py`. These tests use local TLS/HTTP2 servers and need no Instagram account.
+
 #### Stages
 
 To customize / override a specific testing stage, please read the documentation specific to that tool:
@@ -94,9 +96,7 @@ maintainers cut a version tag only after the checks are green.
 
 ## Continuous Integration Pipeline
 
-The `Package` workflow runs pip-audit, Bandit, Ruff, the mypy regression gate, network-free regression tests, and docs
-builds. On canonical repository pushes it also runs `tests/live/smoke.py` against the pooled live-account endpoint
-configured in `TEST_ACCOUNTS_URL`.
+The `Package` workflow runs pip-audit, Bandit, Ruff, the mypy regression gate, network-free regression tests, and docs builds. Its private curl job checks minimum and current curl_cffi on Python 3.10 and 3.14. On canonical repository pushes it also runs `tests/live/smoke.py` against the pooled live-account endpoint configured in `TEST_ACCOUNTS_URL`.
 
 Realtime MQTT/FBNS live tests also use `TEST_ACCOUNTS_URL` for pooled accounts. Set `IG_REALTIME_PROXY` when the account
 HTTP proxy can log in but cannot open a CONNECT tunnel to Instagram's MQTT hosts; the realtime tests use that proxy only

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -5,7 +5,7 @@
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.18.18
+instagrapi 2.18.19
 ```
 
 `aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback
@@ -32,6 +32,8 @@ challenge context handling, and clearer Reel/clip upload failure details.
 `aiograpi 1.6.0` continues the baseline through `instagrapi 2.12.0` and ports typed preservation for v2-only `UserShort` fields in private GraphQL follow-list payloads, including `friendship_status` and normalized `latest_reel_media`.
 
 `aiograpi 1.12.14` continues the baseline through `instagrapi 2.18.18`. Its HTTPX transport already exposes the final HTTP response directly, so exhausted `429` responses map to `ClientThrottledError` or `PleaseWaitFewMinutes` without leaking urllib3 retry errors or adding a second transport retry layer.
+
+The `instagrapi` 2.18.19 transport port adds optional native async private HTTP/2 through `curl_cffi`, preserving HTTPX request preparation, redirects and cookies. The private transport API, saved settings, guarded CAA/saved-session live tests and real TLS/HTTP2 CI coverage are mirrored; default login routing remains unchanged.
 
 ## Release policy
 

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -104,6 +104,7 @@ settings = {
    },
    "user_agent": "Instagram 117.0.0.28.123 Android (23/6.0.1; ...US; 168361634)",
    "public_transport": "requests",
+   "private_transport": "requests",
    "public_transport_impersonate": "chrome136",
    "tls_verify": True
 }
@@ -156,6 +157,7 @@ cl.dump_settings('/tmp/dump.json')
 | set_country_code(country_code: int = 1)  | bool | Set country calling code. Default: +1 (USA)
 | set_locale(locale: str = "en_US")        | bool | Set locale (advice: use the locale of your proxy)
 | set_timezone_offset(seconds: int)        | bool | Set timezone offset in seconds
+| set_retry_config(...)                    | bool | Configure request timing, retry settings and public/private transport choices
 | set_tls_verify(tls_verify: bool \| str)  | bool | Update TLS certificate verification for existing public, private and GraphQL sessions
 
 ``` python
@@ -205,8 +207,7 @@ Then opt in explicitly:
 cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 ```
 
-The default remains `public_transport="requests"`. Configure private mobile API requests separately with `private_transport`.
-See [Public Transport](public-transport.md) for live comparison results and caveats.
+The default remains `public_transport="requests"`. Configure private mobile API requests separately with `private_transport`. See [Public Transport](public-transport.md) for live comparison results and caveats.
 
 ### Private HTTP/2 transport
 

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -56,6 +56,7 @@ We recommend using [these proxies](https://soax.com/?r=sEysufQI)
 | ------------------- | --------------------------------------------------------------
 | request\_logger     | Logger in which various actions from Instagram are registered
 | request\_timeout    | Timeout in seconds between requests (1 second by default)
+| private\_transport | Private mobile transport: `requests` (HTTPX) by default, or native async `curl` for HTTP/2
 | public\_transport   | Public web transport: `requests`-compatible async transport by default, or `curl` when `aiograpi[curl]` is installed
 | public\_transport\_impersonate | Browser fingerprint used by the optional curl public transport
 | tls\_verify | TLS certificate verification: `True` by default, `False` for temporary trusted MITM debugging, or a CA bundle path
@@ -204,8 +205,34 @@ Then opt in explicitly:
 cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 ```
 
-The default remains `public_transport="requests"`. Private mobile API requests still use the regular mobile session.
+The default remains `public_transport="requests"`. Configure private mobile API requests separately with `private_transport`.
 See [Public Transport](public-transport.md) for live comparison results and caveats.
+
+### Private HTTP/2 transport
+
+Install `aiograpi[curl]` and use `Client(private_transport="curl")` to send all private mobile API requests, including the existing CAA login flow, through native asynchronous `curl_cffi`. HTTPS advertises only `h2` through ALPN and rejects an HTTP/1 response. Mobile headers and device settings are preserved; no browser impersonation is applied.
+
+```python
+from aiograpi import Client
+
+cl = Client()
+cl.load_settings("session.json")  # if you have saved settings
+cl.set_retry_config(private_transport="curl")  # choose after loading settings
+await cl.login(USERNAME, PASSWORD)
+cl.dump_settings("session.json")
+```
+
+The transport choice is saved with settings. An explicit saved choice overrides the constructor; old settings without this field preserve the constructor choice. The default remains `private_transport="requests"`, aiograpi's existing HTTPX transport. Selecting curl does not change the order or error handling of login methods.
+
+Requirements: `curl_cffi>=0.15.0` and its bundled libcurl >= 8.10.0. No system `curl` executable is needed. Availability depends on curl_cffi wheels for your platform; Android/Termux has not been verified.
+
+HTTPX prepares requests, scopes cookies, follows redirects and decodes responses. Curl maintains native asynchronous connections with no automatic retries, so an interrupted password POST is not resubmitted by the legacy incomplete-read handler. Curl network errors become the existing `ConnectProxyError`; an HTTP 429 remains `ClientThrottledError` with its response.
+
+The curl session uses the explicitly configured proxy and `tls_verify`, ignoring environment proxy and CA overrides. Set a trusted CA bundle with `Client(tls_verify="/path/to/ca.pem")`. Changing transport, proxy or TLS settings preserves the curl session's cookies; replaced async clients are closed on the next awaited request or session close. Change configuration between requests, not while requests are in flight.
+
+Curl buffers responses. HTTPX numeric connect/read timeout values map to curl's connect/read tuple, with a total transfer budget equal to their sum; write/pool limits are not separate curl timers. `timeout=None` is unlimited. Mixed numeric/`None` connect/read values are rejected before I/O. Native asyncio cancellation propagates normally.
+
+This option addresses a reproduced transport-sensitive empty-429 login case. It does not bypass verification, suspension or rate limits, and does not guarantee that rejected saved sessions will become valid.
 
 ### Private mobile headers
 

--- a/docs/usage-guide/public-transport.md
+++ b/docs/usage-guide/public-transport.md
@@ -25,8 +25,7 @@ cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 user = await cl.user_info_by_username_gql("instagram")
 ```
 
-Private mobile API requests can separately opt into `private_transport="curl"`; see [private HTTP/2 transport](interactions.md#private-http2-transport). The public transport setting only changes the public web
-session.
+Private mobile API requests can separately opt into `private_transport="curl"`; see [private HTTP/2 transport](interactions.md#private-http2-transport). The public transport setting only changes the public web session.
 
 ## Live Comparison
 

--- a/docs/usage-guide/public-transport.md
+++ b/docs/usage-guide/public-transport.md
@@ -25,7 +25,7 @@ cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 user = await cl.user_info_by_username_gql("instagram")
 ```
 
-Private mobile API requests still use the regular mobile session. The curl transport only changes the public web
+Private mobile API requests can separately opt into `private_transport="curl"`; see [private HTTP/2 transport](interactions.md#private-http2-transport). The public transport setting only changes the public web
 session.
 
 ## Live Comparison

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ Changelog = "https://github.com/subzeroid/aiograpi/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 curl = [
+    "curl_cffi>=0.15.0",
     "curl-adapter>=1.2.1",
 ]
 video = [
@@ -87,6 +88,8 @@ video = [
     "python-dotenv>=0.10",
 ]
 test = [
+    "h2>=4.3.0",
+    "cryptography>=46.0.5",
     "mypy==1.20.2",
     "Pillow==12.3.0",
     "bandit==1.9.4",

--- a/tests/http2_server.py
+++ b/tests/http2_server.py
@@ -1,0 +1,289 @@
+"""Real loopback TLS/H2 fixture; it never opens an upstream connection."""
+
+import base64
+import gzip
+import socket
+import socketserver
+import ssl
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+from h2.config import H2Configuration
+from h2.connection import H2Connection
+from h2.events import DataReceived, RequestReceived, StreamEnded
+
+LAB_HOST = "localhost"
+LAB_JSON = b'{"status":"lab-ok"}'
+
+
+def peek_protocols(sock):
+    """Read ALPN names from the actual ClientHello without consuming it."""
+    header = sock.recv(5, socket.MSG_PEEK | socket.MSG_WAITALL)
+    if len(header) != 5 or header[0] != 22:
+        raise ValueError("Expected a TLS handshake")
+    size = 5 + int.from_bytes(header[3:5], "big")
+    record = sock.recv(size, socket.MSG_PEEK | socket.MSG_WAITALL)
+    if len(record) != size or record[5] != 1:
+        raise ValueError("Expected one complete ClientHello")
+    hello = record[9:]
+    offset = 34
+    offset += 1 + hello[offset]
+    offset += 2 + int.from_bytes(hello[offset : offset + 2], "big")
+    offset += 1 + hello[offset]
+    end = offset + 2 + int.from_bytes(hello[offset : offset + 2], "big")
+    offset += 2
+    protocols = []
+    while offset < end:
+        kind = int.from_bytes(hello[offset : offset + 2], "big")
+        length = int.from_bytes(hello[offset + 2 : offset + 4], "big")
+        value = hello[offset + 4 : offset + 4 + length]
+        offset += 4 + length
+        if kind == 16:
+            index = 2
+            while index < len(value):
+                length = value[index]
+                protocols.append(value[index + 1 : index + 1 + length].decode("ascii"))
+                index += 1 + length
+    if offset != end or end != len(hello):
+        raise ValueError("Malformed ClientHello")
+    return protocols
+
+
+class Handler(socketserver.BaseRequestHandler):
+    def handle(self):
+        raw = self.request
+        raw.settimeout(5)
+        try:
+            offers = peek_protocols(raw)
+            conn = self.server.tls.wrap_socket(raw, server_side=True)
+        except (OSError, ValueError, ssl.SSLError):
+            return
+        with conn:
+            with self.server.lock:
+                self.server.connection_count += 1
+                connection_id = self.server.connection_count
+            h2 = H2Connection(config=H2Configuration(client_side=False, header_encoding="utf-8"))
+            h2.initiate_connection()
+            pending = {}
+            try:
+                conn.sendall(h2.data_to_send())
+                while data := conn.recv(65535):
+                    for event in h2.receive_data(data):
+                        if isinstance(event, RequestReceived):
+                            pending[event.stream_id] = {
+                                "headers": event.headers,
+                                "body": bytearray(),
+                            }
+                        elif isinstance(event, DataReceived):
+                            pending[event.stream_id]["body"].extend(event.data)
+                            h2.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+                        elif isinstance(event, StreamEnded):
+                            request = pending.pop(event.stream_id)
+                            record = {
+                                "connection_id": connection_id,
+                                "stream_id": event.stream_id,
+                                "alpn_offers": offers,
+                                "negotiated": conn.selected_alpn_protocol(),
+                                "headers": request["headers"],
+                                "body_base64": base64.b64encode(request["body"]).decode(),
+                            }
+                            with self.server.lock:
+                                self.server.records.append(record)
+                            path = dict(request["headers"])[":path"]
+                            if path == "/lab/drop":
+                                return
+                            status, response_headers, body = self.response(path)
+                            declared_length = len(body) + (10 if path.endswith("/lab/partial") else 0)
+                            headers = [
+                                (":status", str(status)),
+                                ("content-length", str(declared_length)),
+                                *response_headers,
+                            ]
+                            if dict(request["headers"])[":method"] == "HEAD":
+                                body = b""
+                            h2.send_headers(event.stream_id, headers, end_stream=not body)
+                            if body:
+                                h2.send_data(event.stream_id, body, end_stream=True)
+                    outgoing = h2.data_to_send()
+                    if outgoing:
+                        conn.sendall(outgoing)
+            except (OSError, ssl.SSLError):
+                return
+
+    @staticmethod
+    def response(path):
+        if path.endswith("/lab/rate-limit"):
+            return 429, [("content-type", "text/plain"), ("retry-after", "7")], b""
+        if path == "/lab/slow":
+            time.sleep(0.25)
+        body = gzip.compress(LAB_JSON, mtime=0)
+        return (
+            200,
+            [
+                ("content-type", "application/json"),
+                ("content-encoding", "gzip"),
+                ("set-cookie", "first_cookie=one; Path=/; Secure"),
+                ("set-cookie", "second_cookie=two; Path=/; Secure"),
+            ],
+            body,
+        )
+
+
+class TCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    daemon_threads = True
+    block_on_close = False
+    allow_reuse_address = True
+
+
+def _write_certificates(artifacts):
+    root_key = ec.generate_private_key(ec.SECP256R1())
+    root_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "curl adapter lab CA")])
+    now = datetime.now(timezone.utc)
+    root = (
+        x509.CertificateBuilder()
+        .subject_name(root_name)
+        .issuer_name(root_name)
+        .public_key(root_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=None,
+                decipher_only=None,
+            ),
+            critical=True,
+        )
+        .sign(root_key, hashes.SHA256())
+    )
+    leaf_key = ec.generate_private_key(ec.SECP256R1())
+    leaf_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, LAB_HOST)])
+    leaf = (
+        x509.CertificateBuilder()
+        .subject_name(leaf_name)
+        .issuer_name(root_name)
+        .public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName(LAB_HOST)]), critical=False)
+        .add_extension(x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]), critical=False)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=True,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(root_key, hashes.SHA256())
+    )
+    ca_path = artifacts / "lab-ca.pem"
+    cert_path = artifacts / "lab-leaf.pem"
+    key_path = artifacts / "lab-leaf-key.pem"
+    ca_path.write_bytes(root.public_bytes(serialization.Encoding.PEM))
+    cert_path.write_bytes(leaf.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        leaf_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+    ca_path.chmod(0o600)
+    cert_path.chmod(0o600)
+    key_path.chmod(0o600)
+    return ca_path, cert_path, key_path
+
+
+class LoopbackServer:
+    def __init__(self, artifacts):
+        ca_path, cert_path, key_path = _write_certificates(artifacts)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.set_alpn_protocols(["h2"])
+        context.load_cert_chain(cert_path, key_path)
+        self.server = TCPServer(("127.0.0.1", 0), Handler)
+        self.server.tls = context
+        self.server.lock = threading.Lock()
+        self.server.connection_count = 0
+        self.server.records = []
+        self.port = self.server.server_address[1]
+        self.records = self.server.records
+        self.ca_path = ca_path
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def start(self):
+        self.thread.start()
+        return self
+
+    def close(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+class LoopbackProxy:
+    """CONNECT tunnel restricted to the associated loopback server."""
+
+    def __init__(self, lab):
+        import select
+        from http.server import BaseHTTPRequestHandler
+
+        records = self.records = []
+
+        class ConnectHandler(BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def do_CONNECT(self):
+                if self.path != f"{LAB_HOST}:{lab.port}":
+                    self.send_error(403)
+                    return
+                records.append(dict(self.headers))
+                with socket.create_connection(("127.0.0.1", lab.port), timeout=3) as upstream:
+                    self.send_response(200)
+                    self.end_headers()
+                    peers = [self.connection, upstream]
+                    while True:
+                        readable, _, _ = select.select(peers, [], [], 3)
+                        if not readable:
+                            return
+                        for source in readable:
+                            data = source.recv(65536)
+                            if not data:
+                                return
+                            target = upstream if source is self.connection else self.connection
+                            target.sendall(data)
+
+        self.server = TCPServer(("127.0.0.1", 0), ConnectHandler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, *args):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)

--- a/tests/live/test_private_transport.py
+++ b/tests/live/test_private_transport.py
@@ -1,0 +1,245 @@
+"""Explicitly enabled, single-attempt CAA checks on ten fresh test accounts.
+
+Run with AIOGRAPI_RUN_CAA_LIVE=1 and TEST_ACCOUNTS_URL configured. A private
+AIOGRAPI_CAA_ACCOUNTS_FILE may instead supply ten freshly assigned records.
+Do not reuse these records for a second run. Credentials and responses are never
+included in pytest failures; successful settings are saved only in the private
+AIOGRAPI_CAA_LIVE_DIR (or pytest's temporary directory).
+"""
+
+import asyncio
+import copy
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import httpx
+import pytest
+
+from aiograpi import Client
+
+fresh_login_only = pytest.mark.skipif(
+    os.getenv("AIOGRAPI_RUN_CAA_LIVE") != "1", reason="fresh CAA logins require explicit opt-in"
+)
+
+
+class ProbeStopped(BaseException):
+    """Leave library fallback/retry handlers immediately."""
+
+
+@pytest.fixture(scope="module")
+def fresh_accounts():
+    try:
+        if path := os.getenv("AIOGRAPI_CAA_ACCOUNTS_FILE"):
+            accounts = json.loads(Path(path).read_text())
+        else:
+            parts = urlsplit(os.environ["TEST_ACCOUNTS_URL"])
+            query = [(k, v) for k, v in parse_qsl(parts.query, keep_blank_values=True) if k != "count"]
+            source = urlunsplit(
+                (parts.scheme, parts.netloc, parts.path, urlencode([*query, ("count", "10")]), parts.fragment)
+            )
+            response = httpx.get(source, timeout=40)
+            response.raise_for_status()
+            accounts = response.json()
+        assert isinstance(accounts, list) and len(accounts) == 10
+        assert len({account["username"].casefold() for account in accounts}) == 10
+        assert all(
+            all(account.get(key) for key in ("username", "password", "user_id", "proxy", "client_settings"))
+            for account in accounts
+        )
+    except Exception as exc:
+        pytest.fail(f"Fresh-account setup failed ({type(exc).__name__})", pytrace=False)
+    return accounts
+
+
+@pytest.fixture(scope="module")
+def private_results(tmp_path_factory):
+    path = os.getenv("AIOGRAPI_CAA_LIVE_DIR")
+    root = Path(path) if path else tmp_path_factory.mktemp("caa-live")
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    root.chmod(0o700)
+    return root
+
+
+def write_private(path, data):
+    with path.open("w") as stream:
+        path.chmod(0o600)
+        json.dump(data, stream, indent=2)
+
+
+@fresh_login_only
+@pytest.mark.parametrize("index", range(10), ids=[f"account-{n:02d}" for n in range(1, 11)])
+def test_caa_login_with_private_curl(fresh_accounts, private_results, index):
+    asyncio.run(_caa_probe(fresh_accounts, private_results, index))
+
+
+async def _caa_probe(fresh_accounts, private_results, index):
+    account = fresh_accounts[index]
+    result_dir = private_results / f"account-{index + 1:02d}"
+    result_dir.mkdir(mode=0o700, exist_ok=True)
+    marker = result_dir / "started.json"
+    try:
+        with marker.open("x") as stream:
+            marker.chmod(0o600)
+            json.dump({"max_password_submissions": 1}, stream)
+    except FileExistsError:
+        pytest.fail(
+            "This account probe was already started; use fresh records and a new results directory", pytrace=False
+        )
+
+    report = {"password_submissions": 0, "responses": [], "session_validated": False}
+    started = time.monotonic()
+    previous_logging = logging.root.manager.disable
+    logging.disable(logging.CRITICAL)
+    client = None
+    try:
+        settings = copy.deepcopy(account["client_settings"])
+        settings.pop("totp_seed", None)
+        settings.update(session_retry_total=0, public_request_retries_count=1, private_transport="curl")
+        client = Client(settings=settings, proxy=account["proxy"])
+        client.username, client.password = account["username"], account["password"]
+        if not client.bloks_versioning_id:
+            pytest.skip("Assigned profile has no known CAA Bloks hash")
+
+        async def stop(*args, **kwargs):
+            raise ProbeStopped("Manual account verification required")
+
+        client.challenge_code_handler = stop
+        client.change_password_handler = stop
+        client.handle_exception = lambda _client, exc: (_ for _ in ()).throw(exc)
+        for session in (client.private, client.public, client.graphql):
+            original_request = session.request
+
+            async def request(method, url, _request=original_request, **kwargs):
+                target = urlsplit(str(url))
+                if target.hostname not in {"i.instagram.com", "b.i.instagram.com", "www.instagram.com"}:
+                    raise ProbeStopped("Unexpected destination")
+                if any(route in target.path for route in ("/challenge/", "/auth_platform/", "/accounts/login/")):
+                    raise ProbeStopped("Unexpected login or verification route")
+                if len(report["responses"]) >= 25 or time.monotonic() - started > 180:
+                    raise ProbeStopped("Probe request or time budget reached")
+                if "caa.login.async.send_login_request" in target.path:
+                    if report["password_submissions"]:
+                        raise ProbeStopped("Duplicate password submission blocked")
+                    report["password_submissions"] += 1
+                kwargs.update(timeout=httpx.Timeout(25, connect=10), follow_redirects=False)
+                response = await _request(method, url, **kwargs)
+                report["responses"].append(response.status_code)
+                if response.status_code == 429 or 300 <= response.status_code < 400:
+                    raise ProbeStopped("HTTP 429 or unexpected redirect; stopped")
+                return response
+
+            session.request = request
+
+        client._clear_session_state(
+            clear_authorization_data=True,
+            clear_authorization_header=True,
+            clear_private_cookies=True,
+            clear_public_cookies=True,
+            clear_last_login=True,
+        )
+        assert not client.user_id
+        assert await client.bloks_caa_login_prepare(username=client.username)
+        response = await client.bloks_caa_login_send_request(
+            client.password, username=client.username, auto_prepare=False
+        )
+        if not client.bloks_apply_login_response(response):
+            if client.bloks_extract_two_step_verification_context(response) or client.bloks_caa_login_needs_two_step(
+                response
+            ):
+                report["verification_required"] = True
+                pytest.skip("CAA reached account verification; session success was not established")
+            pytest.fail("CAA did not return a session", pytrace=False)
+        report["session_validated"] = str((await client.account_info()).pk) == str(account["user_id"])
+        assert report["session_validated"]
+        assert report["password_submissions"] == 1
+        write_private(result_dir / "settings.private.json", client.get_settings())
+    except ProbeStopped as exc:
+        report["stop_reason"] = str(exc)
+        pytest.fail(str(exc), pytrace=False)
+    except Exception as exc:
+        report["exception"] = type(exc).__name__
+        pytest.fail(f"CAA probe failed ({type(exc).__name__})", pytrace=False)
+    finally:
+        if client:
+            for session in (client.private, client.public, client.graphql):
+                await session._close()
+        logging.disable(previous_logging)
+        report["elapsed_seconds"] = round(time.monotonic() - started, 2)
+        write_private(result_dir / "result.sanitized.json", report)
+
+
+@pytest.mark.skipif(
+    os.getenv("AIOGRAPI_RUN_PRIVATE_CURL_LIVE") != "1", reason="saved-session live reads require explicit opt-in"
+)
+def test_saved_session_private_curl():
+    """Two read-only calls with original proxy; no login or recovery requests."""
+
+    async def probe():
+        previous_logging = logging.root.manager.disable
+        logging.disable(logging.CRITICAL)
+        client = None
+        try:
+            account = json.loads(Path(os.environ["AIOGRAPI_PRIVATE_ACCOUNT_FILE"]).read_text())
+            settings = json.loads(Path(os.environ["AIOGRAPI_PRIVATE_SETTINGS_FILE"]).read_text())
+            settings["private_transport"] = "curl"
+            client = Client(settings=settings, proxy=account["proxy"], request_timeout=0)
+            client.handle_exception = lambda _client, exc: (_ for _ in ()).throw(exc)
+            original = client.private.request
+            seen = []
+
+            async def guarded(method, url, **kwargs):
+                target = urlsplit(str(url))
+                allowed = {"/api/v1/accounts/current_user/", f"/api/v1/users/{account['user_id']}/info/"}
+                if (
+                    method.lower() != "get"
+                    or target.hostname != "i.instagram.com"
+                    or target.path not in allowed
+                    or len(seen) >= 2
+                ):
+                    raise ProbeStopped("Unexpected request or retry blocked")
+                seen.append(target.path)
+                kwargs.update(timeout=httpx.Timeout(25, connect=10), follow_redirects=False)
+                response = await original(method, url, **kwargs)
+                if destination := os.getenv("AIOGRAPI_PRIVATE_RESULTS_DIR"):
+                    directory = Path(destination)
+                    directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+                    write_private(
+                        directory / f"{len(seen)}.response.private.json",
+                        {
+                            "status": response.status_code,
+                            "http_version": response.http_version,
+                            "body": response.text,
+                        },
+                    )
+                if response.status_code != 200 or response.http_version != "HTTP/2":
+                    raise ProbeStopped(
+                        f"Expected HTTP 200 over HTTP/2; got {response.status_code} over {response.http_version}"
+                    )
+                return response
+
+            client.private.request = guarded
+
+            async def stop(*args, **kwargs):
+                raise ProbeStopped("Unexpected public request blocked")
+
+            client.public.request = client.graphql.request = stop
+            assert str((await client.account_info()).pk) == str(account["user_id"])
+            assert str((await client.user_info_v1(account["user_id"])).pk) == str(account["user_id"])
+            assert len(seen) == 2
+            if destination := os.getenv("AIOGRAPI_PRIVATE_SETTINGS_OUTPUT"):
+                write_private(Path(destination), client.get_settings())
+        except ProbeStopped as exc:
+            pytest.fail(str(exc), pytrace=False)
+        except Exception as exc:
+            pytest.fail(f"Saved-session probe failed ({type(exc).__name__})", pytrace=False)
+        finally:
+            if client:
+                for session in (client.private, client.public, client.graphql):
+                    await session._close()
+            logging.disable(previous_logging)
+
+    asyncio.run(probe())

--- a/tests/regression/test_private_transport.py
+++ b/tests/regression/test_private_transport.py
@@ -1,0 +1,207 @@
+import asyncio
+import gzip
+import sys
+from http.cookiejar import Cookie
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from aiograpi import Client
+
+
+def test_default_private_transport_does_not_require_curl(monkeypatch):
+    monkeypatch.setitem(sys.modules, "curl_cffi", None)
+    client = Client()
+    assert client.private_transport == "requests"
+
+
+def test_invalid_private_transport_is_rejected():
+    with pytest.raises(ValueError, match="private_transport"):
+        Client(private_transport="invalid")
+
+
+def test_missing_private_curl_extra_has_install_hint(monkeypatch):
+    monkeypatch.setitem(sys.modules, "curl_cffi", None)
+    with pytest.raises(RuntimeError, match=r"pip install aiograpi\[curl\]"):
+        Client(private_transport="curl")
+
+
+@pytest.mark.parametrize("version", ["libcurl/8.9.1", "unknown"])
+def test_private_curl_requires_h2_only_capable_libcurl(monkeypatch, version):
+    curl = pytest.importorskip("curl_cffi")
+    monkeypatch.setattr(curl, "__curl_version__", version)
+    with pytest.raises(RuntimeError, match="libcurl >= 8.10.0"):
+        Client(private_transport="curl")
+
+
+def test_private_transport_settings_restore_and_old_settings_preserve_selection():
+    pytest.importorskip("curl_cffi")
+    client = Client(private_transport="curl")
+    assert client.get_settings()["private_transport"] == "curl"
+    restored = Client(settings=client.get_settings())
+    assert restored.private_transport == "curl"
+    legacy = client.get_settings()
+    legacy.pop("private_transport")
+    assert Client(settings=legacy, private_transport="curl").private_transport == "curl"
+    assert Client(settings={"private_transport": "requests"}, private_transport="curl").private_transport == "requests"
+
+
+def test_switch_preserves_scoped_cookies_headers_proxy_and_device():
+    pytest.importorskip("curl_cffi")
+    client = Client(proxy="http://127.0.0.1:3128")
+    cookie = Cookie(
+        0,
+        "sessionid",
+        "synthetic",
+        None,
+        False,
+        ".instagram.com",
+        True,
+        True,
+        "/api",
+        True,
+        True,
+        None,
+        True,
+        None,
+        None,
+        {},
+    )
+    client.private.cookies.set_cookie(cookie)
+    client.private.headers["Authorization"] = "Bearer synthetic"
+    client.private.headers["X-Custom"] = "preserve"
+    uuid = client.uuid
+    public, graphql = client.public, client.graphql
+    client.set_retry_config(private_transport="curl")
+    assert client.private_transport == "curl"
+    assert client.private.headers["Authorization"] == "Bearer synthetic"
+    assert client.private.headers["X-Custom"] == "preserve"
+    assert client.private.proxy == "http://127.0.0.1:3128"
+    assert client.private.verify is True
+    assert [(c.name, c.domain, c.path, c.secure) for c in client.private.cookies] == [
+        ("sessionid", ".instagram.com", "/api", True)
+    ]
+    assert client.uuid == uuid and client.public is public and client.graphql is graphql
+    client.set_retry_config(private_transport="requests")
+    assert next(iter(client.private.cookies)).value == "synthetic"
+
+
+def test_saved_curl_cookies_survive_initial_tls_configuration():
+    pytest.importorskip("curl_cffi")
+    client = Client(settings={"private_transport": "curl", "cookies": {"sessionid": "synthetic"}})
+    assert client.private.cookies_dict()["sessionid"] == "synthetic"
+
+
+def test_native_async_transport_preserves_request_and_decodes_once():
+    pytest.importorskip("curl_cffi")
+
+    async def scenario():
+        from curl_cffi import CurlHttpVersion
+        from curl_cffi.requests.headers import Headers
+
+        from aiograpi.transports import CurlH2Transport
+
+        transport = CurlH2Transport(proxy="http://127.0.0.1:3128", verify=False)
+        upstream = SimpleNamespace(
+            status_code=200,
+            content=gzip.compress(b'{"status":"ok"}'),
+            headers=Headers({"content-encoding": "gzip"}),
+            http_version=CurlHttpVersion.V2_0,
+        )
+        transport.client.request = AsyncMock(return_value=upstream)
+        async with httpx.AsyncClient(transport=transport, trust_env=False) as client:
+            response = await client.post(
+                "https://i.instagram.com/api/v1/test/?encoded=%2F",
+                content=b"exact\x00bytes",
+                headers={"X-Mobile": "preserved"},
+                timeout=7,
+            )
+            assert response.json() == {"status": "ok"}
+            assert response.http_version == "HTTP/2"
+            args, kwargs = transport.client.request.call_args
+            assert args[:2] == ("POST", "https://i.instagram.com/api/v1/test/?encoded=%2F")
+            assert kwargs["data"] == b"exact\x00bytes"
+            assert kwargs["proxies"] == {"all": "http://127.0.0.1:3128"}
+            assert kwargs["verify"] is False
+            assert kwargs["allow_redirects"] is False
+            assert kwargs["discard_cookies"] is True
+            assert kwargs["default_headers"] is False
+            assert kwargs["accept_encoding"] is None
+            assert kwargs["quote"] is False
+            assert (b"X-Mobile", b"preserved") in kwargs["headers"]
+            assert transport.client.retry.count == 0
+
+    asyncio.run(scenario())
+
+
+def test_native_transport_rejects_https_http1_without_retry():
+    pytest.importorskip("curl_cffi")
+
+    async def scenario():
+        from curl_cffi import CurlHttpVersion
+        from curl_cffi.requests.headers import Headers
+
+        from aiograpi.transports import CurlH2Transport
+
+        transport = CurlH2Transport()
+        transport.client.request = AsyncMock(
+            return_value=SimpleNamespace(
+                status_code=200, content=b"{}", headers=Headers(), http_version=CurlHttpVersion.V1_1
+            )
+        )
+        async with httpx.AsyncClient(transport=transport, trust_env=False) as client:
+            with pytest.raises(httpx.ConnectError, match="HTTP/2"):
+                await client.post("https://i.instagram.com/api/v1/test/", content=b"synthetic")
+            assert transport.client.request.await_count == 1
+
+    asyncio.run(scenario())
+
+
+def test_partial_transfer_does_not_trigger_private_login_retry():
+    pytest.importorskip("curl_cffi")
+
+    async def scenario():
+        from curl_cffi.requests.exceptions import IncompleteRead
+
+        from aiograpi.exceptions import ConnectProxyError
+
+        client = Client(private_transport="curl", request_timeout=0)
+        transport = client.private._client._transport
+        transport.client.request = AsyncMock(side_effect=IncompleteRead("private credential must not leak"))
+        try:
+            with pytest.raises(ConnectProxyError) as exc:
+                await client.private_request("accounts/login/", data={"synthetic": "value"}, login=True)
+            assert transport.client.request.await_count == 1
+            assert "private credential must not leak" not in str(exc.value)
+        finally:
+            await client.private._close()
+
+    asyncio.run(scenario())
+
+
+def test_switch_closes_retired_async_client_on_explicit_close():
+    pytest.importorskip("curl_cffi")
+
+    async def scenario():
+        client = Client()
+        old = client.private._client
+        client.set_retry_config(private_transport="curl")
+        await client.private._close()
+        assert old.is_closed
+        assert client.private._client.is_closed
+
+    asyncio.run(scenario())
+
+
+def test_failed_transport_switch_keeps_working_session(monkeypatch):
+    client = Client()
+    original = client.private
+    original.headers["X-Custom"] = "preserved"
+    monkeypatch.setitem(sys.modules, "curl_cffi", None)
+    with pytest.raises(RuntimeError, match="optional curl extra"):
+        client.set_retry_config(private_transport="curl")
+    assert client.private is original
+    assert client.get_settings()["private_transport"] == "requests"
+    assert client.private.headers["X-Custom"] == "preserved"

--- a/tests/regression/test_private_transport_wire.py
+++ b/tests/regression/test_private_transport_wire.py
@@ -1,0 +1,284 @@
+"""Native async curl transport over real loopback TLS and HTTP/2."""
+
+import asyncio
+import base64
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+
+pytest.importorskip("curl_cffi")
+pytest.importorskip("h2")
+pytest.importorskip("cryptography")
+
+from curl_cffi import CurlHttpVersion
+
+from aiograpi import Client
+from aiograpi.exceptions import ClientThrottledError
+from tests.http2_server import LAB_JSON, Handler, LoopbackServer
+
+
+@pytest.fixture
+def lab(tmp_path, monkeypatch):
+    for name in ("http_proxy", "https_proxy", "all_proxy", "no_proxy", "requests_ca_bundle", "curl_ca_bundle"):
+        monkeypatch.delenv(name, raising=False)
+        monkeypatch.delenv(name.upper(), raising=False)
+    server = LoopbackServer(tmp_path).start()
+    try:
+        yield server
+    finally:
+        server.close()
+
+
+def url(lab, path="/lab/ok"):
+    return f"https://localhost:{lab.port}{path}"
+
+
+@asynccontextmanager
+async def client_for(lab, **kwargs):
+    client = Client(private_transport="curl", tls_verify=str(lab.ca_path), request_timeout=0, **kwargs)
+    try:
+        yield client
+    finally:
+        for session in (client.private, client.public, client.graphql):
+            await session._close()
+
+
+def test_actual_h2_only_clienthello_and_connection_reuse(lab):
+    async def scenario():
+        async with client_for(lab) as client:
+            first = await client.private.get(url(lab), timeout=2)
+            second = await client.private.get(url(lab), timeout=2)
+            assert first.content == second.content == LAB_JSON
+            assert first.http_version == second.http_version == "HTTP/2"
+        assert [r["alpn_offers"] for r in lab.records] == [["h2"], ["h2"]]
+        assert [r["connection_id"] for r in lab.records] == [1, 1]
+        assert [r["stream_id"] for r in lab.records] == [1, 3]
+
+    asyncio.run(scenario())
+
+
+def test_mixed_alpn_control_negotiates_h2_but_offers_http1(lab):
+    async def scenario():
+        async with client_for(lab) as client:
+            client.private._client._transport.client.http_version = CurlHttpVersion.V2_0
+            response = await client.private.get(url(lab), timeout=2)
+            assert response.http_version == "HTTP/2"
+            assert lab.records[0]["alpn_offers"] == ["h2", "http/1.1"]
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("body", [b"signed_body=SIGNATURE.%7B%22x%22%3A1%7D", b"binary\x00body"])
+def test_prepared_body_and_mobile_headers_are_preserved(lab, body):
+    async def scenario():
+        async with client_for(lab) as client:
+            await client.private.post(
+                url(lab, "/lab/form?encoded=%2F%2B"),
+                content=body,
+                headers={"X-IG-App-ID": "synthetic", "X-Empty": ""},
+                timeout=2,
+            )
+            observed = lab.records[0]
+            headers = dict(observed["headers"])
+            assert base64.b64decode(observed["body_base64"]) == body
+            assert headers[":path"] == "/lab/form?encoded=%2F%2B"
+            assert headers["x-ig-app-id"] == "synthetic"
+            assert headers["x-empty"] == ""
+            assert headers["user-agent"] == client.user_agent
+
+    asyncio.run(scenario())
+
+
+def test_head_and_gzip_keep_connection_usable(lab):
+    async def scenario():
+        async with client_for(lab) as client:
+            response = await client.private.request("HEAD", url(lab), timeout=2)
+            assert response.content == b"" and int(response.headers["Content-Length"]) > 0
+            assert (await client.private.get(url(lab), timeout=2)).content == LAB_JSON
+            assert [r["connection_id"] for r in lab.records] == [1, 1]
+
+    asyncio.run(scenario())
+
+
+def test_httpx_owns_duplicate_cookies_and_cookie_clear(lab):
+    async def scenario():
+        async with client_for(lab) as client:
+            response = await client.private.get(url(lab), timeout=2)
+            assert len(response.headers.get_list("set-cookie")) == 2
+            await client.private.get(url(lab), timeout=2)
+            assert set(dict(lab.records[-1]["headers"])["cookie"].split("; ")) == {
+                "first_cookie=one",
+                "second_cookie=two",
+            }
+            client.private.cookies.clear()
+            await client.private.get(url(lab), timeout=2)
+            assert "cookie" not in dict(lab.records[-1]["headers"])
+
+    asyncio.run(scenario())
+
+
+def test_private_429_preserves_response_without_retry(lab):
+    async def scenario():
+        async with client_for(lab) as client:
+            with pytest.raises(ClientThrottledError) as exc:
+                await client.private_request(
+                    "lab/rate-limit", data={"synthetic_password": "test"}, domain=f"localhost:{lab.port}", login=True
+                )
+            assert exc.value.response.status_code == 429
+            assert exc.value.response.headers["retry-after"] == "7"
+            assert len(lab.records) == 1
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("path", ["/lab/drop", "/lab/partial"])
+def test_dropped_or_partial_response_does_not_resubmit_post(lab, path):
+    async def scenario():
+        async with client_for(lab) as client:
+            with pytest.raises(httpx.ConnectError):
+                await client.private.post(url(lab, path), content=b"synthetic_password=test", timeout=2)
+            assert len(lab.records) == 1
+
+    asyncio.run(scenario())
+
+
+def test_native_async_timeout_and_cancellation(lab):
+    async def scenario():
+        async with client_for(lab) as client:
+            with pytest.raises(httpx.ConnectError):
+                await client.private.get(url(lab, "/lab/slow"), timeout=0.03)
+            task = asyncio.create_task(client.private.get(url(lab, "/lab/slow"), timeout=2))
+            for _ in range(100):
+                await asyncio.sleep(0.005)
+                if len(lab.records) == 2:
+                    break
+            assert len(lab.records) == 2 and not task.done(), "network I/O must not block the event loop"
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert len(lab.records) == 2
+            assert (await client.private.get(url(lab), timeout=2)).status_code == 200
+            assert len(lab.records) == 3
+
+    asyncio.run(scenario())
+
+
+def test_unsupported_timeout_rejected_before_network_and_none_is_unlimited(lab):
+    async def scenario():
+        async with client_for(lab) as client:
+            with pytest.raises(ValueError, match="numeric"):
+                await client.private.get(url(lab), timeout=httpx.Timeout(1, connect=None))
+            assert lab.records == []
+            assert (await client.private.get(url(lab), timeout=None)).status_code == 200
+
+    asyncio.run(scenario())
+
+
+def test_proxy_change_honored_even_with_no_proxy_environment(lab, monkeypatch):
+    async def scenario():
+        async with client_for(lab) as client:
+            await client.private.get(url(lab), timeout=2)
+            client.set_proxy("http://127.0.0.1:1")
+            monkeypatch.setenv("NO_PROXY", "*")
+            with pytest.raises(httpx.ConnectError):
+                await client.private.get(url(lab), timeout=0.2)
+            assert len(lab.records) == 1
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("variable", ["REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"])
+def test_tls_verification_is_explicit_and_ignores_environment(lab, monkeypatch, variable):
+    async def scenario():
+        monkeypatch.setenv(variable, str(lab.ca_path))
+        async with client_for(lab) as client:
+            client.set_tls_verify(True)
+            with pytest.raises(httpx.ConnectError):
+                await client.private.get(url(lab), timeout=2)
+            assert not lab.records
+            client.set_tls_verify(False)
+            assert (await client.private.get(url(lab), timeout=2)).status_code == 200
+            client.set_tls_verify(True)
+            with pytest.raises(httpx.ConnectError):
+                await client.private.get(url(lab), timeout=2)
+            assert len(lab.records) == 1
+
+    asyncio.run(scenario())
+
+
+def test_httpx_redirect_preserves_method_body_and_strips_cross_origin_auth(lab, tmp_path, monkeypatch):
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    other = LoopbackServer(other_dir).start()
+    # Both servers use different CAs; this test concerns redirect semantics only.
+    original = Handler.response
+
+    def redirect(path):
+        if path == "/lab/redirect":
+            return 307, [("location", url(other, "/lab/final"))], b""
+        return original(path)
+
+    monkeypatch.setattr(Handler, "response", staticmethod(redirect))
+
+    async def scenario():
+        async with client_for(lab) as client:
+            client.set_tls_verify(False)
+            response = await client.private.post(
+                url(lab, "/lab/redirect"),
+                content=b"synthetic",
+                headers={"Authorization": "Bearer synthetic"},
+                timeout=2,
+            )
+            assert len(response.history) == 1 and response.status_code == 200
+            assert dict(lab.records[0]["headers"])["authorization"] == "Bearer synthetic"
+            headers = dict(other.records[0]["headers"])
+            assert "authorization" not in headers and headers[":method"] == "POST"
+            assert base64.b64decode(other.records[0]["body_base64"]) == b"synthetic"
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        other.close()
+
+
+def test_connect_proxy_reuses_tunnel_without_forwarding_proxy_auth(lab, monkeypatch):
+    from tests.http2_server import LoopbackProxy
+
+    async def scenario(proxy):
+        monkeypatch.setenv("NO_PROXY", "*")
+        credentials = ":".join(("synthetic", "password"))
+        async with client_for(lab, proxy=f"http://{credentials}@127.0.0.1:{proxy.port}") as client:
+            assert (await client.private.get(url(lab), timeout=2)).status_code == 200
+            assert (await client.private.get(url(lab), timeout=2)).status_code == 200
+            assert len(proxy.records) == 1
+            assert proxy.records[0]["Proxy-Authorization"].startswith("Basic ")
+            assert [r["connection_id"] for r in lab.records] == [1, 1]
+            assert all("proxy-authorization" not in dict(r["headers"]) for r in lab.records)
+
+    with LoopbackProxy(lab) as proxy:
+        asyncio.run(scenario(proxy))
+
+
+@pytest.mark.parametrize("change", ["tls", "proxy", "transport"])
+def test_configuration_change_preserves_cookies_and_closes_opened_client(lab, change):
+    async def scenario():
+        async with client_for(lab) as client:
+            await client.private.get(url(lab), timeout=2)
+            old = client.private._client
+            if change == "tls":
+                client.set_tls_verify(str(lab.ca_path))
+            elif change == "proxy":
+                client.set_proxy(None)
+            else:
+                client.set_retry_config(private_transport="requests")
+                client.set_retry_config(private_transport="curl")
+            assert not old.is_closed
+            await client.private.get(url(lab), timeout=2)
+            assert old.is_closed
+            assert set(dict(lab.records[-1]["headers"])["cookie"].split("; ")) == {
+                "first_cookie=one",
+                "second_cookie=two",
+            }
+
+    asyncio.run(scenario())

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -129,7 +129,7 @@ def test_tracker_syntax_is_compatible_with_macos_bash_3_2():
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.18.18"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.18.19"
 
 
 def test_upstream_sync_doc_matches_recorded_baseline():


### PR DESCRIPTION
Private mobile API callers can now opt into native asynchronous HTTP/2 with `Client(private_transport="curl")`. This ports the transport API from [instagrapi #2783](https://github.com/subzeroid/instagrapi/pull/2783), released in 2.18.19 (upstream commit `2fee9ac47cb47eaf267db9894a20c7f41f160236`). The default HTTPX transport and login routing remain unchanged.

HTTPX keeps request preparation, redirects, cookie scope and decoding; curl_cffi keeps persistent async connections, advertises only `h2` for HTTPS and does not retry credential POSTs. The setting round-trips through saved settings. Switching transport, proxy or TLS settings preserves cookies and closes retired async clients on the next awaited request or explicit close. The optional extra requires curl_cffi >= 0.15.0 and libcurl >= 8.10.0.

Validation: **922 passed, 13 expected skips, 35 subtests** across the offline CI target; **32 transport tests**, including real TLS/HTTP2 and CONNECT proxy tests, also pass on Linux with minimum curl_cffi 0.15.0. Ruff, formatting, Bandit, strict documentation, pre-commit and wheel/sdist builds pass. Full mypy analysis reports 219 errors against the unchanged legacy baseline of 220; two optional domain annotations were corrected. CI covers Python 3.10/3.14 with minimum/current curl.

Live validation: ten additional previously authenticated sessions passed both `account_info()` and `user_info_v1()` checks: **20/20 HTTP 200 over HTTP/2**, zero password submissions. Three older saved sessions were separately rejected with HTTP 400 and account verification responses. These are session-read results, not a fresh-login success rate or a claim to bypass restrictions.

## Test coverage

- Configuration: defaults, dependency errors, persisted choice, cookie/header/device preservation, failed-switch atomicity and async client cleanup.
- Wire behavior: h2-only ALPN, mixed-ALPN control, connection/tunnel reuse, exact request bodies, gzip, HEAD, cookies, redirect auth stripping, TLS policy, timeout/cancellation and subsequent reuse.
- Error behavior: HTTP 429 remains typed; dropped/partial transfers do not trigger duplicate credential submissions.

All 28 behavior groups identified by the review have tests; this is a bounded review checklist, not measured line coverage. Guarded live targets are explicit opt-in and stop before unexpected login/recovery requests.

## Documentation

Updated installation and saved-settings examples, private/public transport boundaries, timeout/TLS/async lifecycle limits, development test commands, CI matrix, upstream sync notes and the Unreleased changelog. Strict MkDocs build passed.
