### PR TITLE
v1.12.16 chore: release private curl TLS fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ starting with 1.0.0.
 
 ## [Unreleased]
 
+## [1.12.16] - 2026-09-12
+
 ### Fixed
 
 - Advertise the hybrid `X25519MLKEM768` TLS group in the optional private curl transport to address connection failures on proxy paths that reject a classical-only ClientHello. Preserve classical groups and h2-only ALPN; this changes TLS reachability, not authentication handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ starting with 1.0.0.
 
 ## [1.12.16] - 2026-09-12
 
+### Changed
+
+- Record compatibility through `instagrapi` 2.18.20.
+
 ### Fixed
 
 - Advertise the hybrid `X25519MLKEM768` TLS group in the optional private curl transport to address connection failures on proxy paths that reject a classical-only ClientHello. Preserve classical groups and h2-only ALPN; this changes TLS reachability, not authentication handling.

--- a/aiograpi/__init__.py
+++ b/aiograpi/__init__.py
@@ -48,7 +48,7 @@ from aiograpi.mixins.video import DownloadVideoMixin, UploadVideoMixin
 # Used as fallback logger if another is not provided.
 DEFAULT_LOGGER = logging.getLogger("aiograpi")
 
-__upstream_instagrapi_version__ = "2.18.19"
+__upstream_instagrapi_version__ = "2.18.20"
 
 
 class Client(

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -5,7 +5,7 @@
 The current recorded API baseline is:
 
 ```text
-instagrapi 2.18.19
+instagrapi 2.18.20
 ```
 
 `aiograpi 1.0.x` established the SemVer async baseline through `instagrapi 2.7.17`, including Bloks login fallback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.12.15"
+version = "1.12.16"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/regression/test_upstream_sync.py
+++ b/tests/regression/test_upstream_sync.py
@@ -129,7 +129,7 @@ def test_tracker_syntax_is_compatible_with_macos_bash_3_2():
 
 
 def test_upstream_instagrapi_baseline_is_recorded():
-    assert aiograpi.__upstream_instagrapi_version__ == "2.18.19"
+    assert aiograpi.__upstream_instagrapi_version__ == "2.18.20"
 
 
 def test_upstream_sync_doc_matches_recorded_baseline():


### PR DESCRIPTION
Prepare aiograpi 1.12.16 for PyPI publication with the private curl TLS fix from #442. Update the package version, date the changelog entry and record compatibility through instagrapi 2.18.20 in the upstream tracker, guide and existing regression expectation.

Validation: 927 offline tests passed (13 skipped); wheel and sdist build successfully. Strict documentation build and 23 targeted upstream-sync tests passed. Independent release metadata review found no issues.

## Documentation

Record the instagrapi 2.18.20 baseline in the upstream sync guide and changelog; synchronize the tracker marker and existing regression expectation.
