### PR TITLE
fix: advertise hybrid TLS group in private curl transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
+## [Unreleased]
+
+### Fixed
+
+- Advertise the hybrid `X25519MLKEM768` TLS group in the optional private curl transport to address connection failures on proxy paths that reject a classical-only ClientHello. Preserve classical groups and h2-only ALPN; this changes TLS reachability, not authentication handling.
+
 ## [1.12.15] - 2026-09-09
 
 ### Added

--- a/aiograpi/transports.py
+++ b/aiograpi/transports.py
@@ -33,7 +33,13 @@ class CurlH2Transport(httpx.AsyncBaseTransport):
         self._verify = verify
         self._client = None
         self._closed = False
-        self._curl_options = {CurlOpt.HTTP_CONTENT_DECODING: 0, CurlOpt.NOPROXY: ""}
+        self._curl_options = {
+            CurlOpt.HTTP_CONTENT_DECODING: 0,
+            CurlOpt.NOPROXY: "",
+            # Some proxy paths reject the default classical-only ClientHello.
+            # Keep classical groups available for peers without hybrid support.
+            CurlOpt.SSL_EC_CURVES: "X25519MLKEM768:X25519:P-256:P-384",
+        }
         if isinstance(verify, str) and os.path.isdir(verify):
             self._curl_options.update({CurlOpt.CAPATH: verify, CurlOpt.CAINFO: ffi.NULL})
             self._verify = True

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -227,6 +227,8 @@ The transport choice is saved with settings. An explicit saved choice overrides 
 
 Requirements: `curl_cffi>=0.15.0` and its bundled libcurl >= 8.10.0. No system `curl` executable is needed. Availability depends on curl_cffi wheels for your platform; Android/Termux has not been verified.
 
+The TLS offer includes the hybrid `X25519MLKEM768` group alongside `X25519`, `P-256` and `P-384` to address connection failures on some proxy paths. Servers without hybrid support can still select a classical group, while ALPN offers only `h2`.
+
 HTTPX prepares requests, scopes cookies, follows redirects and decodes responses. Curl maintains native asynchronous connections with no automatic retries, so an interrupted password POST is not resubmitted by the legacy incomplete-read handler. Curl network errors become the existing `ConnectProxyError`; an HTTP 429 remains `ClientThrottledError` with its response.
 
 The curl session uses the explicitly configured proxy and `tls_verify`, ignoring environment proxy and CA overrides. Set a trusted CA bundle with `Client(tls_verify="/path/to/ca.pem")`. Changing transport, proxy or TLS settings preserves the curl session's cookies; replaced async clients are closed on the next awaited request or session close. Change configuration between requests, not while requests are in flight.

--- a/tests/http2_server.py
+++ b/tests/http2_server.py
@@ -21,8 +21,8 @@ LAB_HOST = "localhost"
 LAB_JSON = b'{"status":"lab-ok"}'
 
 
-def peek_protocols(sock):
-    """Read ALPN names from the actual ClientHello without consuming it."""
+def peek_client_hello(sock):
+    """Read ALPN and supported groups from the actual ClientHello."""
     header = sock.recv(5, socket.MSG_PEEK | socket.MSG_WAITALL)
     if len(header) != 5 or header[0] != 22:
         raise ValueError("Expected a TLS handshake")
@@ -38,12 +38,15 @@ def peek_protocols(sock):
     end = offset + 2 + int.from_bytes(hello[offset : offset + 2], "big")
     offset += 2
     protocols = []
+    groups = []
     while offset < end:
         kind = int.from_bytes(hello[offset : offset + 2], "big")
         length = int.from_bytes(hello[offset + 2 : offset + 4], "big")
         value = hello[offset + 4 : offset + 4 + length]
         offset += 4 + length
-        if kind == 16:
+        if kind == 10:
+            groups = [int.from_bytes(value[i : i + 2], "big") for i in range(2, len(value), 2)]
+        elif kind == 16:
             index = 2
             while index < len(value):
                 length = value[index]
@@ -51,7 +54,7 @@ def peek_protocols(sock):
                 index += 1 + length
     if offset != end or end != len(hello):
         raise ValueError("Malformed ClientHello")
-    return protocols
+    return {"alpn_offers": protocols, "supported_groups": groups}
 
 
 class Handler(socketserver.BaseRequestHandler):
@@ -59,7 +62,7 @@ class Handler(socketserver.BaseRequestHandler):
         raw = self.request
         raw.settimeout(5)
         try:
