### PR TITLE
fix: stop Reels pagination on repeated cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [Unreleased]
+
+### Fixed
+
+- Reels feed readers now accept media from current `items_with_ads` responses when legacy `items` is empty or absent, avoiding empty results and unnecessary pagination. Existing feed ordering and cursor behavior are preserved.
+
 ## [1.12.15] - 2026-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## Unreleased
+
+### Fixed
+
+- Reels readers now stop as soon as the requested amount is collected, including on the final page or before a later stop marker.
+
 ## [1.12.15] - 2026-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## Unreleased
+
+### Fixed
+
+- Reels pagination now stops when the next cursor is missing or already visited, preserving collected media without repeating the same requests.
+
 ## [1.12.15] - 2026-09-09
 
 ### Added

--- a/aiograpi/mixins/timeline.py
+++ b/aiograpi/mixins/timeline.py
@@ -109,6 +109,8 @@ class ReelsMixin(ClientMixin):
                 if last_media_pk and last_media_pk == item["media"]["pk"]:
                     return total_items
                 total_items.append(extract_media_v1(item.get("media")))
+                if len(total_items) >= float(amount):
+                    return total_items[:amount]
 
             if not result.get("paging_info", {}).get("more_available"):
                 return total_items

--- a/aiograpi/mixins/timeline.py
+++ b/aiograpi/mixins/timeline.py
@@ -92,6 +92,7 @@ class ReelsMixin(ClientMixin):
         last_media_pk = last_media_pk and int(last_media_pk)
         total_items = []
         next_max_id = ""
+        seen_cursors = {next_max_id}
         while True:
             if len(total_items) >= float(amount):
                 return total_items[:amount]
@@ -114,3 +115,6 @@ class ReelsMixin(ClientMixin):
                 return total_items
 
             next_max_id = result.get("paging_info", {}).get("max_id", "")
+            if not next_max_id or next_max_id in seen_cursors:
+                return total_items
+            seen_cursors.add(next_max_id)

--- a/aiograpi/mixins/timeline.py
+++ b/aiograpi/mixins/timeline.py
@@ -105,10 +105,14 @@ class ReelsMixin(ClientMixin):
                 self.logger.exception(e)
                 return total_items
 
-            for item in result["items"]:
-                if last_media_pk and last_media_pk == item["media"]["pk"]:
+            items = result.get("items") or result.get("items_with_ads") or []
+            for item in items:
+                media = item.get("media")
+                if not media:
+                    continue
+                if last_media_pk and last_media_pk == media["pk"]:
                     return total_items
-                total_items.append(extract_media_v1(item.get("media")))
+                total_items.append(extract_media_v1(media))
 
             if not result.get("paging_info", {}).get("more_available"):
                 return total_items

