### PR TITLE
fix: return configured uploads without exposure requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ starting with 1.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Return configured photos, videos, albums, Reels, IGTV and Stories without a follow-up `qe/expose/` request, preventing an exposure endpoint error from hiding a successful upload (instagrapi #2790).
+
 ## [1.12.16] - 2026-09-12
 
 ### Changed

--- a/aiograpi/mixins/album.py
+++ b/aiograpi/mixins/album.py
@@ -272,7 +272,6 @@ class UploadAlbumMixin(ClientMixin):
                 raise e
             else:
                 if configured:
-                    await self.expose()
                     return self._extract_configured_media_or_raise(
                         configured,
                         configure_exception or AlbumConfigureError,

--- a/aiograpi/mixins/clip.py
+++ b/aiograpi/mixins/clip.py
@@ -1000,7 +1000,6 @@ class UploadClipMixin(ClientMixin):
                 raise e
             else:
                 if configured:
-                    await self.expose()
                     return self._extract_configured_media_or_raise(
                         configured,
                         ClipConfigureError,

--- a/aiograpi/mixins/igtv.py
+++ b/aiograpi/mixins/igtv.py
@@ -187,7 +187,6 @@ class UploadIGTVMixin(ClientMixin):
                 raise e
             else:
                 if configured:
-                    await self.expose()
                     return self._extract_configured_media_or_raise(
                         configured,
                         IGTVConfigureError,

--- a/aiograpi/mixins/photo.py
+++ b/aiograpi/mixins/photo.py
@@ -340,7 +340,6 @@ class UploadPhotoMixin(ClientMixin):
                 location,
                 extra_data=extra_data,
             ):
-                await self.expose()
                 media = await self._extract_configured_media_or_recent(
                     self.last_json,
                     PhotoConfigureError,
@@ -640,7 +639,6 @@ class UploadPhotoMixin(ClientMixin):
                 extra_data=extra_data,
             )
             if configured:
-                await self.expose()
                 return await self._extract_configured_story_or_recent(
                     configured,
                     PhotoConfigureStoryError,

--- a/aiograpi/mixins/video.py
+++ b/aiograpi/mixins/video.py
@@ -541,7 +541,6 @@ class UploadVideoMixin(ClientMixin):
                 raise e
             else:
                 if configured:
-                    await self.expose()
                     return self._extract_configured_media_or_raise(
                         configured,
                         VideoConfigureError,
@@ -802,7 +801,6 @@ class UploadVideoMixin(ClientMixin):
                         continue
                     raise e
                 if configured:
-                    await self.expose()
                     return await self._extract_configured_story_or_recent(
                         configured,
                         VideoConfigureStoryError,

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -284,6 +284,9 @@ If Instagram returns a `Content-Length` header and the downloaded file is shorte
 
 ## Upload media
 
+Photo, video, album, Reel, IGTV and Story upload helpers return the configured publication without a follow-up
+`qe/expose/` request. Errors from the upload or configure request still propagate normally.
+
 Upload medias to your feed. Common arguments:
 
 * `path` - Path to source file

--- a/tests/regression/test_upload_without_expose.py
+++ b/tests/regression/test_upload_without_expose.py
@@ -1,0 +1,164 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+from aiograpi.exceptions import ClientNotFoundError
+from aiograpi.types import Media, Story
+from tests.regression import test_upload as upload_fixtures
+
+UPLOAD_CASES = {
+    "photo_upload": ("media/configure/", 1, Media),
+    "photo_upload_to_story": ("media/configure_to_story/", 1, Story),
+    "album_upload": ("media/configure_sidecar/", 8, Media),
+    "video_upload": ("media/configure/?video=1", 2, Media),
+    "video_upload_to_story": ("media/configure_to_story/?video=1", 2, Story),
+    "clip_upload": ("media/configure_to_clips/?video=1", 2, Media),
+    "igtv_upload": ("media/configure_to_igtv/?video=1", 2, Media),
+}
+
+
+class UploadWithoutExposeRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.fixtures = upload_fixtures.UploadRegressionTestCase()
+        self.client = self.fixtures.build_client()
+        del self.client.expose  # Exercise the real expose API if an upload calls it.
+        self.client.user_medias_v1 = AsyncMock(return_value=[])
+        self.client.user_stories = AsyncMock(return_value=[])
+        self.client.photo_rupload = AsyncMock(return_value=("1", 720, 1280))
+        self.client.video_rupload = AsyncMock(return_value=("1", 720, 1280, 5, Path("thumbnail.jpg")))
+        self.requests = []
+        sleep = patch("asyncio.sleep", new=AsyncMock())
+        sleep.start()
+        self.addCleanup(sleep.stop)
+
+    async def upload(self, method_name, configure_error=None):
+        configure_endpoint, media_type, result_type = UPLOAD_CASES[method_name]
+        payload = self.fixtures.build_media_payload(media_type=media_type)
+        payload["product_type"] = "story" if result_type is Story else "feed"
+        if method_name == "clip_upload":
+            payload["product_type"] = "clips"
+        if method_name == "igtv_upload":
+            payload["product_type"] = "igtv"
+            payload["title"] = "Video title"
+        if method_name == "album_upload":
+            payload["carousel_media"] = [self.fixtures.build_media_payload(media_type=1)]
+
+        async def private_request(endpoint, *args, **kwargs):
+            self.requests.append(endpoint)
+            if endpoint == "qe/expose/":
+                self.client.last_json = {"status": "fail", "message": "Not found"}
+                raise ClientNotFoundError("qe/expose/ returned 404", response=Mock(status_code=404))
+            self.assertEqual(endpoint, configure_endpoint)
+            if configure_error is not None:
+                self.client.last_json = {"status": "fail", "message": "Configure failed"}
+                raise configure_error
+            self.client.last_json = {"status": "ok", "media": payload}
+            return self.client.last_json
+
+        self.client.private_request = AsyncMock(side_effect=private_request)
+        path = Path("example.jpg" if media_type in (1, 8) else "example.mp4")
+        if method_name == "album_upload":
+            return await self.client.album_upload([path], "caption", configure_timeout=0)
+        if method_name in ("clip_upload", "igtv_upload"):
+            response = Mock(status_code=200)
+            self.client.private.get = AsyncMock(return_value=response)
+            self.client.private.post = AsyncMock(return_value=response)
+            module_name = method_name.split("_", 1)[0]
+            with tempfile.TemporaryDirectory() as directory:
+                path = Path(directory) / "example.mp4"
+                path.write_bytes(b"video-bytes")
+                with patch(
+                    f"aiograpi.mixins.{module_name}.analyze_video",
+                    return_value=(Path("thumbnail.jpg"), 720, 1280, 5),
+                ):
+                    if method_name == "igtv_upload":
+                        return await self.client.igtv_upload(path, "Video title", "caption", configure_timeout=0)
+                    return await self.client.clip_upload(path, "caption", configure_timeout=0)
+        return await getattr(self.client, method_name)(path, "caption")
+
+    async def assert_upload_returns_configured_result(self, method_name):
+        configure_endpoint, media_type, result_type = UPLOAD_CASES[method_name]
+
+        result = await self.upload(method_name)
+
+        self.assertIsInstance(result, result_type)
+        self.assertEqual(result.pk, "1")
+        self.assertEqual(result.id, "1_1")
+        self.assertEqual(result.media_type, media_type)
+        self.assertEqual(result.user.username, "example")
+        if result_type is Media:
+            self.assertEqual(result.caption_text, "caption")
+        else:
+            self.assertEqual(result.product_type, "story")
+        if media_type == 2:
+            self.assertEqual(str(result.video_url), "https://example.com/video.mp4")
+        if method_name == "album_upload":
+            self.assertEqual(len(result.resources), 1)
+            self.assertEqual(result.resources[0].pk, "1")
+        if method_name == "igtv_upload":
+            self.assertEqual(result.title, "Video title")
+        self.assertEqual(self.requests, [configure_endpoint])
+
+    async def assert_upload_propagates_configure_error(self, method_name):
+        error = ClientNotFoundError("Configure endpoint returned 404", response=Mock(status_code=404))
+
+        with self.assertRaises(ClientNotFoundError) as caught:
+            await self.upload(method_name, configure_error=error)
+
+        self.assertIs(caught.exception, error)
+        self.assertEqual(self.requests, [UPLOAD_CASES[method_name][0]])
+
+    async def test_photo_upload_returns_media_without_expose(self):
+        await self.assert_upload_returns_configured_result("photo_upload")
+
+    async def test_photo_story_upload_returns_story_without_expose(self):
+        await self.assert_upload_returns_configured_result("photo_upload_to_story")
+
+    async def test_album_upload_returns_media_without_expose(self):
+        await self.assert_upload_returns_configured_result("album_upload")
+
+    async def test_video_upload_returns_media_without_expose(self):
+        await self.assert_upload_returns_configured_result("video_upload")
+
+    async def test_video_story_upload_returns_story_without_expose(self):
+        await self.assert_upload_returns_configured_result("video_upload_to_story")
+
+    async def test_clip_upload_returns_media_without_expose(self):
+        await self.assert_upload_returns_configured_result("clip_upload")
+
+    async def test_igtv_upload_returns_media_without_expose(self):
+        await self.assert_upload_returns_configured_result("igtv_upload")
+
+    async def test_photo_upload_propagates_configure_error(self):
+        await self.assert_upload_propagates_configure_error("photo_upload")
+
+    async def test_photo_story_upload_propagates_configure_error(self):
+        await self.assert_upload_propagates_configure_error("photo_upload_to_story")
+
+    async def test_album_upload_propagates_configure_error(self):
+        await self.assert_upload_propagates_configure_error("album_upload")
+
+    async def test_video_upload_propagates_configure_error(self):
+        await self.assert_upload_propagates_configure_error("video_upload")
+
+    async def test_video_story_upload_propagates_configure_error(self):
+        await self.assert_upload_propagates_configure_error("video_upload_to_story")
+
+    async def test_clip_upload_propagates_configure_error(self):
+        await self.assert_upload_propagates_configure_error("clip_upload")
+
+    async def test_igtv_upload_propagates_configure_error(self):
+        await self.assert_upload_propagates_configure_error("igtv_upload")
+
+    async def test_explicit_expose_still_requests_experiment_endpoint(self):
+        response = {"status": "ok"}
+        self.client.private_request = AsyncMock(return_value=response)
+
+        result = await self.client.expose()
+
+        self.assertIs(result, response)
+        self.client.private_request.assert_awaited_once_with(
+            "qe/expose/",
+            {"id": self.client.uuid, "experiment": "ig_android_profile_contextual_feed"},
+        )


### PR DESCRIPTION
Uploads can raise `ClientNotFoundError` from `qe/expose/` after Instagram has already configured the publication successfully. Remove that automatic follow-up from photo, album, video, Reel, IGTV and both Story upload paths so callers receive the configured `Media` or `Story`.

Upload/configure errors still propagate, and the explicit `await client.expose()` API remains available. Update the media guide and release changelog.

Mirrors subzeroid/instagrapi#2794; related to subzeroid/instagrapi#2790.

Refreshed against the released 2.0.0 base. Retains its CAA login, default private curl/HTTP2 transport, dependencies and complete regression CI matrix. Prepare patch release 2.0.1.

Validation:
- Fresh reproduction on the 2.0.0 base: all seven successful-upload scenarios fail at the post-configure exposure request; the seven configure-error scenarios pass.
- With this fix: 15 focused regressions pass across all seven paths; includes the explicit expose API contract.
- Full offline suite: 971 passed, 13 skipped, 55 subtests passed.
- Pre-commit, Ruff, formatting, Bandit, strict documentation build, wheel and sdist pass.
- Mypy baseline check passes: 219 errors within the existing 220-error ceiling.
- Independent specification, coverage and adversarial code reviews found no outstanding issues.
- External networking disabled during local checks. No live upload test run.
