### PR TITLE
feat!: use CAA login and private HTTP/2 by default

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -89,11 +89,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install \
+            "curl_cffi==0.15.0" \
             "httpx==0.28.1" \
             "orjson==3.11.8" \
             "PySocks==1.7.1" \
             "pydantic==2.12.5" \
-            "Pillow==12.2.0" \
+            "Pillow==12.3.0" \
             "pycryptodomex==3.23.0" \
             "zstandard==0.25.0"
           python -m pip install .
@@ -101,7 +102,7 @@ jobs:
           python - <<'PY'
           from aiograpi import Client
 
-          Client()
+          assert Client().private_transport == "curl"
           PY
 
   mypy:
@@ -128,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
     steps:
       - name: Check out code
         uses: actions/checkout@v7
@@ -167,6 +168,45 @@ jobs:
             tests/legacy.py::ChapiPortedRegressionTestCase \
             tests/regression
 
+  default-install:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.14"]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Verify a clean standard installation
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          environment = Path(".default-install").resolve()
+          subprocess.run([sys.executable, "-m", "venv", str(environment)], check=True)
+          python = environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+          subprocess.run([str(python), "-m", "pip", "install", "."], check=True)
+          subprocess.run([str(python), "-m", "pip", "check"], check=True)
+          code = """
+          import importlib.util
+          from aiograpi import Client
+
+          assert importlib.util.find_spec("h2") is None
+          assert importlib.util.find_spec("curl_adapter") is None
+          client = Client()
+          assert client.private_transport == "curl"
+          assert callable(client.login_legacy)
+          print(type(client.private).__name__, client.private_transport)
+          """
+          subprocess.run([str(python), "-c", code], cwd=environment, check=True)
+          PY
+
   private-curl-test:
     runs-on: ubuntu-latest
     strategy:
@@ -182,12 +222,12 @@ jobs:
         env:
           CURL_VERSION: ${{ matrix.curl-version }}
         run: |
-          python -m pip install -e ".[test,curl]"
+          python -m pip install -e ".[test]"
           if [ "$CURL_VERSION" = minimum ]; then
             python -m pip install "curl_cffi==0.15.0"
           fi
       - name: Check private transport and real TLS/HTTP2 behavior
-        run: python -m pytest -q tests/regression/test_private_transport.py tests/regression/test_private_transport_wire.py
+        run: python -m pytest -q tests/regression/test_default_transport.py tests/regression/test_private_transport.py tests/regression/test_private_transport_wire.py
 
   live-test:
     # Live IG tests via pooled accounts. Only on canonical-repo pushes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ starting with 1.0.0.
 
 ## [Unreleased]
 
+- **Breaking:** Make `login()` use CAA directly; retain the previous login flow and arguments as `login_legacy()`. Default login does not automatically fall back to legacy login.
+- Reject CAA login with a clear error before preflight when saved app settings lack the required Bloks hash; document explicit app-profile migration.
+- **Breaking:** Use `curl_cffi` and private HTTP/2 by default and install `curl_cffi` as a runtime dependency. Preserve explicit saved transport choices and the `private_transport="requests"` compatibility option.
+
 ## [1.12.16] - 2026-09-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 starting with 1.0.0.
 