--- a/tests/regression/test_reels_amount_limit.py
+++ b/tests/regression/test_reels_amount_limit.py
@@ -1,0 +1,73 @@
+"""Bounded regression tests for Reels pagination."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from aiograpi import Client
+
+
+@pytest.fixture
+def client(monkeypatch):
+    client = Client()
+    client.logger = Mock()
+    monkeypatch.setattr("aiograpi.mixins.timeline.extract_media_v1", lambda value: SimpleNamespace(pk=str(value["pk"])))
+    return client
+
+
+def page(*pks, more=False, cursor=""):
+    return {"items": [{"media": {"pk": pk}} for pk in pks], "paging_info": {"more_available": more, "max_id": cursor}}
+
+
+def run(client, **kwargs):
+    return asyncio.run(client.reels_timeline_media(**kwargs))
+
+
+def request_mock(**kwargs):
+    return AsyncMock(**kwargs)
+
+
+@pytest.mark.parametrize("collection", ["reels", "explore_reels", "friends_reels"])
+def test_terminal_page_respects_amount(client, collection):
+    client.private_request = request_mock(return_value=page(1, 2, 3))
+    assert [m.pk for m in run(client, collection_pk=collection, amount=1)] == ["1"]
+    assert client.private_request.call_count == 1
+
+
+def test_amount_is_enforced_when_next_page_is_terminal(client):
+    client.private_request = request_mock(side_effect=[page(1, more=True, cursor="A"), page(2, 3, 4)])
+    assert [m.pk for m in run(client, collection_pk="reels", amount=2)] == ["1", "2"]
+    assert client.private_request.call_count == 2
+
+
+def test_amount_is_enforced_before_stop_marker(client):
+    client.private_request = request_mock(return_value=page(1, 2, 3, 4))
+    assert [m.pk for m in run(client, collection_pk="reels", amount=1, last_media_pk=4)] == ["1"]
+
+
+def test_media_beyond_amount_is_not_extracted(client, monkeypatch):
+    def extract(value):
+        assert value["pk"] == 1, "media beyond requested amount must not be parsed"
+        return SimpleNamespace(pk="1")
+
+    monkeypatch.setattr("aiograpi.mixins.timeline.extract_media_v1", extract)
+    client.private_request = request_mock(return_value=page(1, 2, more=True, cursor="A"))
+    assert [m.pk for m in run(client, collection_pk="reels", amount=1)] == ["1"]
+    assert client.private_request.call_count == 1
+
+
+@pytest.mark.parametrize("amount", [0, -1])
+def test_nonpositive_amount_does_not_request_a_page(client, amount):
+    client.private_request = request_mock()
+    assert run(client, collection_pk="reels", amount=amount) == []
+    client.private_request.assert_not_called()
+
+
+def test_partial_results_survive_request_failure(client):
+    client.private_request = request_mock(
+        side_effect=[page(1, more=True, cursor="A"), RuntimeError("synthetic failure")]
+    )
+    assert [m.pk for m in run(client, collection_pk="reels", amount=3)] == ["1"]
+    assert client.private_request.call_count == 2

--- a/tests/regression/test_reels_cursor_progress.py
+++ b/tests/regression/test_reels_cursor_progress.py
@@ -1,0 +1,82 @@
+"""Bounded regression tests for Reels pagination."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from aiograpi import Client
+
+
+@pytest.fixture
+def client(monkeypatch):
+    client = Client()
+    client.logger = Mock()
+    monkeypatch.setattr("aiograpi.mixins.timeline.extract_media_v1", lambda value: SimpleNamespace(pk=str(value["pk"])))
+    return client
+
+
+def page(*pks, more=False, cursor=""):
+    return {"items": [{"media": {"pk": pk}} for pk in pks], "paging_info": {"more_available": more, "max_id": cursor}}
+
+
+def run(client, **kwargs):
+    return asyncio.run(client.reels_timeline_media(**kwargs))
+
+
+def request_mock(**kwargs):
+    return AsyncMock(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "paging",
+    [{"more_available": True}, {"more_available": True, "max_id": ""}, {"more_available": True, "max_id": None}],
+)
+def test_missing_cursor_stops_before_another_request(client, paging):
+    response = page(1)
+    response["paging_info"] = paging
+    client.private_request = request_mock(side_effect=[response, AssertionError("unexpected extra request")])
+    assert [m.pk for m in run(client, collection_pk="reels", amount=10)] == ["1"]
+    assert client.private_request.call_count == 1
+
+
+@pytest.mark.parametrize("pks", [(), (2,)])
+def test_unchanged_cursor_stops_on_empty_or_nonempty_page(client, pks):
+    client.private_request = request_mock(
+        side_effect=[
+            page(1, more=True, cursor="A"),
+            page(*pks, more=True, cursor="A"),
+            AssertionError("unexpected repeated cursor"),
+        ]
+    )
+    assert [m.pk for m in run(client, collection_pk="reels", amount=10)] == ["1", *map(str, pks)]
+    assert client.private_request.call_count == 2
+
+
+def test_cursor_cycle_is_not_requested_again(client):
+    client.private_request = request_mock(
+        side_effect=[
+            page(1, more=True, cursor="A"),
+            page(2, more=True, cursor="B"),
+            page(3, more=True, cursor="A"),
+            AssertionError("unexpected cycle"),
+        ]
+    )
+    assert [m.pk for m in run(client, collection_pk="reels", amount=10)] == ["1", "2", "3"]
+    assert client.private_request.call_count == 3
+    assert [call.kwargs["params"]["max_id"] for call in client.private_request.call_args_list] == ["", "A", "B"]
+
+
+def test_empty_page_with_new_cursor_still_advances(client):
+    client.private_request = request_mock(
+        side_effect=[page(more=True, cursor="A"), page(1, more=True, cursor="B"), page(2)]
+    )
+    assert [m.pk for m in run(client, collection_pk="reels", amount=10)] == ["1", "2"]
+    assert [call.kwargs["params"]["max_id"] for call in client.private_request.call_args_list] == ["", "A", "B"]
+
+
+def test_terminal_page_does_not_follow_cursor(client):
+    client.private_request = request_mock(return_value=page(1, cursor="unused"))
+    assert [m.pk for m in run(client, collection_pk="reels", amount=10)] == ["1"]
+    assert client.private_request.call_count == 1