-            offers = peek_protocols(raw)
+            hello = peek_client_hello(raw)
             conn = self.server.tls.wrap_socket(raw, server_side=True)
         except (OSError, ValueError, ssl.SSLError):
             return
@@ -87,7 +90,7 @@ class Handler(socketserver.BaseRequestHandler):
                             record = {
                                 "connection_id": connection_id,
                                 "stream_id": event.stream_id,
-                                "alpn_offers": offers,
+                                **hello,
                                 "negotiated": conn.selected_alpn_protocol(),
                                 "headers": request["headers"],
                                 "body_base64": base64.b64encode(request["body"]).decode(),

--- a/tests/regression/test_private_transport_wire.py
+++ b/tests/regression/test_private_transport_wire.py
@@ -282,3 +282,93 @@ def test_configuration_change_preserves_cookies_and_closes_opened_client(lab, ch
             }
 
     asyncio.run(scenario())
+
+
+@pytest.fixture
+def hybrid_lab(lab, monkeypatch):
+    from tests import http2_server
+
+    original = http2_server.peek_client_hello
+    hellos = []
+
+    def require_hybrid_group(sock):
+        hello = original(sock)
+        hellos.append(hello)
+        if 4588 not in hello["supported_groups"]:
+            raise ValueError("Peer requires the hybrid group to be advertised")
+        return hello
+
+    monkeypatch.setattr(http2_server, "peek_client_hello", require_hybrid_group)
+    return lab, hellos
+
+
+@pytest.mark.parametrize("proxy_scheme", [None, "http", "socks5h"])
+def test_hybrid_group_reaches_peer_through_proxy(hybrid_lab, proxy_scheme):
+    from contextlib import ExitStack
+
+    from tests.http2_server import LoopbackProxy
+    from tests.socks5_proxy import LoopbackSocksProxy
+
+    lab, hellos = hybrid_lab
+
+    async def scenario(proxy_url):
+        async with client_for(lab) as client:
+            client.private.proxy = proxy_url
+            first = await client.private.post(url(lab), content=b"synthetic-body", timeout=2)
+            second = await client.private.get(url(lab), timeout=2)
+            assert first.content == second.content == LAB_JSON
+            assert first.http_version == second.http_version == "HTTP/2"
+            headers = dict(lab.records[0]["headers"])
+            assert headers["user-agent"] == client.user_agent
+            assert "proxy-authorization" not in headers
+            assert base64.b64decode(lab.records[0]["body_base64"]) == b"synthetic-body"
+
+    with ExitStack() as stack:
+        proxy_url = None
+        if proxy_scheme:
+            proxy_type = LoopbackProxy if proxy_scheme == "http" else LoopbackSocksProxy
+            proxy = stack.enter_context(proxy_type(lab))
+            proxy_url = f"{proxy_scheme}://synthetic:password@127.0.0.1:{proxy.port}"
+        asyncio.run(scenario(proxy_url))
+        assert hellos == [{"alpn_offers": ["h2"], "supported_groups": [4588, 29, 23, 24]}]
+        assert [r["connection_id"] for r in lab.records] == [1, 1]
+        if proxy_scheme:
+            assert len(proxy.records) == 1
+        if proxy_scheme == "socks5h":
+            assert proxy.records[0] == {"hostname": "localhost", "port": lab.port, "authenticated": True}
+
+
+def test_classical_group_control_fails_without_resubmitting(hybrid_lab):
+    from curl_cffi import CurlOpt
+
+    from tests.socks5_proxy import LoopbackSocksProxy
+
+    lab, hellos = hybrid_lab
+
+    async def scenario(proxy):
+        proxy_url = f"socks5h://synthetic:password@127.0.0.1:{proxy.port}"
+        async with client_for(lab) as client:
+            client.private.proxy = proxy_url
+            transport = client.private._client._transport
+            transport._curl_options[CurlOpt.SSL_EC_CURVES] = "X25519:P-256:P-384"
+            with pytest.raises(httpx.ConnectError):
+                await client.private.post(url(lab), content=b"synthetic-body", timeout=2)
+        assert len(proxy.records) == len(hellos) == 1
+        assert hellos[0]["supported_groups"] == [29, 23, 24]
+        assert not lab.records
+
+    with LoopbackSocksProxy(lab) as proxy:
+        asyncio.run(scenario(proxy))
+
+
+def test_hybrid_offer_remains_compatible_with_classical_peer(lab):
+    # Restrict the server to P-256, which must remain in the client's offer.
+    lab.server.tls.set_ecdh_curve("prime256v1")
+
+    async def scenario():
+        async with client_for(lab) as client:
+            assert (await client.private.get(url(lab), timeout=2)).content == LAB_JSON
+        assert 23 in lab.records[0]["supported_groups"]
+        assert lab.records[0]["negotiated"] == "h2"
+
+    asyncio.run(scenario())

--- a/tests/socks5_proxy.py
+++ b/tests/socks5_proxy.py
@@ -1,0 +1,77 @@
+"""Authenticated SOCKS5 fixture restricted to one loopback TLS server."""
+
+import select
+import socket
+import socketserver
+import threading
+
+
+def read_exact(sock, size):
+    data = bytearray()
+    while len(data) < size:
+        chunk = sock.recv(size - len(data))
+        if not chunk:
+            raise OSError("Incomplete SOCKS5 message")
+        data.extend(chunk)
+    return bytes(data)
+
+
+class LoopbackSocksProxy:
+    def __init__(self, lab):
+        self.records = []
+        records = self.records
+
+        class Handler(socketserver.BaseRequestHandler):
+            def handle(self):
+                conn = self.request
+                conn.settimeout(3)
+                try:
+                    version, count = read_exact(conn, 2)
+                    if version != 5 or 2 not in read_exact(conn, count):
+                        return
+                    conn.sendall(b"\x05\x02")
+                    version, length = read_exact(conn, 2)
+                    username = read_exact(conn, length)
+                    password = read_exact(conn, read_exact(conn, 1)[0])
+                    if version != 1 or username != b"synthetic" or password != b"password":
+                        conn.sendall(b"\x01\x01")
+                        return
+                    conn.sendall(b"\x01\x00")
+                    # Domain-name addressing proves that socks5h defers DNS.
+                    if read_exact(conn, 4) != b"\x05\x01\x00\x03":
+                        return
+                    hostname = read_exact(conn, read_exact(conn, 1)[0]).decode("ascii")
+                    port = int.from_bytes(read_exact(conn, 2), "big")
+                    if hostname != "localhost" or port != lab.port:
+                        return
+                    records.append({"hostname": hostname, "port": port, "authenticated": True})
+                    with socket.create_connection(("127.0.0.1", lab.port), timeout=3) as upstream:
+                        conn.sendall(b"\x05\x00\x00\x01\x7f\x00\x00\x01\x00\x00")
+                        while True:
+                            ready, _, _ = select.select([conn, upstream], [], [], 3)
+                            if not ready:
+                                return
+                            for source in ready:
+                                data = source.recv(65536)
+                                if not data:
+                                    return
+                                (upstream if source is conn else conn).sendall(data)
+                except (OSError, UnicodeError):
+                    return
+
+        class Server(socketserver.ThreadingMixIn, socketserver.TCPServer):
+            daemon_threads = True
+            block_on_close = False
+
+        self.server = Server(("127.0.0.1", 0), Handler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, *args):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)