-## [Unreleased]
+## [2.0.0] - 2026-09-13
 
 - **Breaking:** Make `login()` use CAA directly; retain the previous login flow and arguments as `login_legacy()`. Default login does not automatically fall back to legacy login.
 - Reject CAA login with a clear error before preflight when saved app settings lack the required Bloks hash; document explicit app-profile migration.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ See the [Migration Guide](https://subzeroid.github.io/aiograpi/latest/migration/
 pip install aiograpi
 ```
 
-Optional public web TLS impersonation and private HTTP/2 transports are available as an extra:
+Private mobile requests use HTTP/2 through `curl_cffi`, included in the standard installation. `Client()` needs no transport argument, and `login()` uses CAA directly. The previous login remains available as `login_legacy()`. See the [login migration guide](docs/usage-guide/login-migration.md).
+
+Optional public web TLS impersonation is available as an extra:
 
 ```bash
 pip install "aiograpi[curl]"
@@ -158,7 +160,7 @@ cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 
 See the [public transport guide](docs/usage-guide/public-transport.md) for live comparison results and caveats.
 
-Private mobile API requests can separately use native async HTTP/2 with `Client(private_transport="curl")`. See the [private HTTP/2 transport guide](docs/usage-guide/interactions.md#private-http2-transport) for saved-session setup, requirements and limitations.
+Private mobile API requests use curl and HTTP/2 by default. See the [private HTTP/2 transport guide](docs/usage-guide/interactions.md#private-http2-transport) for saved-session setup, requirements and limitations.
 
 TLS certificate verification is enabled by default. For a trusted debugging MITM proxy, prefer `Client(tls_verify="/path/to/proxy-ca.pem")`; use `Client(tls_verify=False)` only for temporary local debugging because it allows session interception.
 

--- a/aiograpi/mixins/auth.py
+++ b/aiograpi/mixins/auth.py
@@ -737,8 +737,96 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         relogin: bool = False,
         verification_code: str = "",
     ) -> bool:
+        """Log in using the current Android CAA flow.
+
+        Parameters
+        ----------
+        username: str
+            Instagram Username. Uses stored credentials when omitted.
+        password: str
+            Instagram Password. Uses stored credentials when omitted.
+        relogin: bool
+            Clear the current session before logging in, default False.
+        verification_code: str
+            Two-factor or profile verification code.
+
+        Returns
+        -------
+        bool
+            True after successful login or validation of an existing session.
+
+        Notes
+        -----
+        Existing sessions are validated before reuse. Rejected sessions are
+        cleared and refreshed through CAA. CAA errors propagate directly;
+        use ``login_legacy`` to select the legacy accounts login flow.
         """
-        Login
+        if username and password:
+            self.username = username
+            self.password = password
+        if self.username is None or self.password is None:
+            raise BadCredentials("Both username and password must be provided.")
+        if isinstance(self.username, str):
+            self.username = self.username.strip()
+
+        if relogin:
+            self._clear_session_state(
+                clear_authorization_data=True,
+                clear_authorization_header=True,
+                clear_private_cookies=True,
+                clear_public_cookies=True,
+            )
+            if self.relogin_attempt > 1:
+                raise ReloginAttemptExceeded()
+            self.relogin_attempt += 1
+        if self.user_id and not relogin:
+            try:
+                await self.account_info()
+            except LoginRequired:
+                return await self.login(relogin=True, verification_code=verification_code)
+            return True
+
+        if not self.bloks_versioning_id:
+            raise ClientError(
+                "CAA login requires bloks_versioning_id for the saved app profile. "
+                "Load settings with override_app_version=True to use the supported app profile, "
+                "or provide the matching Bloks hash."
+            )
+        outcome = await self.bloks_caa_login(verification_code=verification_code)
+        logged = bool(outcome.get("logged_in"))
+        if not logged:
+            context = self._extract_two_step_verification_context(outcome)
+            if context:
+                exc = TwoFactorRequired(
+                    "Instagram returned a Bloks two-factor context from the CAA login flow; "
+                    "provide verification_code for login",
+                    response=self.last_response,
+                    **self._exception_context(outcome),
+                )
+                if not verification_code.strip():
+                    raise exc
+                logged = await self._login_with_bloks_two_factor(verification_code, outcome, exc)
+            if not logged:
+                raise ClientError(
+                    str(outcome.get("reason") or "CAA login did not return a session"),
+                    response=self.last_response,
+                    **self._exception_context(outcome),
+                )
+
+        await self.login_flow()
+        self.last_login = time.time()
+        self.relogin_attempt = 0
+        return True
+
+    async def login_legacy(
+        self,
+        username: Union[str, None] = None,
+        password: Union[str, None] = None,
+        relogin: bool = False,
+        verification_code: str = "",
+    ) -> bool:
+        """
+        Login using the legacy accounts endpoint and its existing fallbacks.
 
         Parameters
         ----------
@@ -787,7 +875,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             try:
                 await self.account_info()
             except LoginRequired:
-                return await self.login(relogin=True, verification_code=verification_code)
+                return await self.login_legacy(relogin=True, verification_code=verification_code)
             return True
         try:
             await self.pre_login_flow()

--- a/aiograpi/mixins/base.py
+++ b/aiograpi/mixins/base.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 if TYPE_CHECKING:
+    from aiograpi.types import Account
 
     class ClientMixin:
         """
@@ -126,6 +127,8 @@ if TYPE_CHECKING:
         def _track_highlight_start(self, *args: Any, **kwargs: Any) -> int: ...
 
         def _track_value(self, *args: Any, **kwargs: Any) -> Any: ...
+
+        async def account_info(self) -> Account: ...
 
         async def _send_private_request(self, *args: Any, **kwargs: Any) -> Any: ...
 

--- a/aiograpi/mixins/private.py
+++ b/aiograpi/mixins/private.py
@@ -147,7 +147,7 @@ class PrivateRequestMixin(ClientMixin):
     session_retry_total = 3
     session_retry_backoff_factor = 2
     session_retry_statuses = [429, 500, 502, 503, 504]
-    private_transport = "requests"
+    private_transport = "curl"
     domain = config.API_DOMAIN
     last_response = None
     last_json = {}

--- a/aiograpi/transports.py
+++ b/aiograpi/transports.py
@@ -20,7 +20,7 @@ class CurlH2Transport(httpx.AsyncBaseTransport):
             from curl_cffi import requests as curl_requests
         except ImportError as exc:
             raise RuntimeError(
-                "curl private transport requires the optional curl extra: pip install aiograpi[curl]"
+                "curl private transport requires curl_cffi>=0.15.0; reinstall aiograpi with its dependencies"
             ) from exc
 
         version = re.search(r"libcurl/(\d+)\.(\d+)\.(\d+)", curl_cffi.__curl_version__)

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -68,7 +68,7 @@ coverage rather than decreasing it.
 
 We use [pytest][pytest-docs] as our testing framework.
 
-To include the optional private curl transport tests, install both extras with `python -m pip install -e ".[test,curl]"`, then run `python -m pytest -q tests/regression/test_private_transport.py tests/regression/test_private_transport_wire.py`. These tests use local TLS/HTTP2 servers and need no Instagram account.
+To run private curl transport tests, install test dependencies with `python -m pip install -e ".[test]"`, then run `python -m pytest -q tests/regression/test_private_transport.py tests/regression/test_private_transport_wire.py`. These tests use local TLS/HTTP2 servers and need no Instagram account.
 
 #### Stages
 

--- a/docs/usage-guide/best-practices.md
+++ b/docs/usage-guide/best-practices.md
@@ -51,8 +51,8 @@ cl.delay_range = [1, 3]
 
 ## Use Sessions
 
-When using `.login()` you will login and create a new session with Instagram every time.
-This is suspicious for Instagram.
+Calling `.login()` without a reusable saved session starts a fresh login with Instagram.
+Load settings first so `login()` can validate and reuse the saved session.
 For example, when you use your mobile device, you login to Instagram once
 and then you can use it for a long time without logging in again. This is because Instagram stores
 your session on your device and you can use it to login to Instagram without entering your username

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -56,7 +56,7 @@ We recommend using [these proxies](https://soax.com/?r=sEysufQI)
 | ------------------- | --------------------------------------------------------------
 | request\_logger     | Logger in which various actions from Instagram are registered
 | request\_timeout    | Timeout in seconds between requests (1 second by default)
-| private\_transport | Private mobile transport: `requests` (HTTPX) by default, or native async `curl` for HTTP/2
+| private\_transport | Private mobile transport: native async `curl` by default for HTTP/2; `requests` selects the previous HTTPX transport
 | public\_transport   | Public web transport: `requests`-compatible async transport by default, or `curl` when `aiograpi[curl]` is installed
 | public\_transport\_impersonate | Browser fingerprint used by the optional curl public transport
 | tls\_verify | TLS certificate verification: `True` by default, `False` for temporary trusted MITM debugging, or a CA bundle path
@@ -66,12 +66,15 @@ We recommend using [these proxies](https://soax.com/?r=sEysufQI)
 
 | Method                               | Return  | Description
 | ------------------------------------ | ------- | -------------------------------------------------
-| login(username: str, password: str)  | bool    | Login by username and password (get new cookies if it does not exist in settings)
-| login(username: str, password: str, verification\_code: str) | bool | Login by username and password with 2FA verification code (use Google Authenticator or something similar to generate TOTP code, not work with SMS)
+| login(username: str, password: str)  | bool    | CAA login by username and password; validate and reuse a saved session when present
+| login(username: str, password: str, verification\_code: str) | bool | CAA login with a supported TOTP, SMS, backup or profile verification code
+| login\_legacy(username: str, password: str, relogin: bool = False, verification\_code: str = "") | bool | Explicit compatibility entry point for the previous login flow
 | relogin()                            | bool    | Re-login with clean cookies (required cl.username and cl.password)
 | login\_by\_sessionid(sessionid: str) | bool    | Lightweight compatibility login using a session cookie value
 | inject\_sessionid\_to\_public()      | bool    | Inject sessionid from Private Session to Public Session
 | logout()                             | bool    | Logout
+
+`login()` uses CAA directly and does not automatically fall back to `login_legacy()`. Both entry points accept the same arguments. See the [login migration guide](login-migration.md) for compatibility and saved-session behavior.
 
 `login_by_sessionid()` only works when Instagram accepts that `sessionid` for the private mobile API. A browser/web `sessionid` can be rejected with `login_required` or invalidated server-side; for long-lived automation, prefer `login()` once, then `dump_settings()` and reuse the saved settings.
 
@@ -104,7 +107,7 @@ settings = {
    },
    "user_agent": "Instagram 117.0.0.28.123 Android (23/6.0.1; ...US; 168361634)",
    "public_transport": "requests",
-   "private_transport": "requests",
+   "private_transport": "curl",
    "public_transport_impersonate": "chrome136",
    "tls_verify": True
 }
@@ -211,19 +214,18 @@ The default remains `public_transport="requests"`. Configure private mobile API 
 
 ### Private HTTP/2 transport
 
-Install `aiograpi[curl]` and use `Client(private_transport="curl")` to send all private mobile API requests, including the existing CAA login flow, through native asynchronous `curl_cffi`. HTTPS advertises only `h2` through ALPN and rejects an HTTP/1 response. Mobile headers and device settings are preserved; no browser impersonation is applied.
+The standard installation includes `curl_cffi`. `Client()` sends private mobile API requests over HTTP/2 with an ALPN offer containing only `h2`, including CAA login. Mobile request headers and account device settings are preserved.
 
 ```python
 from aiograpi import Client
 
 cl = Client()
 cl.load_settings("session.json")  # if you have saved settings
-cl.set_retry_config(private_transport="curl")  # choose after loading settings
 await cl.login(USERNAME, PASSWORD)
 cl.dump_settings("session.json")
 ```
 
-The transport choice is saved with settings. An explicit saved choice overrides the constructor; old settings without this field preserve the constructor choice. The default remains `private_transport="requests"`, aiograpi's existing HTTPX transport. Selecting curl does not change the order or error handling of login methods.
+Transport selection is saved in settings. An explicit saved choice overrides the constructor; settings without this field preserve the constructor choice, which defaults to `curl`. To migrate settings that explicitly saved `requests`, call `cl.set_retry_config(private_transport="curl")` after loading them, then save again. `Client(private_transport="requests")` selects the previous private transport. Public and GraphQL transports have their own configuration.
 
 Requirements: `curl_cffi>=0.15.0` and its bundled libcurl >= 8.10.0. No system `curl` executable is needed. Availability depends on curl_cffi wheels for your platform; Android/Termux has not been verified.
 

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -115,6 +115,8 @@ settings = {
 cl = Client(settings)
 ```
 
+This example contains an older app profile without a Bloks hash. Before a fresh CAA login, follow the [older-profile migration steps](login-migration.md#older-app-profiles-without-a-bloks-hash).
+
 ### Settings
 
 Store and manage uuids, device configuration, user agent, authorization data (aka cookies) and other session settings
@@ -123,7 +125,7 @@ Store and manage uuids, device configuration, user agent, authorization data (ak
 | ------------------------------ | ------- | ------------------------------------------------------------------
 | get\_settings()                | dict    | Return settings dict
 | set\_settings(settings: dict)  | bool    | Set session settings
-| load\_settings(path: Path)     | dict    | Load session settings from file
+| load\_settings(path: Path, override\_app\_version: bool = False) | dict | Load session settings; optionally update the app version, version code and Bloks hash
 | dump\_settings(path: Path)     | bool    | Serialize and save session settings to file
 
 In order for Instagram [to trust you more](https://github.com/subzeroid/instagrapi/discussions/220), you must always login from one device and one IP (or from a subnet):

--- a/docs/usage-guide/login-migration.md
+++ b/docs/usage-guide/login-migration.md
@@ -1,6 +1,6 @@
 # CAA login migration
 
-The upcoming major version changes the default login flow and private transport. These changes are currently unreleased.
+Version 2.0.0 changes the default login flow and private transport. This guide explains how to migrate existing applications and saved settings.
 
 ## Default usage
 

--- a/docs/usage-guide/login-migration.md
+++ b/docs/usage-guide/login-migration.md
@@ -1,0 +1,90 @@
+# CAA login migration
+
+The upcoming major version changes the default login flow and private transport. These changes are currently unreleased.
+
+## Default usage
+
+Install the package normally; `curl_cffi` is a required dependency:
+
+```bash
+pip install aiograpi
+```
+
+The application code stays simple:
+
+```python
+from aiograpi import Client
+
+cl = Client()
+await cl.login(USERNAME, PASSWORD)
+```
+
+`login()` uses CAA directly. It does not try `accounts/login/` first and does not automatically fall back to that endpoint after a CAA failure. All private mobile API requests use curl with HTTP/2 by default. Public web and GraphQL transports retain their separate configuration.
+
+## Keep the previous login flow
+
+The previous method is now named `login_legacy()`. Its arguments and existing fallback behavior are preserved:
+
+```python
+cl = Client()
+await cl.login_legacy(USERNAME, PASSWORD, verification_code="123456")
+```
+
+Login flow and transport are independent choices. To explicitly use the previous HTTPX private transport as well:
+
+```python
+cl = Client(private_transport="requests")
+await cl.login_legacy(USERNAME, PASSWORD)
+```
+
+An explicit legacy login may still invoke its existing CAA fallback. There is no automatic fallback in the opposite direction. `relogin()` uses the new default CAA flow; use `login_legacy(relogin=True)` to explicitly repeat the previous flow.
+
+## Reuse saved sessions
+
+Both entry points validate an existing session before using the supplied credentials. If Instagram rejects that session with `LoginRequired`, each repeats its own login flow after clearing the expired authorization state.
+
+```python
+cl = Client()
+cl.load_settings("session.json")
+await cl.login(USERNAME, PASSWORD)
+cl.dump_settings("session.json")
+```
+
+Settings with an explicit `private_transport` keep that choice, even when it differs from the constructor. Settings without that field keep the selected constructor transport, which now defaults to `curl`.
+
+To migrate settings that explicitly saved `requests`:
+
+```python
+cl.load_settings("session.json")
+cl.set_retry_config(private_transport="curl")
+await cl.login(USERNAME, PASSWORD)
+cl.dump_settings("session.json")
+```
+
+This transport change does not replace the saved device profile, proxy, cookies or authorization data. Keep the account's existing proxy configuration when restoring its session.
+
+## Older app profiles without a Bloks hash
+
+CAA needs a Bloks hash matching the configured app version. Saved settings for an older unsupported version may lack this hash. If the session cannot be reused, `login()` raises `ClientError` before starting CAA requests and explains how to update the profile.
+
+Use the supported profile explicitly when migrating those settings:
+
+```python
+cl = Client()
+cl.load_settings("session.json", override_app_version=True)
+cl.set_retry_config(private_transport="curl")  # migrate an explicit saved requests choice
+await cl.login(USERNAME, PASSWORD)
+cl.dump_settings("session.json")
+```
+
+`override_app_version=True` updates the app version, version code and Bloks hash. It retains hardware settings and device identifiers. Keep using the account's existing proxy. Alternatively, provide the correct Bloks hash for the original profile or explicitly use `login_legacy()`.
+
+## Verification and failures
+
+Continue to pass `verification_code` for supported two-factor challenges. The CAA profile-code flow also supports `challenge_code_handler`; see [TOTP](totp.md). Native CAA exceptions propagate. A response without a session or a supported verification context raises `ClientError` with the CAA failure reason. Curl does not automatically retry a failed password POST.
+
+## Installation requirements
+
+Private HTTP/2 requires `curl_cffi>=0.15.0` and libcurl 8.10 or newer. `curl_cffi` normally supplies libcurl in its wheels; a system `curl` executable and the Python `h2` package are not required for this transport. A compatible wheel or a supported native build is required for your platform. Android/Termux has not been verified.
+
+The optional `aiograpi[curl]` extra remains available for public web browser impersonation through `curl-adapter`. It is not required for private HTTP/2. See [private HTTP/2 transport](interactions.md#private-http2-transport) for TLS, proxy and timeout behavior.

--- a/docs/usage-guide/public-transport.md
+++ b/docs/usage-guide/public-transport.md
@@ -25,7 +25,7 @@ cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 user = await cl.user_info_by_username_gql("instagram")
 ```
 
-Private mobile API requests can separately opt into `private_transport="curl"`; see [private HTTP/2 transport](interactions.md#private-http2-transport). The public transport setting only changes the public web session.
+Private mobile API requests use `private_transport="curl"` by default; see [private HTTP/2 transport](interactions.md#private-http2-transport). The public transport setting only changes the public web session.
 
 ## Live Comparison
 

--- a/docs/usage-guide/totp.md
+++ b/docs/usage-guide/totp.md
@@ -38,9 +38,9 @@ Notes:
 
 ## Bloks two-factor flow
 
-Some accounts are moved by Instagram to a newer CAA/Bloks two-factor flow. In that case the legacy `accounts/two_factor_login/` endpoint can reject a valid code with `Invalid Parameters`.
+`await cl.login(..., verification_code="123456")` uses CAA directly, including device registration and server-issued preflight state. A successful embedded session is applied automatically. The CAA profile-code flow uses the supplied `verification_code` or `challenge_code_handler`. When Instagram returns `two_step_verification_context`, the existing Bloks verification helpers handle the code; a missing code raises `TwoFactorRequired`.
 
-`await Client.login(..., verification_code="123456")` still uses the legacy mobile endpoint first. If Instagram returns a `two_step_verification_context`, aiograpi automatically retries through the Bloks two-factor flow. If the legacy endpoint instead returns `BadPassword` without that context, aiograpi retries the current Android CAA login sequence, including its device registration and server-issued preflight state. A successful embedded session is applied automatically. When Instagram opens the CAA profile-code screen, aiograpi uses the supplied `verification_code` or `challenge_code_handler` and applies the terminal session response.
+The previous login flow is available explicitly as `await cl.login_legacy(...)`, with the same arguments and its existing CAA/Bloks fallbacks. Default `login()` never invokes that legacy flow automatically. See the [login migration guide](login-migration.md).
 
 8-digit backup codes can be passed through the same `verification_code` parameter:
 
@@ -89,4 +89,4 @@ result = await cl.bloks_two_step_verification_verify_code(context, "12345678", c
 
 `bloks_extract_login_response(...)` returns decoded `login_response`, response `headers`, cookie values, raw cookie header text, and the raw embedded object when Instagram returns a successful Bloks login payload. It returns `{}` when the response is an intermediate UI state or an error. `bloks_apply_login_response(...)` can then copy the returned authorization data and cookies into the current client session.
 
-The separate account-recovery UI used by some accounts is not automated. If current CAA login does not return a session or a supported profile-code challenge, `login()` preserves the original `BadPassword`. That response can still mean a wrong password or Instagram account-risk handling, so inspect proxy/IP and device consistency before retrying repeatedly.
+The separate account-recovery UI used by some accounts is not automated. Native CAA exceptions propagate from `login()`. If CAA returns neither a session nor a supported verification context, `login()` raises `ClientError` with the CAA failure reason. The explicit `login_legacy()` entry point preserves its previous fallback error behavior.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
     - Examples: usage-guide/examples.md
     - Fundamentals: usage-guide/fundamentals.md
     - Interactions: usage-guide/interactions.md
+    - Login Migration: usage-guide/login-migration.md
     - Types: usage-guide/types.md
     - Handle Exceptions: usage-guide/handle_exception.md
     - Challenge Resolver: usage-guide/challenge_resolver.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ keywords = [
     "aiograpi",
 ]
 dependencies = [
+    "curl_cffi>=0.15.0",
     "httpx>=0.28.1,<0.29",
     "orjson>=3.11.8,<4",
     "PySocks>=1.7.1,<2",
@@ -74,7 +75,6 @@ Changelog = "https://github.com/subzeroid/aiograpi/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 curl = [
-    "curl_cffi>=0.15.0",
     "curl-adapter>=1.2.1",
 ]
 video = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiograpi"
-version = "1.12.16"
+version = "2.0.0"
 authors = [
     { name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com" },
 ]

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -1104,7 +1104,7 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(BadCredentials):
             await client.login()
 
-    async def test_login_continues_after_pre_login_throttling(self):
+    async def test_login_legacy_continues_after_pre_login_throttling(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -1116,14 +1116,14 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.login_flow = AsyncMock()
         client.password_encrypt = AsyncMock(return_value="enc-password")
 
-        result = await client.login()
+        result = await client.login_legacy()
 
         self.assertTrue(result)
         client.pre_login_flow.assert_called_once_with()
         client.private_request.assert_called_once()
         client.login_flow.assert_called_once_with()
 
-    async def test_login_continues_after_client_throttled_error(self):
+    async def test_login_legacy_continues_after_client_throttled_error(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -1135,7 +1135,7 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.login_flow = AsyncMock()
         client.password_encrypt = AsyncMock(return_value="enc-password")
 
-        result = await client.login()
+        result = await client.login_legacy()
 
         self.assertTrue(result)
         client.pre_login_flow.assert_called_once_with()
@@ -1173,7 +1173,7 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.pre_login_flow.assert_not_called()
         client.private_request.assert_not_called()
 
-    async def test_login_uses_stored_username_when_called_without_args(self):
+    async def test_login_legacy_uses_stored_username_when_called_without_args(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -1185,13 +1185,13 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.login_flow = AsyncMock()
         client.password_encrypt = AsyncMock(return_value="enc-password")
 
-        result = await client.login()
+        result = await client.login_legacy()
 
         self.assertTrue(result)
         payload = client.private_request.call_args.args[1]
         self.assertEqual(payload["username"], "example")
 
-    async def test_login_strips_outer_username_whitespace(self):
+    async def test_login_legacy_strips_outer_username_whitespace(self):
         client = Client()
         client.authorization_data = {}
         client.last_response = Mock(headers={"ig-set-authorization": "Bearer token"})
@@ -1201,14 +1201,14 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.login_flow = AsyncMock()
         client.password_encrypt = AsyncMock(return_value="enc-password")
 
-        result = await client.login(" example ", "password")
+        result = await client.login_legacy(" example ", "password")
 
         self.assertTrue(result)
         payload = client.private_request.call_args.args[1]
         self.assertEqual(payload["username"], "example")
         self.assertEqual(client.username, "example")
 
-    async def test_login_two_factor_requires_verification_code(self):
+    async def test_login_legacy_two_factor_requires_verification_code(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -1217,11 +1217,11 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.password_encrypt = AsyncMock(return_value="enc-password")
 
         with self.assertRaises(TwoFactorRequired) as cm:
-            await client.login()
+            await client.login_legacy()
 
         self.assertIn("you did not provide verification_code", str(cm.exception))
 
-    async def test_login_two_factor_uses_verification_code_flow(self):
+    async def test_login_legacy_two_factor_uses_verification_code_flow(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -1243,7 +1243,7 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
             ]
         )
 
-        result = await client.login(verification_code="123456")
+        result = await client.login_legacy(verification_code="123456")
 
         self.assertTrue(result)
         self.assertEqual(client.private_request.call_count, 2)
@@ -1256,7 +1256,7 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(second_call.args[1]["username"], "example")
         client.login_flow.assert_called_once_with()
 
-    async def test_login_two_factor_invalid_parameters_raises_clear_bloks_hint(self):
+    async def test_login_legacy_two_factor_invalid_parameters_raises_clear_bloks_hint(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -1276,12 +1276,12 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         )
 
         with self.assertRaises(TwoFactorRequired) as cm:
-            await client.login(verification_code="123456")
+            await client.login_legacy(verification_code="123456")
 
         self.assertIn("Bloks-based two-factor verification flow", str(cm.exception))
         self.assertEqual(client.private_request.call_count, 2)
 
-    async def test_login_two_factor_invalid_parameters_falls_back_to_bloks_when_context_available(self):
+    async def test_login_legacy_two_factor_invalid_parameters_falls_back_to_bloks_when_context_available(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -1313,7 +1313,7 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.bloks_two_step_verification_verify_code = AsyncMock(return_value={"layout": {}})
         client.bloks_apply_login_response = Mock(return_value=True)
 
-        result = await client.login(verification_code="123456")
+        result = await client.login_legacy(verification_code="123456")
 
         self.assertTrue(result)
         self.assertEqual(client.private_request.call_count, 2)
@@ -1331,7 +1331,7 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.bloks_apply_login_response.assert_called_once_with({"layout": {}})
         client.login_flow.assert_awaited_once_with()
 
-    async def test_login_two_factor_invalid_parameters_without_context_keeps_clear_error(self):
+    async def test_login_legacy_two_factor_invalid_parameters_without_context_keeps_clear_error(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -1352,12 +1352,12 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.bloks_two_step_verification_verify_code = AsyncMock()
 
         with self.assertRaises(TwoFactorRequired) as cm:
-            await client.login(verification_code="123456")
+            await client.login_legacy(verification_code="123456")
 
         self.assertIn("two_step_verification_context", str(cm.exception))
         client.bloks_two_step_verification_verify_code.assert_not_called()
 
-    async def test_login_bad_password_with_bloks_context_and_code_falls_back_to_bloks(self):
+    async def test_login_legacy_bad_password_with_bloks_context_and_code_falls_back_to_bloks(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -1377,7 +1377,7 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.bloks_two_step_verification_verify_code = AsyncMock(return_value={"layout": {}})
         client.bloks_apply_login_response = Mock(return_value=True)
 
-        result = await client.login(verification_code="654321")
+        result = await client.login_legacy(verification_code="654321")
 
         self.assertTrue(result)
         client.bloks_two_step_verification_select_method.assert_awaited_once_with(
@@ -1486,7 +1486,7 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(AssertionError):
             await client.login_by_sessionid("abcdefghijklmnopqrstuvwxyz123456")
 
-    async def test_login_resets_relogin_attempt_after_success(self):
+    async def test_login_legacy_resets_relogin_attempt_after_success(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -1499,7 +1499,7 @@ class AuthAndStoryRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.login_flow = AsyncMock()
         client.password_encrypt = AsyncMock(return_value="enc-password")
 
-        result = await client.login(relogin=True)
+        result = await client.login_legacy(relogin=True)
 
         self.assertTrue(result)
         self.assertEqual(client.relogin_attempt, 0)

--- a/tests/regression/test_auth.py
+++ b/tests/regression/test_auth.py
@@ -33,7 +33,7 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.pre_login_flow.assert_not_awaited()
         client.private_request.assert_not_awaited()
 
-    async def test_login_refreshes_session_rejected_during_validation(self):
+    async def test_login_legacy_refreshes_session_rejected_during_validation(self):
         client = Client()
         client.authorization_data = {"ds_user_id": "123", "sessionid": "stale"}
         client.private.set_cookies({"sessionid": "stale"})
@@ -47,7 +47,7 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.private_request = AsyncMock(return_value=True)
         client.login_flow = AsyncMock()
 
-        result = await client.login("example", "password")
+        result = await client.login_legacy("example", "password")
 
         self.assertTrue(result)
         client.account_info.assert_awaited_once_with()
@@ -123,7 +123,7 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.user_short_gql.assert_not_awaited()
         self.assertEqual(client.username, "example")
 
-    async def test_login_bad_password_without_context_tries_current_caa_flow(self):
+    async def test_login_legacy_bad_password_without_context_tries_current_caa_flow(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -135,13 +135,13 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.private_request = AsyncMock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
         client.bloks_caa_login = AsyncMock(return_value={"logged_in": True})
 
-        result = await client.login(verification_code="654321")
+        result = await client.login_legacy(verification_code="654321")
 
         self.assertTrue(result)
         client.bloks_caa_login.assert_awaited_once_with(verification_code="654321")
         client.login_flow.assert_awaited_once_with()
 
-    async def test_login_bad_password_recovery_response_tries_current_caa_flow_without_code(self):
+    async def test_login_legacy_bad_password_recovery_response_tries_current_caa_flow_without_code(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -157,13 +157,13 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.private_request = AsyncMock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
         client.bloks_caa_login = AsyncMock(return_value={"logged_in": True})
 
-        result = await client.login()
+        result = await client.login_legacy()
 
         self.assertTrue(result)
         client.bloks_caa_login.assert_awaited_once_with(verification_code="")
         client.login_flow.assert_awaited_once_with()
 
-    async def test_login_with_eight_digit_backup_code_selects_backup_code_bloks_challenge(self):
+    async def test_login_legacy_with_eight_digit_backup_code_selects_backup_code_bloks_challenge(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -184,7 +184,7 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.bloks_two_step_verification_verify_code = AsyncMock(return_value={"layout": {}})
         client.bloks_apply_login_response = Mock(return_value=True)
 
-        result = await client.login(verification_code="1234 5678")
+        result = await client.login_legacy(verification_code="1234 5678")
 
         self.assertTrue(result)
         client.bloks_two_step_verification_select_method.assert_awaited_once_with(
@@ -199,7 +199,7 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         )
         client.login_flow.assert_awaited_once_with()
 
-    async def test_login_two_factor_backup_code_with_context_uses_bloks_without_legacy_two_factor_request(self):
+    async def test_login_legacy_two_factor_backup_code_with_context_uses_bloks_without_legacy_two_factor_request(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -227,7 +227,7 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.bloks_two_step_verification_verify_code = AsyncMock(return_value={"layout": {}})
         client.bloks_apply_login_response = Mock(return_value=True)
 
-        result = await client.login(verification_code="1234 5678")
+        result = await client.login_legacy(verification_code="1234 5678")
 
         self.assertTrue(result)
         self.assertEqual(client.private_request.await_count, 1)
@@ -243,7 +243,7 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         )
         client.login_flow.assert_awaited_once_with()
 
-    async def test_login_bad_password_without_context_preserves_original_error_when_caa_has_no_session(self):
+    async def test_login_legacy_bad_password_without_context_preserves_original_error_when_caa_has_no_session(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -265,14 +265,14 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.bloks_caa_login = AsyncMock(side_effect=caa_without_session)
 
         with self.assertRaises(BadPassword) as raised:
-            await client.login(verification_code="654321")
+            await client.login_legacy(verification_code="654321")
 
         self.assertIs(raised.exception, original)
         client.bloks_caa_login.assert_awaited_once_with(verification_code="654321")
         self.assertEqual(client.last_json, legacy_json)
         self.assertIs(client.last_response, legacy_response)
 
-    async def test_login_bad_password_without_context_preserves_original_error_when_caa_is_unavailable(self):
+    async def test_login_legacy_bad_password_without_context_preserves_original_error_when_caa_is_unavailable(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -301,14 +301,14 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.bloks_caa_login = AsyncMock(side_effect=unavailable_caa)
 
         with self.assertRaises(BadPassword) as raised:
-            await client.login(verification_code="654321")
+            await client.login_legacy(verification_code="654321")
 
         self.assertIs(raised.exception, original)
         client.bloks_caa_login.assert_awaited_once_with(verification_code="654321")
         self.assertEqual(client.last_json, legacy_json)
         self.assertIs(client.last_response, legacy_response)
 
-    async def test_login_bad_password_without_bloks_hash_preserves_original_error(self):
+    async def test_login_legacy_bad_password_without_bloks_hash_preserves_original_error(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -321,7 +321,7 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.bloks_caa_login = AsyncMock(side_effect=AssertionError("Bloks hash is required"))
 
         with self.assertRaises(BadPassword):
-            await client.login(verification_code="654321")
+            await client.login_legacy(verification_code="654321")
 
         client.bloks_caa_login.assert_not_awaited()
 
@@ -336,7 +336,7 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertIs(raised.exception, rejection)
 
-    async def test_login_caa_rate_limit_error_is_not_replaced_and_retains_caa_state(self):
+    async def test_login_legacy_caa_rate_limit_error_is_not_replaced_and_retains_caa_state(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -358,7 +358,7 @@ class AuthRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.bloks_caa_login = AsyncMock(side_effect=rate_limited_caa)
 
         with self.assertRaises(RateLimitError) as raised:
-            await client.login(verification_code="654321")
+            await client.login_legacy(verification_code="654321")
 
         self.assertIs(raised.exception, rejection)
         self.assertEqual(client.last_json, caa_json)

--- a/tests/regression/test_default_transport.py
+++ b/tests/regression/test_default_transport.py
@@ -1,0 +1,33 @@
+import asyncio
+
+import pytest
+
+from aiograpi import Client
+from aiograpi.httpx_ext import CurlPrivateSession
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        ({}, "curl"),
+        ({"settings": {"locale": "en_US"}}, "curl"),
+        ({"private_transport": "requests"}, "requests"),
+        ({"settings": {"locale": "en_US"}, "private_transport": "requests"}, "requests"),
+        ({"settings": {"private_transport": "requests"}, "private_transport": "curl"}, "requests"),
+        ({"settings": {"private_transport": "curl"}, "private_transport": "requests"}, "curl"),
+    ],
+)
+def test_private_transport_default_and_saved_precedence(kwargs, expected):
+    client = Client(**kwargs)
+    try:
+        assert client.private_transport == expected
+        assert (isinstance(client.private, CurlPrivateSession)) is (expected == "curl")
+        assert client.get_settings()["private_transport"] == expected
+        assert client.public_transport == "requests"
+    finally:
+
+        async def close():
+            for session in (client.private, client.public, client.graphql):
+                await session._close()
+
+        asyncio.run(close())

--- a/tests/regression/test_login_default.py
+++ b/tests/regression/test_login_default.py
@@ -1,0 +1,416 @@
+import asyncio
+import inspect
+import unittest
+from copy import deepcopy
+from unittest.mock import AsyncMock, Mock, patch
+
+from aiograpi import Client, config
+from aiograpi.exceptions import (
+    BadCredentials,
+    BadPassword,
+    ChallengeError,
+    ClientError,
+    ClientNotFoundError,
+    LoginRequired,
+    PleaseWaitFewMinutes,
+    ReloginAttemptExceeded,
+    TwoFactorRequired,
+    UnknownError,
+)
+
+
+class LoginDefaultRegressionTestCase(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.client = Client(private_transport="requests")
+        self.client.pre_login_flow = AsyncMock(side_effect=AssertionError("Unexpected legacy preflight"))
+        self.client.password_encrypt = AsyncMock(side_effect=AssertionError("Unexpected legacy encryption"))
+        self.client.private_request = AsyncMock(side_effect=AssertionError("Unexpected legacy request"))
+        self.client.login_flow = AsyncMock()
+        self.client.bloks_caa_login = AsyncMock(side_effect=self.caa_success)
+
+    def caa_success(self, **kwargs):
+        self.client.authorization_data = {"ds_user_id": "123", "sessionid": "fresh"}
+        return self.caa_outcome(logged_in=True)
+
+    def caa_outcome(self, **updates):
+        outcome = {
+            "logged_in": False,
+            "two_step_verification_context": "",
+            "result": {},
+            "two_step": {},
+            "reason": "CAA login did not return a session",
+        }
+        outcome.update(updates)
+        return outcome
+
+    def legacy_success(self):
+        self.client.pre_login_flow = AsyncMock(return_value=True)
+        self.client.password_encrypt = AsyncMock(return_value="encrypted")
+        self.client.private_request = AsyncMock(return_value=True)
+        self.client.last_response = Mock(headers={"ig-set-authorization": "Bearer fresh"})
+        self.client.parse_authorization = Mock(return_value={"ds_user_id": "123", "sessionid": "fresh"})
+        self.client.bloks_caa_login = AsyncMock(side_effect=AssertionError("Unexpected CAA fallback"))
+
+    def saved_session(self):
+        self.client.authorization_data = {"ds_user_id": "123", "sessionid": "stale"}
+        self.client.private.set_cookies({"sessionid": "stale"})
+        self.client.public.set_cookies({"sessionid": "public-stale"})
+        self.client.private.headers["Authorization"] = "Bearer stale"
+
+    def assert_session_cleared(self):
+        self.assertNotIn("Authorization", self.client.private.headers)
+        self.assertEqual(self.client.private.cookies_dict(), {})
+        self.assertEqual(self.client.public.cookies_dict(), {})
+
+    async def test_login_uses_caa_directly_and_finalizes_success(self):
+        self.client.relogin_attempt = 1
+        with patch("aiograpi.mixins.auth.time.time", return_value=1234567890.0):
+            result = await self.client.login(" example ", "password", False, "654321")
+
+        self.assertTrue(result)
+        self.assertEqual(self.client.username, "example")
+        self.assertEqual(self.client.password, "password")
+        self.assertEqual(self.client.authorization_data["sessionid"], "fresh")
+        self.client.bloks_caa_login.assert_awaited_once_with(verification_code="654321")
+        self.client.pre_login_flow.assert_not_awaited()
+        self.client.password_encrypt.assert_not_awaited()
+        self.client.private_request.assert_not_awaited()
+        self.client.login_flow.assert_awaited_once_with()
+        self.assertEqual(self.client.last_login, 1234567890.0)
+        self.assertEqual(self.client.relogin_attempt, 0)
+
+    async def test_login_uses_stored_credentials(self):
+        self.client.username = " example "
+        self.client.password = "password"
+
+        self.assertTrue(await self.client.login())
+
+        self.assertEqual(self.client.username, "example")
+        self.client.bloks_caa_login.assert_awaited_once_with(verification_code="")
+
+    async def test_login_and_legacy_keep_the_same_call_signature(self):
+        self.assertTrue(hasattr(Client, "login_legacy"))
+        self.assertEqual(inspect.signature(Client.login), inspect.signature(Client.login_legacy))
+
+    async def test_both_entrypoints_require_credentials_before_network_calls(self):
+        self.assertTrue(hasattr(Client, "login_legacy"))
+        for entrypoint in ("login", "login_legacy"):
+            with self.subTest(entrypoint=entrypoint):
+                with self.assertRaises(BadCredentials):
+                    await getattr(self.client, entrypoint)()
+        self.client.bloks_caa_login.assert_not_awaited()
+        self.client.pre_login_flow.assert_not_awaited()
+
+    async def test_legacy_login_keeps_accounts_endpoint_and_preflight(self):
+        self.assertTrue(hasattr(Client, "login_legacy"))
+        self.legacy_success()
+
+        self.assertTrue(await self.client.login_legacy(" example ", "password", False, "654321"))
+
+        self.client.pre_login_flow.assert_awaited_once_with()
+        self.client.password_encrypt.assert_awaited_once_with("password")
+        self.client.private_request.assert_awaited_once()
+        self.assertEqual(self.client.private_request.await_args.args[0], "accounts/login/")
+        self.assertEqual(self.client.private_request.await_args.args[1]["username"], "example")
+        self.client.bloks_caa_login.assert_not_awaited()
+        self.client.login_flow.assert_awaited_once_with()
+
+    async def test_both_entrypoints_validate_saved_sessions_without_submitting_credentials(self):
+        self.assertTrue(hasattr(Client, "login_legacy"))
+        self.saved_session()
+        self.client.account_info = AsyncMock(return_value=object())
+        self.client.last_login = 123.0
+        for entrypoint in ("login", "login_legacy"):
+            with self.subTest(entrypoint=entrypoint):
+                self.assertTrue(await getattr(self.client, entrypoint)("example", "password"))
+        self.assertEqual(self.client.account_info.await_count, 2)
+        self.client.bloks_caa_login.assert_not_awaited()
+        self.client.pre_login_flow.assert_not_awaited()
+        self.client.login_flow.assert_not_awaited()
+        self.assertEqual(self.client.last_login, 123.0)
+
+    async def test_expired_session_is_cleared_and_refreshed_with_caa(self):
+        self.saved_session()
+        self.client.account_info = AsyncMock(side_effect=LoginRequired())
+
+        self.assertTrue(await self.client.login("example", "password", verification_code="654321"))
+
+        self.client.account_info.assert_awaited_once_with()
+        self.client.bloks_caa_login.assert_awaited_once_with(verification_code="654321")
+        self.assert_session_cleared()
+        self.assertEqual(self.client.authorization_data["sessionid"], "fresh")
+        self.assertEqual(self.client.relogin_attempt, 0)
+
+    async def test_expired_legacy_session_stays_on_legacy_entrypoint(self):
+        self.assertTrue(hasattr(Client, "login_legacy"))
+        self.saved_session()
+        self.legacy_success()
+        self.client.account_info = AsyncMock(side_effect=LoginRequired())
+
+        self.assertTrue(await self.client.login_legacy("example", "password", verification_code="654321"))
+
+        self.client.account_info.assert_awaited_once_with()
+        self.client.pre_login_flow.assert_awaited_once_with()
+        self.assertEqual(self.client.private_request.await_args.args[0], "accounts/login/")
+        self.client.bloks_caa_login.assert_not_awaited()
+        self.assert_session_cleared()
+        self.assertEqual(self.client.authorization_data["sessionid"], "fresh")
+
+    async def test_relogin_clears_session_without_validation(self):
+        self.saved_session()
+        self.client.account_info = AsyncMock(side_effect=AssertionError("Unexpected session validation"))
+
+        self.assertTrue(await self.client.login("example", "password", relogin=True))
+
+        self.assert_session_cleared()
+        self.client.account_info.assert_not_awaited()
+        self.client.bloks_caa_login.assert_awaited_once_with(verification_code="")
+        self.assertEqual(self.client.relogin_attempt, 0)
+
+    async def test_failed_relogin_attempts_are_bounded_for_both_entrypoints(self):
+        self.assertTrue(hasattr(Client, "login_legacy"))
+        for entrypoint in ("login", "login_legacy"):
+            with self.subTest(entrypoint=entrypoint):
+                self.client.relogin_attempt = 0
+                self.client.pre_login_flow = AsyncMock(return_value=True)
+                self.client.password_encrypt = AsyncMock(return_value="encrypted")
+                self.client.private_request = AsyncMock(side_effect=PleaseWaitFewMinutes("rate limit"))
+                self.client.bloks_caa_login = AsyncMock(side_effect=PleaseWaitFewMinutes("rate limit"))
+                for attempt in (1, 2):
+                    self.saved_session()
+                    with self.assertRaises(PleaseWaitFewMinutes):
+                        await getattr(self.client, entrypoint)("example", "password", relogin=True)
+                    self.assertEqual(self.client.relogin_attempt, attempt)
+                    self.assert_session_cleared()
+                    self.assertEqual(self.client.authorization_data, {})
+                self.saved_session()
+                with self.assertRaises(ReloginAttemptExceeded):
+                    await getattr(self.client, entrypoint)(relogin=True)
+                self.assert_session_cleared()
+                self.assertEqual(self.client.authorization_data, {})
+                request = self.client.bloks_caa_login if entrypoint == "login" else self.client.private_request
+                self.assertEqual(request.call_count, 2)
+
+    async def test_default_propagates_native_caa_errors_without_retry_or_finalization(self):
+        for exception_type in (
+            BadPassword,
+            ClientNotFoundError,
+            UnknownError,
+            ChallengeError,
+            TwoFactorRequired,
+            LoginRequired,
+            PleaseWaitFewMinutes,
+            ClientError,
+        ):
+            with self.subTest(exception_type=exception_type):
+                error = exception_type("native CAA failure")
+                self.client.bloks_caa_login = AsyncMock(side_effect=error)
+                with self.assertRaises(exception_type) as caught:
+                    await self.client.login("example", "password", verification_code="654321")
+                self.assertIs(caught.exception, error)
+                self.client.bloks_caa_login.assert_awaited_once_with(verification_code="654321")
+        self.client.pre_login_flow.assert_not_awaited()
+        self.client.private_request.assert_not_awaited()
+        self.client.login_flow.assert_not_awaited()
+        self.assertIsNone(self.client.last_login)
+
+    async def test_session_validation_failure_is_not_retried_as_login(self):
+        self.saved_session()
+        error = PleaseWaitFewMinutes("validation rate limit")
+        self.client.account_info = AsyncMock(side_effect=error)
+
+        with self.assertRaises(PleaseWaitFewMinutes) as caught:
+            await self.client.login("example", "password")
+
+        self.assertIs(caught.exception, error)
+        self.client.bloks_caa_login.assert_not_awaited()
+        self.assertEqual(self.client.authorization_data["sessionid"], "stale")
+
+    async def test_caa_outcome_without_session_raises_its_reason(self):
+        self.client.bloks_caa_login = AsyncMock(return_value=self.caa_outcome(reason="CAA preflight was incomplete"))
+
+        with self.assertRaisesRegex(ClientError, "CAA preflight was incomplete"):
+            await self.client.login("example", "password")
+
+        self.client.bloks_caa_login.assert_awaited_once_with(verification_code="")
+        self.client.login_flow.assert_not_awaited()
+        self.client.pre_login_flow.assert_not_awaited()
+
+    async def test_caa_outcome_without_reason_has_clear_error(self):
+        self.client.bloks_caa_login = AsyncMock(return_value=self.caa_outcome(reason=""))
+
+        with self.assertRaisesRegex(ClientError, "CAA login did not return a session"):
+            await self.client.login("example", "password")
+
+    async def test_caa_two_factor_context_requires_a_code(self):
+        self.client.bloks_caa_login = AsyncMock(
+            return_value=self.caa_outcome(two_step_verification_context="context-1")
+        )
+
+        with self.assertRaisesRegex(TwoFactorRequired, "verification_code"):
+            await self.client.login("example", "password", verification_code=" ")
+
+        self.client.bloks_caa_login.assert_awaited_once_with(verification_code=" ")
+        self.client.login_flow.assert_not_awaited()
+        self.client.private_request.assert_not_awaited()
+
+    async def test_caa_context_selects_totp_sms_and_normalized_backup_codes(self):
+        for code, challenge, flags, expected_code in (
+            ("654321", "totp", {"totp_two_factor_on": True}, "654321"),
+            ("654321", "sms", {"sms_two_factor_on": True}, "654321"),
+            ("1234 5678", "backup_codes", {"totp_two_factor_on": True}, "12345678"),
+        ):
+            with self.subTest(challenge=challenge):
+                self.client.bloks_caa_login = AsyncMock(
+                    return_value=self.caa_outcome(
+                        two_step_verification_context="context-1",
+                        result={"two_factor_info": flags},
+                    )
+                )
+                self.client.bloks_two_step_verification_entrypoint = AsyncMock(return_value={"status": "ok"})
+                self.client.bloks_two_step_verification_method_picker = AsyncMock(return_value={"status": "ok"})
+                self.client.bloks_two_step_verification_select_method = AsyncMock(return_value={"status": "ok"})
+                self.client.bloks_two_step_verification_enter_backup_code = AsyncMock(return_value={"status": "ok"})
+                self.client.bloks_two_step_verification_verify_code = AsyncMock(return_value={"layout": {}})
+                self.client.bloks_apply_login_response = Mock(return_value=True)
+
+                self.assertTrue(await self.client.login("example", "password", verification_code=code))
+
+                self.client.bloks_caa_login.assert_awaited_once_with(verification_code=code)
+                self.client.bloks_two_step_verification_entrypoint.assert_awaited_once_with("context-1")
+                self.client.bloks_two_step_verification_select_method.assert_awaited_once_with(
+                    "context-1", selected_method=challenge
+                )
+                self.client.bloks_two_step_verification_verify_code.assert_awaited_once_with(
+                    "context-1", expected_code, challenge=challenge
+                )
+                self.client.bloks_apply_login_response.assert_called_once_with({"layout": {}})
+                if challenge == "backup_codes":
+                    self.client.bloks_two_step_verification_enter_backup_code.assert_awaited_once_with("context-1")
+                else:
+                    self.client.bloks_two_step_verification_enter_backup_code.assert_not_awaited()
+        self.assertEqual(self.client.login_flow.await_count, 3)
+        self.client.private_request.assert_not_awaited()
+
+    async def test_context_verification_error_is_not_retried(self):
+        self.client.bloks_caa_login = AsyncMock(
+            return_value=self.caa_outcome(two_step_verification_context="context-1")
+        )
+        error = TwoFactorRequired("Incorrect verification code")
+        self.client.bloks_two_step_verification_entrypoint = AsyncMock(side_effect=error)
+
+        with self.assertRaises(TwoFactorRequired) as caught:
+            await self.client.login("example", "password", verification_code="654321")
+
+        self.assertIs(caught.exception, error)
+        self.client.bloks_caa_login.assert_awaited_once_with(verification_code="654321")
+        self.client.login_flow.assert_not_awaited()
+
+    async def test_completed_caa_verification_does_not_submit_code_again(self):
+        self.client.bloks_caa_login = AsyncMock(
+            return_value=self.caa_outcome(logged_in=True, two_step={"logged_in": True})
+        )
+        self.client.bloks_two_step_verification_entrypoint = AsyncMock(
+            side_effect=AssertionError("Unexpected repeated two-factor verification")
+        )
+
+        self.assertTrue(await self.client.login("example", "password", verification_code="654321"))
+
+        self.client.bloks_caa_login.assert_awaited_once_with(verification_code="654321")
+        self.client.bloks_two_step_verification_entrypoint.assert_not_awaited()
+        self.client.login_flow.assert_awaited_once_with()
+
+    async def test_caa_cancellation_propagates_without_retry_or_finalization(self):
+        self.client.bloks_caa_login = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.client.login("example", "password")
+
+        self.client.bloks_caa_login.assert_awaited_once_with(verification_code="")
+        self.client.pre_login_flow.assert_not_awaited()
+        self.client.private_request.assert_not_awaited()
+        self.client.login_flow.assert_not_awaited()
+
+    def old_app_settings(self):
+        settings = deepcopy(self.client.get_settings())
+        settings["device_settings"].update({"app_version": "410.0.0.0.1", "version_code": "123456789"})
+        settings["device_settings"].pop("bloks_versioning_id", None)
+        return settings
+
+    async def test_missing_saved_app_hash_stops_caa_before_preflight(self):
+        settings = self.old_app_settings()
+        original_settings = deepcopy(settings)
+        for mode in ("fresh", "relogin", "expired"):
+            with self.subTest(mode=mode):
+                self.client = Client(settings=settings, private_transport="requests")
+                self.assertIsNone(self.client.bloks_versioning_id)
+                self.client.bloks_caa_login = AsyncMock(wraps=self.client.bloks_caa_login)
+                self.client.bloks_caa_login_prepare = AsyncMock(side_effect=AssertionError("Unexpected CAA preflight"))
+                self.client.pre_login_flow = AsyncMock(side_effect=AssertionError("Unexpected legacy preflight"))
+                self.client.login_legacy = AsyncMock(side_effect=AssertionError("Unexpected legacy fallback"))
+                self.client.private_request = AsyncMock(side_effect=AssertionError("Unexpected private request"))
+                if mode != "fresh":
+                    self.saved_session()
+                if mode == "expired":
+                    self.client.account_info = AsyncMock(side_effect=LoginRequired())
+
+                with self.assertRaisesRegex(ClientError, "CAA login requires bloks_versioning_id") as caught:
+                    await self.client.login("example", "password", relogin=mode == "relogin")
+
+                self.assertIs(type(caught.exception), ClientError)
+                self.assertIn("override_app_version=True", str(caught.exception))
+                self.assertIn("matching Bloks hash", str(caught.exception))
+                self.client.bloks_caa_login.assert_not_awaited()
+                self.client.bloks_caa_login_prepare.assert_not_awaited()
+                self.client.pre_login_flow.assert_not_awaited()
+                self.client.login_legacy.assert_not_awaited()
+                self.client.private_request.assert_not_awaited()
+                self.assertEqual(self.client.device_settings, settings["device_settings"])
+                self.assertEqual(self.client.get_settings()["uuids"], settings["uuids"])
+                self.assertEqual(settings, original_settings)
+                if mode != "fresh":
+                    self.assert_session_cleared()
+                    self.assertEqual(self.client.authorization_data, {})
+
+    async def test_saved_session_without_app_hash_can_still_be_reused(self):
+        self.client = Client(settings=self.old_app_settings(), private_transport="requests")
+        self.assertIsNone(self.client.bloks_versioning_id)
+        self.saved_session()
+        self.client.account_info = AsyncMock(return_value=object())
+        self.client.bloks_caa_login = AsyncMock(side_effect=AssertionError("Unexpected CAA login"))
+        self.client.pre_login_flow = AsyncMock(side_effect=AssertionError("Unexpected legacy preflight"))
+
+        self.assertTrue(await self.client.login("example", "password"))
+
+        self.client.account_info.assert_awaited_once_with()
+        self.client.bloks_caa_login.assert_not_awaited()
+        self.client.pre_login_flow.assert_not_awaited()
+        self.assertEqual(self.client.authorization_data["sessionid"], "stale")
+        self.assertIsNone(self.client.bloks_versioning_id)
+
+    async def test_app_override_restores_caa_profile_and_preserves_device_uuids_and_proxy(self):
+        settings = self.old_app_settings()
+        original_settings = deepcopy(settings)
+        proxy = "http://127.0.0.1:4321"
+        self.client = Client(settings=settings, proxy=proxy, override_app_version=True, private_transport="requests")
+        self.client.bloks_caa_login = AsyncMock(side_effect=self.caa_success)
+        self.client.login_flow = AsyncMock()
+        self.client.pre_login_flow = AsyncMock(side_effect=AssertionError("Unexpected legacy preflight"))
+        self.client.private_request = AsyncMock(side_effect=AssertionError("Unexpected private request"))
+
+        self.assertTrue(await self.client.login("example", "password"))
+
+        supported_profile = config.APP_SETTINGS[config.DEFAULT_APP_VERSION]
+        for key in ("app_version", "version_code", "bloks_versioning_id"):
+            self.assertEqual(self.client.device_settings[key], supported_profile[key])
+        self.assertEqual(self.client.bloks_versioning_id, supported_profile["bloks_versioning_id"])
+        for key, value in settings["device_settings"].items():
+            if key not in {"app_version", "version_code", "bloks_versioning_id"}:
+                self.assertEqual(self.client.device_settings[key], value)
+        self.assertEqual(self.client.get_settings()["uuids"], settings["uuids"])
+        self.assertEqual(self.client.proxy, proxy)
+        self.assertEqual(self.client.private.proxy, proxy)
+        self.assertEqual(self.client.public.proxy, proxy)
+        self.assertEqual(settings, original_settings)
+        self.client.bloks_caa_login.assert_awaited_once_with(verification_code="")
+        self.client.login_flow.assert_awaited_once_with()

--- a/tests/regression/test_private_transport.py
+++ b/tests/regression/test_private_transport.py
@@ -11,9 +11,9 @@ import pytest
 from aiograpi import Client
 
 
-def test_default_private_transport_does_not_require_curl(monkeypatch):
+def test_explicit_requests_transport_does_not_require_curl(monkeypatch):
     monkeypatch.setitem(sys.modules, "curl_cffi", None)
-    client = Client()
+    client = Client(private_transport="requests")
     assert client.private_transport == "requests"
 
 
@@ -22,10 +22,11 @@ def test_invalid_private_transport_is_rejected():
         Client(private_transport="invalid")
 
 
-def test_missing_private_curl_extra_has_install_hint(monkeypatch):
+@pytest.mark.parametrize("kwargs", [{}, {"private_transport": "curl"}])
+def test_missing_private_curl_dependency_has_install_hint(monkeypatch, kwargs):
     monkeypatch.setitem(sys.modules, "curl_cffi", None)
-    with pytest.raises(RuntimeError, match=r"pip install aiograpi\[curl\]"):
-        Client(private_transport="curl")
+    with pytest.raises(RuntimeError, match=r"requires curl_cffi>=0.15.0"):
+        Client(**kwargs)
 
 
 @pytest.mark.parametrize("version", ["libcurl/8.9.1", "unknown"])
@@ -50,7 +51,7 @@ def test_private_transport_settings_restore_and_old_settings_preserve_selection(
 
 def test_switch_preserves_scoped_cookies_headers_proxy_and_device():
     pytest.importorskip("curl_cffi")
-    client = Client(proxy="http://127.0.0.1:3128")
+    client = Client(private_transport="requests", proxy="http://127.0.0.1:3128")
     cookie = Cookie(
         0,
         "sessionid",
@@ -185,7 +186,7 @@ def test_switch_closes_retired_async_client_on_explicit_close():
     pytest.importorskip("curl_cffi")
 
     async def scenario():
-        client = Client()
+        client = Client(private_transport="requests")
         old = client.private._client
         client.set_retry_config(private_transport="curl")
         await client.private._close()
@@ -196,11 +197,11 @@ def test_switch_closes_retired_async_client_on_explicit_close():
 
 
 def test_failed_transport_switch_keeps_working_session(monkeypatch):
-    client = Client()
+    client = Client(private_transport="requests")
     original = client.private
     original.headers["X-Custom"] = "preserved"
     monkeypatch.setitem(sys.modules, "curl_cffi", None)
-    with pytest.raises(RuntimeError, match="optional curl extra"):
+    with pytest.raises(RuntimeError, match="requires curl_cffi"):
         client.set_retry_config(private_transport="curl")
     assert client.private is original
     assert client.get_settings()["private_transport"] == "requests"

--- a/tests/regression/test_private_transport_wire.py
+++ b/tests/regression/test_private_transport_wire.py
@@ -36,7 +36,7 @@ def url(lab, path="/lab/ok"):
 
 @asynccontextmanager
 async def client_for(lab, **kwargs):
-    client = Client(private_transport="curl", tls_verify=str(lab.ca_path), request_timeout=0, **kwargs)
+    client = Client(tls_verify=str(lab.ca_path), request_timeout=0, **kwargs)
     try:
         yield client
     finally:

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -29,6 +29,7 @@ class UploadRegressionTestCase(unittest.IsolatedAsyncioTestCase):
         client.with_default_data = lambda data: data
         client.request_log = lambda response: None
         client.expose = AsyncMock(return_value=None)
+        client._current_media_ids = AsyncMock(return_value=set())
         return client
 
     def build_media(self, media_type=1):


### PR DESCRIPTION
## Summary

Make a standard installation use CAA authentication and private HTTP/2 without constructor flags:

```python
from aiograpi import Client

cl = Client()
await cl.login(USERNAME, PASSWORD)
```

- `login()` calls CAA directly, reuses valid saved sessions, and propagates native failures without falling back to the old password endpoint.
- Preserve the previous implementation as `login_legacy()` with the same arguments and existing legacy fallbacks. Transport remains a separate choice; `private_transport="httpx"` is still available.
- Install `curl_cffi>=0.15.0` as a runtime dependency. Private HTTP/2 uses libcurl; neither a system curl executable nor Python `h2` is required. The optional `curl` extra remains for public browser impersonation.
- Preserve explicitly saved transport choices. Saved settings without a transport key inherit the constructor default. An unsupported old app profile without a Bloks hash fails before CAA requests with actionable migration guidance; `override_app_version=True` updates the app profile while retaining hardware and device identifiers.

This is the breaking 2.0.0 major release. The release version, changelog and migration guide are included. Related to subzeroid/instagrapi#2778 and subzeroid/instagrapi#2792. Paired PR: subzeroid/instagrapi#2795. Implementation: [instagrapi commit](https://github.com/subzeroid/instagrapi/commit/4741a11673286fe2129b2710248c75ad7463415b).

## Test coverage and review

Covered direct CAA outcomes, saved-session reuse and expiry, verification context and codes, relogin limits, missing app hashes, native errors, legacy compatibility, default transport selection, settings precedence, missing dependencies, and real TLS/HTTP2 traffic. Independent specification and adversarial code reviews passed; the legacy implementation was checked for unchanged behavior except its name and recursive entry point.

## Validation

- Local full offline suite: **956 passed, 13 skipped, 55 subtests passed**.
- Ruff, formatting, Bandit, pre-commit, strict documentation build, wheel/sdist builds, and clean normal installation passed.
- Mypy stays within the existing error budget: 219 errors versus 220 at the base.
- Clean installation selects curl without the optional curl extra, Python h2, or curl-adapter.
- CI now runs full offline regressions on Python 3.10–3.14, minimum/current curl HTTP/2 wire tests, and clean installations on Linux, macOS, and Windows.
- CI passed: **23 successful checks**; the separately triggered live job and branch-only documentation deployment were skipped.
- Fresh live sample: **10/10 CAA logins, 10/10 current-user checks, 10/10 saved-session restorations**. Exactly 10 password submissions, zero old `accounts/login/` requests and zero HTTP 429 responses.
- All **90/90 private responses used HTTP/2**. The existing public password-key helper remains unchanged; its expected HTTP 405 response supplied valid encryption-key headers.
- Live checks explicitly selected the supported 428 app profile while preserving each account's assigned proxy, hardware settings and device identifiers. These results apply to this ten-account sample.

## Documentation

- Added CAA migration guidance covering default login, explicit login_legacy(), saved-session and transport precedence, older-profile updates, verification failures, and installation requirements.
- Updated README, TOTP, transport guidance, navigation, and development setup; clarified saved-session reuse, the load_settings override_app_version option, and migration for the old-profile settings example.
- Strict MkDocs build and changed-file documentation checks pass. Release metadata and migration guidance now target 2.0.0; historical release notes are preserved.