--- a/tests/regression/test_reels_response.py
+++ b/tests/regression/test_reels_response.py
@@ -1,0 +1,116 @@
+"""Reels feeds can carry media in items_with_ads instead of legacy items."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from aiograpi import Client
+
+
+def media(pk):
+    pk = str(pk)
+    code = f"code{pk}"
+    return {
+        "media": {
+            "pk": pk,
+            "id": f"{pk}_1",
+            "code": code,
+            "taken_at": 1710000000,
+            "media_type": 2,
+            "caption": {"text": "caption"},
+            "user": {"pk": "1", "username": "example", "profile_pic_url": "https://example.com/profile.jpg"},
+            "like_count": 0,
+            "video_versions": [{"url": "https://example.com/video.mp4", "width": 720, "height": 1280}],
+            "image_versions2": {
+                "candidates": [{"url": "https://example.com/thumbnail.jpg", "width": 720, "height": 1280}]
+            },
+        }
+    }
+
+
+@pytest.mark.parametrize("collection", ["reels", "explore_reels", "friends_reels"])
+@pytest.mark.parametrize("legacy", [{}, {"items": []}])
+def test_modern_reels_returns_first_media_without_requesting_another_page(collection, legacy):
+    client = Client()
+    client.logger = Mock()
+    client.private_request = AsyncMock(
+        side_effect=[
+            {
+                **legacy,
+                "items_with_ads": [media(1), media(2)],
+                "paging_info": {"more_available": True, "max_id": "next-page"},
+            }
+        ]
+    )
+
+    result = asyncio.run(client.reels_timeline_media(collection, amount=1))
+
+    assert [item.pk for item in result] == ["1"]
+    assert client.private_request.call_count == 1
+
+
+def test_nonempty_legacy_items_keep_priority_when_both_lists_are_present():
+    client = Client()
+    client.private_request = AsyncMock(
+        return_value={
+            "items": [media(1)],
+            "items_with_ads": [media(2)],
+            "paging_info": {"more_available": False},
+        }
+    )
+
+    assert [item.pk for item in asyncio.run(client.explore_reels(amount=10))] == ["1"]
+    assert client.private_request.call_count == 1
+
+
+def test_modern_reels_skips_non_media_wrappers_and_preserves_order():
+    client = Client()
+    client.private_request = AsyncMock(
+        return_value={
+            "items": [],
+            "items_with_ads": [media(1), {"ad": {"id": "synthetic"}}, {"media": None}, media(2)],
+            "paging_info": {"more_available": False},
+        }
+    )
+
+    assert [item.pk for item in asyncio.run(client.explore_reels(amount=10))] == ["1", "2"]
+
+
+def test_modern_reels_preserves_server_cursor_between_pages():
+    client = Client()
+    client.private_request = AsyncMock(
+        side_effect=[
+            {"items": [], "items_with_ads": [media(1)], "paging_info": {"more_available": True, "max_id": "next-page"}},
+            {"items_with_ads": [media(2)], "paging_info": {"more_available": False}},
+        ]
+    )
+
+    assert [item.pk for item in asyncio.run(client.explore_reels(amount=10))] == ["1", "2"]
+    assert [call.kwargs["params"]["max_id"] for call in client.private_request.call_args_list] == ["", "next-page"]
+
+
+def test_empty_modern_and_legacy_lists_return_no_media():
+    client = Client()
+    client.private_request = AsyncMock(
+        return_value={"items": [], "items_with_ads": [], "paging_info": {"more_available": False}}
+    )
+
+    assert asyncio.run(client.explore_reels(amount=10)) == []
+    assert client.private_request.call_count == 1
+
+
+def test_modern_reels_preserves_existing_integer_stop_marker():
+    client = Client()
+    stop_item = media(2)
+    stop_item["media"]["pk"] = 2
+    client.private_request = AsyncMock(
+        return_value={
+            "items": [],
+            "items_with_ads": [media(1), stop_item, media(3)],
+            "paging_info": {"more_available": False},
+        }
+    )
+
+    assert [item.pk for item in asyncio.run(client.explore_reels(amount=10, last_media_pk=2))] == ["1"]
+    assert client.private_request.call_count == 1


### PR DESCRIPTION
Stop Reels pagination when the next cursor is missing or has already been visited, returning collected media without repeated requests.

Mirrored in subzeroid/instagrapi#2786. Applies to `reels()`, `explore_reels()` and `friends_reels()`.

Prepared for ordered landing: #436 → #437 → #438 → #439. This tested branch includes the preceding fixes in that sequence.

Validation:
- Checked independently against released 2.0.1: 979 offline tests passed.
- Checked with the preceding fixes: 999 offline tests passed.
- The final combined release passes 1009 offline tests and 18 additional interaction scenarios.
- Original regression fixtures are preserved. Existing login, private transport, upload behavior and full CI matrix are retained.
- Pre-commit, Ruff/format, Bandit, strict docs and wheel/sdist checks pass for the combined release.
- Mypy baseline check passes: 219 errors within the existing 220-error ceiling.
- Relevant edge cases are verified with regression tests and explicitly derived offline fixtures; this does not claim they occurred in the captured live responses.
- External networking disabled in local checks. No new live login or upload performed for this release.