### PR DESCRIPTION
The private curl transport can fail before receiving a TLS ServerHello on proxy paths that reject its default classical-only group offer. Advertise `X25519MLKEM768:X25519:P-256:P-384` while retaining h2-only ALPN, certificate verification, mobile request preparation, and existing retry behavior.

Fixes #441. Thank you to @marnelle1 for the detailed report, control cases, and minimal reproduction.

## Validation

- Five new wire cases: direct, HTTP CONNECT, authenticated SOCKS5h with remote DNS and tunnel reuse, a rejecting-peer classical-only control without resubmission, and compatibility with a classical-only TLS server.
- Before the production change, all three hybrid-required connection cases failed with TLS errors; they pass with the fix.
- Transport suite: **37/37 passed** with curl_cffi **0.15.0 and 0.16.3**.
- Full offline suite: **927 passed, 13 expected skips**. Ruff, pre-commit, Bandit, and package builds passed.
- Independent coverage and adversarial reviews found no issues.

A separate uncredentialed reachability control across ten HTTP CONNECT proxies returned HTTP 405 over HTTP/2 in all 40 requests, both before and after this change. It showed no failing baseline. The reported external SOCKS5 failure has not been independently reproduced; SOCKS5 behavior is covered by the local fixture. This is a TLS reachability change, with no claim of improved authentication outcomes.

Adds an Unreleased changelog entry; no version or default transport changes.

## Documentation

The private transport guide now documents the hybrid TLS group, classical alternatives and preserved h2-only ALPN. Strict MkDocs build passed.
